### PR TITLE
libris/lxltools#2 - Fix error with ZipFile-PosixPath incompatibility

### DIFF
--- a/datasets.py
+++ b/datasets.py
@@ -34,7 +34,7 @@ def to_camel_case(label):
 
 
 def _get_zipped_graph(path, name):
-    with zipfile.ZipFile(path, 'r') as zipped:
+    with zipfile.ZipFile(str(path), 'r') as zipped:
         return Graph().parse(zipped.open(name), format='turtle')
 
 


### PR DESCRIPTION
Fixes libris/lxltools#2 (preventing me from getting LibrisXL ES/PSQL in shape).