### PR TITLE
Update chips of Organisation, Jurisdiction and Meeting

### DIFF
--- a/source/vocab/display.jsonld
+++ b/source/vocab/display.jsonld
@@ -109,7 +109,7 @@
         "Jurisdiction": {
           "@type": "fresnel:Lens",
           "classLensDomain": "Jurisdiction",
-          "showProperties": [ "name", {"isPartOf": "name"}, "marc:subordinateUnit" ]
+          "showProperties": [ "name", "isPartOf", "marc:subordinateUnit" ]
         },
         "Meeting": {
           "@type": "fresnel:Lens",
@@ -119,7 +119,7 @@
         "Organization": {
           "@type": "fresnel:Lens",
           "classLensDomain": "Organization",
-          "showProperties": [ "name", {"isPartOf": "name"}, "marc:subordinateUnit" ]
+          "showProperties": [ "name", "isPartOf", "marc:subordinateUnit" ]
         },
         "Library": {
           "@type": "fresnel:Lens",
@@ -258,7 +258,7 @@
         "Jurisdiction": {
           "@type": "fresnel:Lens",
           "classLensDomain": "Jurisdiction",
-          "showProperties": [ "name", {"isPartOf": "name"}, "marc:subordinateUnit", "note" ]
+          "showProperties": [ "name", "isPartOf", "marc:subordinateUnit", "note" ]
         },
         "Meeting": {
           "@type": "fresnel:Lens",
@@ -269,7 +269,7 @@
           "@type": "fresnel:Lens",
           "@id": "Organization-cards",
           "classLensDomain": "Organization",
-          "showProperties": [ "name", {"isPartOf": "name"}, "marc:subordinateUnit", "note" ]
+          "showProperties": [ "name", "isPartOf", "marc:subordinateUnit", "note" ]
         },
         "Concept": {
           "@type": "fresnel:Lens",

--- a/source/vocab/display.jsonld
+++ b/source/vocab/display.jsonld
@@ -109,17 +109,17 @@
         "Jurisdiction": {
           "@type": "fresnel:Lens",
           "classLensDomain": "Jurisdiction",
-          "showProperties": [ "name" ]
+          "showProperties": [ "name", {"isPartOf": "name"}, "marc:subordinateUnit" ]
         },
         "Meeting": {
           "@type": "fresnel:Lens",
           "classLensDomain": "Meeting",
-          "showProperties": [ "name", "date" ]
+          "showProperties": [ "name", "marc:subordinateUnit", "date" ]
         },
         "Organization": {
           "@type": "fresnel:Lens",
           "classLensDomain": "Organization",
-          "showProperties": [ "name" ]
+          "showProperties": [ "name", {"isPartOf": "name"}, "marc:subordinateUnit" ]
         },
         "Library": {
           "@type": "fresnel:Lens",


### PR DESCRIPTION
Add marc:subOrdinateUnit and isPartOf { name }

It's missing supports of the model when marc:subOrdinateUnit exists and therefore only displays "{Namnlös entitet}"