### PR TITLE
Make schemes notation lower-case for 'barn', since it is used as code

### DIFF
--- a/source/schemes.ttl
+++ b/source/schemes.ttl
@@ -61,6 +61,7 @@
 
 <barn> a skos:ConceptScheme;
     skos:notation "barn";
+    dc:alternative "Barn";
     dc:title "Barnämnesord"@sv;
     dc:description """
         Barnämnesorden (Barn) är en lista med termer för indexering av litteratur för barn och ungdomar. Den innehåller cirka 1 500 godkända termer. Dessa finns i databasen Svenska ämnesord sedan 2005.
@@ -72,6 +73,7 @@
 
 <barngf> a skos:ConceptScheme;
     skos:notation "barngf";
+    dc:alternative "BarnGF";
     dc:title "Barn - Genre och form"@sv;
     rdfs:seeAlso <barn>;
     void:inDataset </> .

--- a/source/schemes.ttl
+++ b/source/schemes.ttl
@@ -71,7 +71,7 @@
     void:inDataset </> .
 
 <barngf> a skos:ConceptScheme;
-    skos:notation "BarnGF";
+    skos:notation "barngf";
     dc:title "Barn - Genre och form"@sv;
     rdfs:seeAlso <barn>;
     void:inDataset </> .

--- a/source/schemes.ttl
+++ b/source/schemes.ttl
@@ -60,7 +60,7 @@
     void:inDataset </> .
 
 <barn> a skos:ConceptScheme;
-    skos:notation "Barn";
+    skos:notation "barn";
     dc:title "Barnämnesord"@sv;
     dc:description """
         Barnämnesorden (Barn) är en lista med termer för indexering av litteratur för barn och ungdomar. Den innehåller cirka 1 500 godkända termer. Dessa finns i databasen Svenska ämnesord sedan 2005.


### PR DESCRIPTION
Since notation is used as code, it needs to be lower-case to be able to match (for instance at revert).