### PR TITLE
Feature/minor bug fixes

### DIFF
--- a/source/marc/enums.ttl
+++ b/source/marc/enums.ttl
@@ -2043,10 +2043,6 @@
     skos:prefLabel "Subject Subdivision"@en,
         "Typ av underindelning"@sv .
 
-:systemDetailsNote a owl:ObjectProperty ;
-   # TODO: range and domain
-   skos:prefLabel "System details note"@en, "Anmärkningstext"@sv .
-
 :technique a owl:ObjectProperty ;
     sdo:domainIncludes kbv:Visual ;
     sdo:rangeIncludes :VisualTechniqueType ;

--- a/source/marc/terms.ttl
+++ b/source/marc/terms.ttl
@@ -400,7 +400,7 @@ marc:SystemDetailsNote a owl:Class ;
     rdfs:subClassOf kbv:StructuredValue .
 
 marc:systemDetailsNote a owl:DatatypeProperty ;
-    rdfs:label "Anmärkningstext"@sv ;
+    rdfs:label "Anmärkningstext"@sv, "System details note"@en ;
     rdfs:domain marc:SystemDetailsNote .
 
 marc:uniformResourceIdentifier a owl:DatatypeProperty ;

--- a/source/vocab/details.ttl
+++ b/source/vocab/details.ttl
@@ -480,7 +480,7 @@
     rdfs:range bf2:Status;
     owl:equivalentProperty bf2:status .
 
-:acquisitionTerms a rdf:Property;
+:acquisitionTerms a owl:DatatypeProperty;
     owl:equivalentProperty bf2:acquisitionTerms;
     rdfs:label "Anskaffningsvillkor"@sv .
 


### PR DESCRIPTION
I noticed two more terms in vocab where @type is set to both ObjectProperty and DatatypeProperty. This should be the last terms with conflicting property types.