### PR TITLE
Make Role and Relation subclasses of kbv:ObjectProperty 

### DIFF
--- a/source/vocab/relations.ttl
+++ b/source/vocab/relations.ttl
@@ -453,7 +453,7 @@
 
 :Role a owl:Class;
     rdfs:label "Funktion"@sv;
-    rdfs:subClassOf owl:ObjectProperty ;
+    rdfs:subClassOf :ObjectProperty ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:onProperty rdfs:range ;
             owl:allValuesFrom :Agent
@@ -512,7 +512,7 @@
 
 :Relation a owl:Class;
     rdfs:label "Relation"@sv;
-    rdfs:subClassOf owl:ObjectProperty ;
+    rdfs:subClassOf :ObjectProperty ;
     owl:equivalentClass bflc:Relation .
 
 :Relationship a owl:Class ;


### PR DESCRIPTION
The relation to owl is retained by kbv:ObjectProperty is equivalentClass with owl:ObjectProperty