### PR TITLE
Remove marc enumerations that should not be used anymore

### DIFF
--- a/source/marc/indicators.ttl
+++ b/source/marc/indicators.ttl
@@ -52,8 +52,6 @@ marc:MedicalSubjectHeadingsNlmNameAuthorityFile a marc:Thesaurus ;
           rdfs:label "MeSH/NLM authority files" .
 marc:NationalAgriculturalLibrarySubjectAuthorityFile a marc:Thesaurus ;
           rdfs:label "NAL subject authority file" .
-marc:SourceNotSpecified a marc:Thesaurus ;
-          rdfs:label "System ej specificerat" .
 marc:CanadianSubjectHeadingsNlcNameAuthorityFile a marc:Thesaurus ;
           rdfs:label "Canadian SH/ NLC authority file" .
 marc:RepertoireDeVedettesMatiere a marc:Thesaurus ;
@@ -81,8 +79,6 @@ marc:typeOfDate a owl:ObjectProperty ;
 marc:TypeOfDate a marc:CollectionClass;
     rdfs:label "Typ av datum"@sv ;
     rdfs:subClassOf marc:EnumeratedTerm .
-marc:NoDateInformation a marc:TypeOfDate ;
-    rdfs:label "Tidsangivelse saknas"@sv .
 marc:SingleDate a marc:TypeOfDate ;
     rdfs:label "En tidsangivelse"@sv .
 marc:MultipleSingleDates a marc:TypeOfDate ;
@@ -119,8 +115,6 @@ marc:languageCode a owl:ObjectProperty ;
 marc:LanguageCode a marc:CollectionClass;
     rdfs:label "Språkkod"@sv ;
     rdfs:subClassOf marc:EnumeratedTerm .
-marc:ISO-639-2B a marc:LanguageCode ;
-    rdfs:label "Språkkod enligt ISO 639-2B"@sv .
 
 marc:typeOfTimePeriod a owl:ObjectProperty ;
     rdfs:label "typ av tidsperiod"@sv ;


### PR DESCRIPTION
Applies to marc enumerations that have been removed from marcframe (when marcDefault has been added). The enumerations are therefore no longer mapped in marcframe and can not be reverted.

The enumerations were previously mapped to:
* auth 710/711/730/748: marc:SourceNotSpecified
* auth 377: marc:ISO-639-2B
* bib 033: marc:NoDateInformation