### PR TITLE
Add domainIncludes Titlepart to partNumber and partName

### DIFF
--- a/source/vocab/details.ttl
+++ b/source/vocab/details.ttl
@@ -77,13 +77,13 @@
     rdfs:label "part title"@en, "deltitel"@sv;
     rdfs:range rdfs:Literal;
     owl:equivalentProperty bf2:partName;
-    rdfs:domain :Title .
+    sdo:domainIncludes :Title, :TitlePart .
 
 :partNumber a owl:DatatypeProperty;
     rdfs:label "part number"@en, "delbeteckning"@sv;
     rdfs:range rdfs:Literal;
     owl:equivalentProperty bf2:partNumber;
-    rdfs:domain :Title .
+    sdo:domainIncludes :Title, :TitlePart .
 
 #:WorkTitle  a owl:Class;
 #    owl:equivalentClass bf2:WorkTitle;


### PR DESCRIPTION
In order to add partNumber and partName to a TitlePart, domainIncludes has been extended with Titlepart for these properties. Since Titlepart is not and should not be a subClass of Title which was the original domain.