### PR TITLE
Update range for termComponentList to Identity

### DIFF
--- a/source/vocab/concepts.ttl
+++ b/source/vocab/concepts.ttl
@@ -330,7 +330,7 @@
     rdfs:subPropertyOf :label, :hasPart;
     skos:related :broader;
     rdfs:domain :Concept;
-    rdfs:range :Identity ;
+    sdo:rangeIncludes :Subject, :Subdivision, :GenreForm, :TopicSubdivision, :Temporal, :Geographic, :Work, :Agent ;
     rdfs:label "Term components"@en, "Termkomponenter"@sv;
     rdfs:comment "En ordnad lista på de komponenter som termen består av."@sv .
 

--- a/source/vocab/concepts.ttl
+++ b/source/vocab/concepts.ttl
@@ -330,7 +330,7 @@
     rdfs:subPropertyOf :label, :hasPart;
     skos:related :broader;
     rdfs:domain :Concept;
-    sdo:rangeIncludes :Subject, :Subdivision ;
+    rdfs:range :Identity ;
     rdfs:label "Term components"@en, "Termkomponenter"@sv;
     rdfs:comment "En ordnad lista på de komponenter som termen består av."@sv .
 


### PR DESCRIPTION
Previous range with only subject and subdivision was too narrow. Need to be able to handle Works, Agents, Temporals etc. Identity covers all the cases but might also be to broad. Need user input if further tweaks should be done.