### PR TITLE
Narrower rangeIncludes of termComponentList to:

### DIFF
--- a/source/vocab/concepts.ttl
+++ b/source/vocab/concepts.ttl
@@ -330,7 +330,7 @@
     rdfs:subPropertyOf :label, :hasPart;
     skos:related :broader;
     rdfs:domain :Concept;
-    sdo:rangeIncludes :Subject, :Subdivision, :Work, :Agent ;
+    sdo:rangeIncludes :Topic, :Geographic, :Temporal, :Subdivision, :Work, :Agent ;
     rdfs:label "Term components"@en, "Termkomponenter"@sv;
     rdfs:comment "En ordnad lista på de komponenter som termen består av."@sv .
 

--- a/source/vocab/concepts.ttl
+++ b/source/vocab/concepts.ttl
@@ -330,7 +330,7 @@
     rdfs:subPropertyOf :label, :hasPart;
     skos:related :broader;
     rdfs:domain :Concept;
-    sdo:rangeIncludes :Subject, :Subdivision, :GenreForm, :TopicSubdivision, :Temporal, :Geographic, :Work, :Agent ;
+    sdo:rangeIncludes :Subject, :Subdivision, :Work, :Agent ;
     rdfs:label "Term components"@en, "Termkomponenter"@sv;
     rdfs:comment "En ordnad lista på de komponenter som termen består av."@sv .
 


### PR DESCRIPTION
* Subject
* Subdivision
* Work
* Agent

A ComplexSubject shall consists of Subject, Work or Agent together
with subclass of Subdivision. (Therefore, we remove GenreForm,
which exists as a Subdivision)