### PR TITLE
Add identifiedBy to all Agent lenses

### DIFF
--- a/source/vocab/display.jsonld
+++ b/source/vocab/display.jsonld
@@ -263,29 +263,29 @@
           "@type": "fresnel:Lens",
           "@id": "Person-cards",
           "classLensDomain": "Person",
-          "showProperties": [ "familyName", "givenName", "name", "marc:numeration", "marc:titlesAndOtherWordsAssociatedWithAName", "marc:fullerFormName", "lifeSpan", "marc:attributionQualifier", "notation", "personTitle", "note" ]
+          "showProperties": [ "familyName", "givenName", "name", "marc:numeration", "marc:titlesAndOtherWordsAssociatedWithAName", "marc:fullerFormName", "lifeSpan", "marc:attributionQualifier", "notation", "personTitle", "note", "identifiedBy" ]
         },
         "Family": {
           "@type": "fresnel:Lens",
           "@id": "Family-cards",
           "classLensDomain": "Family",
-          "showProperties": [ "name", "marc:titlesAndOtherWordsAssociatedWithAName", "lifeSpan", "hasTypeOfFamily", "note" ]
+          "showProperties": [ "name", "marc:titlesAndOtherWordsAssociatedWithAName", "lifeSpan", "hasTypeOfFamily", "note", "identifiedBy" ]
         },
         "Jurisdiction": {
           "@type": "fresnel:Lens",
           "classLensDomain": "Jurisdiction",
-          "showProperties": [ "name", "isPartOf", "marc:subordinateUnit", "note" ]
+          "showProperties": [ "name", "isPartOf", "marc:subordinateUnit", "note", "identifiedBy" ]
         },
         "Meeting": {
           "@type": "fresnel:Lens",
           "classLensDomain": "Meeting",
-          "showProperties": [ "name", "marc:subordinateUnit", "date", "note" ]
+          "showProperties": [ "name", "marc:subordinateUnit", "date", "note", "identifiedBy" ]
         },
         "Organization": {
           "@type": "fresnel:Lens",
           "@id": "Organization-cards",
           "classLensDomain": "Organization",
-          "showProperties": [ "name", "isPartOf", "marc:subordinateUnit", "note" ]
+          "showProperties": [ "name", "isPartOf", "marc:subordinateUnit", "note", "identifiedBy" ]
         },
         "Concept": {
           "@type": "fresnel:Lens",


### PR DESCRIPTION
Persons, Organizations, Meetings, Families, Jurisdictions now have identifiedBy in their cards which means that by next reindexing identifiers are searchable.