### PR TITLE
Feature/cartographic improvements

### DIFF
--- a/source/marc/enums.ttl
+++ b/source/marc/enums.ttl
@@ -224,8 +224,8 @@
     rdfs:subClassOf :EnumeratedTerm ;
     skos:broadMatch kbv:Globe ;
     skos:notation "GlobeMediumType" ;
-    skos:prefLabel "Physical Medium"@en,
-        "Material"@sv .
+    skos:prefLabel "Physical Medium (globe)"@en,
+        "Material (glob)"@sv .
 
 :HoldingComputerSoundType a :CollectionClass ;
     rdfs:subClassOf :EnumeratedTerm ;
@@ -323,8 +323,8 @@
     rdfs:subClassOf :EnumeratedTerm ;
     skos:broadMatch kbv:Map ;
     skos:notation "MapMediumType" ;
-    skos:prefLabel "Physical Medium"@en,
-        "Material"@sv .
+    skos:prefLabel "Physical Medium (map)"@en,
+        "Material (kartor)"@sv .
 
 :MapsFormatType a :CollectionClass ;
     rdfs:subClassOf :EnumeratedTerm ;

--- a/source/marc/terms.ttl
+++ b/source/marc/terms.ttl
@@ -82,6 +82,11 @@ marc:reprintYear a owl:DatatypeProperty ;
 marc:originalYear a owl:DatatypeProperty ;
     rdfs:domain marc:ReprintReissueAndOriginalPublication .
 
+marc:relief a owl:ObjectProperty ;
+    rdfs:label "Relief"@en, "Relief"@sv ;
+    rdfs:domain kbv:Instance ;
+    rdfs:range marc:MapsReliefType .
+
 # IDENTIFIERS
 
 marc:hiddenValue a owl:DatatypeProperty;

--- a/source/marc/terms.ttl
+++ b/source/marc/terms.ttl
@@ -178,6 +178,22 @@ marc:constantRatioLinearVerticalScale a owl:DatatypeProperty ;
 marc:angularScale a owl:DatatypeProperty ;
     rdfs:label "Angular scale"@en, "Vinkelskala (angular scale)"@sv .
 
+marc:westernmostLongitudeCoordinates a owl:DatatypeProperty ;
+    rdfs:label "Coordinates - westernmost longitude"@en, "Koordinater - västlig gränslongitud"@sv ;
+    rdfs:domain kbv:Cartographic .
+
+marc:easternmostLongitudeCoordinates a owl:DatatypeProperty ;
+    rdfs:label "Coordinates - easternmost longitude"@en, "Koordinater - östlig gränslongitud"@sv ;
+    rdfs:domain kbv:Cartographic .
+
+marc:northernmostLatitudeCoordinates a owl:DatatypeProperty ;
+    rdfs:label "Coordinates - northernmost longitude"@en, "Koordinater - nordlig gränslongitud"@sv ;
+    rdfs:domain kbv:Cartographic .
+
+marc:southernmostLatitudeCoordinates a owl:DatatypeProperty ;
+    rdfs:label "Coordinates - southernmost longitude"@en, "Koordinater - sydlig gränslongitud"@sv ;
+    rdfs:domain kbv:Cartographic .
+
 # 040
 
 marc:transcribingAgency a owl:ObjectProperty ;

--- a/source/marc/unlabelled.ttl
+++ b/source/marc/unlabelled.ttl
@@ -154,7 +154,6 @@ marc:denomination a owl:DatatypeProperty .
 marc:displayNote a owl:DatatypeProperty .
 marc:displayText a owl:DatatypeProperty .
 marc:distanceFromEarth a owl:DatatypeProperty .
-marc:easternmostLongitudeCoordinates a owl:DatatypeProperty .
 marc:editionIdentifier a owl:DatatypeProperty .
 marc:editionStatementOfOriginal a owl:DatatypeProperty .
 marc:endOfDateValid a owl:DatatypeProperty .
@@ -310,7 +309,6 @@ marc:musicalPresentationStatement a owl:DatatypeProperty .
 marc:nameOfMeetingFollowingJurisdictionNameEntryElement a owl:DatatypeProperty .
 marc:nameOfPartSectionOfAWork a owl:DatatypeProperty .
 marc:nonProjAspect a owl:ObjectProperty .
-marc:northernmostLatitudeCoordinates a owl:DatatypeProperty .
 marc:noteAboutOriginal a owl:DatatypeProperty .
 marc:numberOfPartSectionMeeting a owl:DatatypeProperty .
 marc:numberOfVolumeOrPart a owl:DatatypeProperty .
@@ -381,7 +379,6 @@ marc:sourceOfLocalSubentityCode a owl:DatatypeProperty .
 marc:sourceOfStockNumberAcquisition a owl:DatatypeProperty .
 marc:sourceOfTaxonomicIdentification a owl:DatatypeProperty .
 marc:sourceOfTerm a owl:DatatypeProperty .
-marc:southernmostLatitudeCoordinates a owl:DatatypeProperty .
 marc:subjectLevel a owl:ObjectProperty .
 marc:sungOrSpokenText a owl:ObjectProperty .
 marc:tableIdentificationTableNumber a owl:DatatypeProperty .
@@ -413,7 +410,6 @@ marc:version a owl:DatatypeProperty .
 marc:verticalPositionalAccuracyExplanation a owl:DatatypeProperty .
 marc:verticalPositionalAccuracyReport a owl:DatatypeProperty .
 marc:verticalPositionalAccuracyValue a owl:DatatypeProperty .
-marc:westernmostLongitudeCoordinates a owl:DatatypeProperty .
 marc:workUnitNumber a owl:DatatypeProperty .
 
 marc:nationalBibliographicAgency a owl:DatatypeProperty .

--- a/source/marc/unlabelled.ttl
+++ b/source/marc/unlabelled.ttl
@@ -349,7 +349,6 @@ marc:referenceInstructionPhrase a owl:DatatypeProperty .
 marc:reformattingQuality a owl:ObjectProperty .
 marc:relatorCode a owl:DatatypeProperty .
 marc:relatorTerm a owl:DatatypeProperty .
-marc:relief a owl:ObjectProperty .
 marc:remoteSensImageAltitude a owl:ObjectProperty .
 marc:remoteSensImageAttitude a owl:ObjectProperty .
 marc:remoteSensImageCloud a owl:ObjectProperty .

--- a/source/vocab/construct-enum-restrictions.rq
+++ b/source/vocab/construct-enum-restrictions.rq
@@ -84,7 +84,9 @@ construct {
 
 (:genreForm	:GenreForm	:Audio	marc:MusicCompositionType)
 (:genreForm	:GenreForm	:Audio	marc:MusicTextType)
+(:genreForm	:GenreForm	:Cartography	marc:MapsMaterialType)
 (:genreForm	:GenreForm	:Cartography	marc:GovernmentPublicationType)
+(:genreForm	:GenreForm	:Cartography	marc:MapsFormatType)
 (:genreForm	:GenreForm	:Multimedia	marc:ComputerTypeOfFileType)
 (:genreForm	:GenreForm	:Multimedia	marc:GovernmentPublicationType)
 (:genreForm	:GenreForm	:Globe	marc:GlobeMaterialType)


### PR DESCRIPTION
* Label for and possibility to add marc:relief.
* More precise labels for Cartographic mediumtypes, making it easier to know which list is which.
* Label for and possibility to add coded coordinates (marc 034).