### PR TITLE
Feature/general definition cleanups

### DIFF
--- a/source/funktionskoder.tsv
+++ b/source/funktionskoder.tsv
@@ -124,7 +124,7 @@ frg	Förfalskare		Forger
 gis	GIS-specialist	Geografisk information	Geographic information specialist				
 grt	Grafisk tekniker	"Obsolet; använd ""art"" (konstnär)"	Graphic technician				
 his	Värdinstitution		Host institution		host institution		
-hnr	Festksriftsföremål	Hit även person etc. som på annat sätt hedrats i verket eller exemplaret	Honoree		honouree of item		
+hnr	Festskriftsföremål	Hit även person etc. som på annat sätt hedrats i verket eller exemplaret	Honoree		honouree of item		
 hst	Programvärd, programledare		Host		host		
 ill	Illustratör		Illustrator		illustrator		
 ilu	Illuminatör	Färglagda initialer, randornament, bilder eller annan utsmyckande illustration i främst medeltida handskrifter	Illuminator		illuminator		

--- a/source/vocab/agents.ttl
+++ b/source/vocab/agents.ttl
@@ -277,8 +277,6 @@
     owl:equivalentClass sdo:Library .
 
 :bibliography a owl:ObjectProperty ;
-    :category :compositional ;
-    # until we can properly link bibliographies, when we do we also probably want to restrict the creation of new ones.
     rdfs:domain :Record ;
     rdfs:range :Library ;
     rdfs:label "bibliografi"@sv .

--- a/source/vocab/agents.ttl
+++ b/source/vocab/agents.ttl
@@ -277,6 +277,8 @@
     owl:equivalentClass sdo:Library .
 
 :bibliography a owl:ObjectProperty ;
+    :category :compositional ;
+    # until we can properly link bibliographies, when we do we also probably want to restrict the creation of new ones.
     rdfs:domain :Record ;
     rdfs:range :Library ;
     rdfs:label "bibliografi"@sv .

--- a/source/vocab/base.ttl
+++ b/source/vocab/base.ttl
@@ -116,11 +116,17 @@ rdf:type a owl:ObjectProperty;
     owl:equivalentProperty sdo:category .
 
 :shorthand a skos:Collection ;
-    rdfs:comment "Används för att i Libris katalogiseringsverktyg kunna dölja kortformer för egenskaper som har en mer komplex bakomliggande struktur. Exempelvis isbn som kan motsvara identifiedBy.ISBN.value"@sv ;
-    :code "shorthand".
+    rdfs:label "kortform"@sv ;
+    rdfs:comment "Anges som kategori på egenskaper som har en mer komplex bakomliggande struktur."@sv ;
+    skos:example "Exempelvis isbn, som motsvarar identifiedBy(type=ISBN).value."@sv ;
+    skos:scopeNote "Används i Libris katalogiseringsverktyg för att dölja dessa vid listning av egenskaper."@sv ;
+    :code "shorthand" .
 
 :compositional a skos:Collection ;
-    rdfs:comment "Används i Libris katalogiseringsverktyg för att stödja arbetsflödet att endast skapa en lokal beskrivning, för en annars länkbar entitet. Exempelvis hasVariant som pekar på Agenter."@sv ;
+    rdfs:label "inneboende del"@sv ;
+    rdfs:comment "Anges på egenskaper för att betrakta deras värde som en sammansatt del av entiteten, istället för en länkbar fristående entitet."@sv ;
+    skos:example "Exempelvis hasVariant, som anger variantbeskrivingar av en Agent som distinkta Agenter (men enbart i formen, de respresenterar samma ting)."@sv ;
+    skos:scopeNote "Används i Libris katalogiseringsverktyg för att stödja arbetsflödet att endast skapa en lokal beskrivning."@sv ;
     :code "compositional" .
 
 :label a owl:DatatypeProperty;

--- a/source/vocab/base.ttl
+++ b/source/vocab/base.ttl
@@ -115,8 +115,13 @@ rdf:type a owl:ObjectProperty;
     rdfs:label "kategori"@sv;
     owl:equivalentProperty sdo:category .
 
-:shorthand a skos:Collection ; :code "shorthand" .
-:compositional a skos:Collection ; :code "compositional" .
+:shorthand a skos:Collection ;
+    rdfs:comment "Används för att i Libris katalogiseringsverktyg kunna dölja kortformer för egenskaper som har en mer komplex bakomliggande struktur. Exempelvis isbn som kan motsvara identifiedBy.ISBN.value"@sv ;
+    :code "shorthand".
+
+:compositional a skos:Collection ;
+    rdfs:comment "Används för att i Libris katalogiseringsverktyg endast möjliggöra beskrivning av en vanligtvis länkbar sak som lokal entitet. Exempelvis hasVariant som pekar på Agenter."@sv ;
+    :code "compositional" .
 
 :label a owl:DatatypeProperty;
     rdfs:label "label"@en, "benämning"@sv;

--- a/source/vocab/base.ttl
+++ b/source/vocab/base.ttl
@@ -120,7 +120,7 @@ rdf:type a owl:ObjectProperty;
     :code "shorthand".
 
 :compositional a skos:Collection ;
-    rdfs:comment "Används för att i Libris katalogiseringsverktyg endast möjliggöra beskrivning av en vanligtvis länkbar sak som lokal entitet. Exempelvis hasVariant som pekar på Agenter."@sv ;
+    rdfs:comment "Används i Libris katalogiseringsverktyg för att stödja arbetsflödet att endast skapa en lokal beskrivning, för en annars länkbar entitet. Exempelvis hasVariant som pekar på Agenter."@sv ;
     :code "compositional" .
 
 :label a owl:DatatypeProperty;

--- a/source/vocab/details.ttl
+++ b/source/vocab/details.ttl
@@ -1159,7 +1159,7 @@
 :ensemble a owl:ObjectProperty;
     rdfs:label "Ensemble"@en, "Ensemble"@sv;
     rdfs:domain :Work;
-    rdfs:range rdfs:MusicEnsemble;
+    rdfs:range :MusicEnsemble;
     owl:equivalentProperty bf2:ensemble .
 
 :ensembleType a owl:DatatypeProperty;

--- a/source/vocab/details.ttl
+++ b/source/vocab/details.ttl
@@ -46,7 +46,7 @@
 :hasTitle a owl:ObjectProperty;
     owl:equivalentProperty bf2:title;
     rdfs:range :Title;
-    rdfs:label "has title"@en, "har titel"@sv;
+    rdfs:label "har titel"@sv;
     rdfs:comment "Innehåller titelelement"@sv .
 
 :Title a owl:Class;
@@ -751,7 +751,7 @@
 #Instance Description Statements
 
 :responsibilityStatement a owl:DatatypeProperty;
-    rdfs:label "responsibility statement"@en, "upphovsuppgift"@sv;
+    rdfs:label "upphovsuppgift"@sv;
     sdo:domainIncludes :ToCEntry ;
     skos:definition "Uppgift som härrör agenter som är ansvariga för, eller som bidragit till, förverkligandet av resursens intellektuella eller konstnärliga innehåll."@sv;
     rdfs:comment "Upphovsuppgift som hänför sig till huvudtiteln. Endast upphovsuppgifter som hämtas från en källa utanför resursen ska klamras."@sv;

--- a/source/vocab/details.ttl
+++ b/source/vocab/details.ttl
@@ -410,7 +410,7 @@
 :MatrixNumber a owl:Class; # rdfs:Datatype ?
     rdfs:subClassOf :Identifier;
     rdfs:label "Matrix number"@en, "Matrisnummer"@en;
-    owl:equivalentClass bf2:MusicDistributorNumber .
+    owl:equivalentClass bf2:MatrixNumber .
 
 :MusicDistributorNumber a owl:Class; # rdfs:Datatype ?
     rdfs:subClassOf :Identifier;

--- a/source/vocab/details.ttl
+++ b/source/vocab/details.ttl
@@ -333,6 +333,7 @@
     rdfs:label "ISBN" .
 
 :ISBN13 a owl:Class; # rdfs:Datatype ?
+    :category :pending ;
     rdfs:subClassOf :ISBN;
     rdfs:label "ISBN-13" .
 

--- a/source/vocab/enums.ttl
+++ b/source/vocab/enums.ttl
@@ -109,7 +109,7 @@
     owl:equivalentClass bf2:TactileNotation .
 
 :intendedAudience a owl:ObjectProperty;
-    rdfs:label "audience"@en, "målgrupp"@sv;
+    rdfs:label "målgrupp"@sv;
     rdfs:comment "Avsedd målgrupp, eller åldersnivå för vilken innehållet i resursen anses lämpligt."@sv;
     rdfs:subPropertyOf sdo:audience;
     owl:equivalentProperty bf2:intendedAudience;

--- a/source/vocab/relations.ttl
+++ b/source/vocab/relations.ttl
@@ -15,7 +15,7 @@
 @prefix bflc: <http://id.loc.gov/ontologies/bflc/> .
 
 @prefix : <https://id.kb.se/vocab/> .
-
+@prefix marc: <https://id.kb.se/marc/> .
 
 :license a owl:ObjectProperty;
     rdfs:label "licens"@sv;
@@ -407,7 +407,7 @@
     rdfs:label "language"@en, "språk"@sv;
     # TODO worklanguage? 
     rdfs:comment "Språk förknippat med en resurs eller dess delar."@sv;
-    sdo:domainIncludes :Creation, :StructuredValue;
+    sdo:domainIncludes :Creation, :Summary, :TableOfContents, :Title, marc:Libretto, marc:SubtitlesOrCaptions, marc:SungOrSpokenText;
     owl:equivalentProperty bf2:language;
     rdfs:subPropertyOf dc:language;
     rdfs:range :Language .

--- a/source/vocab/relations.ttl
+++ b/source/vocab/relations.ttl
@@ -404,7 +404,7 @@
     owl:equivalentProperty foaf:isPrimaryTopicOf .
 
 :language a owl:ObjectProperty;
-    rdfs:label "language"@en, "språk"@sv;
+    rdfs:label "språk"@sv;
     # TODO worklanguage? 
     rdfs:comment "Språk förknippat med en resurs eller dess delar."@sv;
     sdo:domainIncludes :Creation, :Summary, :TableOfContents, :Title, marc:Libretto, marc:SubtitlesOrCaptions, marc:SungOrSpokenText;

--- a/source/vocab/relations.ttl
+++ b/source/vocab/relations.ttl
@@ -407,6 +407,8 @@
     rdfs:label "språk"@sv;
     # TODO worklanguage? 
     rdfs:comment "Språk förknippat med en resurs eller dess delar."@sv;
+    # TODO: define an abstract base class of these?
+    # (E.g. bring back :Annotation in a new guise...)
     sdo:domainIncludes :Creation, :Summary, :TableOfContents, :Title, marc:Libretto, marc:SubtitlesOrCaptions, marc:SungOrSpokenText;
     owl:equivalentProperty bf2:language;
     rdfs:subPropertyOf dc:language;


### PR DESCRIPTION
- Removed english labels that were "almost the same" in BF2 but became doubled in english version of the interface.
- Fixed faulty BF2 mapping of MatrixNumber.
- MusicEnsemble now has correct bf2 prefix
- ISBN13 is now pending so it isn't addable through the interface. Not used in conversion so might actually be an ancient artefact.
- Language, now doesn't include identifier in it's range :)
