### PR TITLE
Feature/label changes

### DIFF
--- a/source/marc/enums.ttl
+++ b/source/marc/enums.ttl
@@ -1203,7 +1203,7 @@
         kbv:Visual ;
     skos:notation "PublicationStatusType" ;
     skos:prefLabel "Publication Status"@en,
-        "Typ av utgivningssdatum"@sv .
+        "Typ av utgivningsdatum"@sv .
 
 :ContinuingResourceCeasedPublication a :PublicationStatusType ;
     #owl:sameAs :PublicationStatusType-d ;

--- a/source/vocab/details.ttl
+++ b/source/vocab/details.ttl
@@ -436,7 +436,7 @@
 
 :PublisherNumber a owl:Class; # rdfs:Datatype ?
     rdfs:subClassOf :Identifier;
-    rdfs:label "Other publisher number"@en, "Utgivningsnummer (annat)"@sv;
+    rdfs:label "Utgivningsnummer"@sv;
     owl:equivalentClass bf2:PublisherNumber .
 
 :PostalRegistration a owl:Class; # rdfs:Datatype ?


### PR DESCRIPTION
Change Swedish label for Publisher Number because update in BF 2.0.1
(https://github.com/lcnetdev/bibframe-ontology/issues/42)

Change Swedish label for Publication Status because of typo.