### PR TITLE
Add marc:previousTitle to marcterms

### DIFF
--- a/source/marc/terms.ttl
+++ b/source/marc/terms.ttl
@@ -312,6 +312,13 @@ marc:formSubheading a owl:DatatypeProperty;
     rdfs:label "Form subheading"@en, "Specificering i form av grupptitel"@sv ;
     rdfs:domain kbv:Title . 
 
+# BIB 247
+
+marc:previousTitle a owl:ObjectProperty;
+  rdfs:label "Tidigare titel"@sv;
+  rdfs:domain kbv:Instance;
+  rdfs:range kbv:Title .
+
 # BIB 249
 
 marc:hasBib249 a owl:ObjectProperty;

--- a/source/marc/unlabelled.ttl
+++ b/source/marc/unlabelled.ttl
@@ -334,7 +334,6 @@ marc:playbackCharacteristic a owl:DatatypeProperty .
 marc:playingSpeed a owl:DatatypeProperty .
 marc:populatedPlaceName a owl:DatatypeProperty .
 marc:postalAddress a owl:DatatypeProperty .
-marc:previousTitle a owl:ObjectProperty .
 marc:primeMeridian a owl:ObjectProperty .
 marc:programElementNumber a owl:DatatypeProperty .
 marc:projGraphAspect a owl:ObjectProperty .


### PR DESCRIPTION
Add marc:previoustitle to marcterms because of usage request.

* Add swedish label for presentation.
* Add domain Instance and range Title so it is possible from gui to add a Title object compatible with MARC conversion.