### PR TITLE
marc:SerialsRegularityType no longer subClass of Frequency

### DIFF
--- a/source/vocab/construct-enum-restrictions.rq
+++ b/source/vocab/construct-enum-restrictions.rq
@@ -76,7 +76,6 @@ construct {
 (:emulsion	:Emulsion	:Microform	marc:MicroformEmulsionType)
 
 (:frequency	:Frequency	:Serial	marc:SerialsFrequencyType)
-(:frequency	:Frequency	:Serial	marc:SerialsRegularityType)
 
 (:generation	:Generation	:Microform	marc:MicroformGenerationType)
 (:generation	:Generation	:MovingImage	marc:MotionPicGenerationType)


### PR DESCRIPTION
This disables the possibility to code frequency with
enums of type marc:SerialRegularityType