### PR TITLE
Add indexedIn as a bflc term

### DIFF
--- a/source/vocab/relations.ttl
+++ b/source/vocab/relations.ttl
@@ -229,6 +229,12 @@
     owl:inverseOf :index;
     owl:equivalentProperty bf2:indexOf .
 
+:indexedIn a owl:ObjectProperty ;
+    rdfs:domain :Endeavour ;
+    sdo:rangeIncludes :Instance, :Work ;
+    rdfs:label "Indexed in"@en, "Indexerad i"@sv ;
+    owl:equivalentProperty bflc:indexedIn .
+
 :hasEquivalent a owl:SymmetricProperty;
     rdfs:label "Equivalence"@en, "Likvärdighet"@sv;
     rdfs:subPropertyOf :relatedTo;

--- a/source/vocab/unstable.ttl
+++ b/source/vocab/unstable.ttl
@@ -54,10 +54,6 @@
     rdfs:label "Apparat"@sv;
     owl:equivalentClass dbpo:Device .
 
-:indexedIn a owl:ObjectProperty ;
-    sdo:domainIncludes :Instance ;
-    rdfs:label "Indexerad i"@sv .
-
 :imageBitDepth a owl:DatatypeProperty ;
     sdo:domainIncludes :Electronic ;
     rdfs:label "Bildens bit-djup"@sv .


### PR DESCRIPTION
Add indexedIn as a stable bflc term usable within the cataloguing client.

Reference: [http://id.loc.gov/ontologies/bflc.html#p_indexedIn](http://id.loc.gov/ontologies/bflc.html#p_indexedIn)