### PR TITLE
Remove Place as rangeInclude for subject

### DIFF
--- a/source/vocab/relations.ttl
+++ b/source/vocab/relations.ttl
@@ -452,7 +452,7 @@
     # - Could use baseclass :Agent in rangeIncludes, but need to exclude subclasses of :Organization...
     # - Should include :Work (but not its subclasses...)
     #sdo:rangeIncludes :Subject, :Agent, :Work .
-    sdo:rangeIncludes :Person, :Family, :Meeting, :Organization, :Jurisdiction, :Subject, :Work, :Place .
+    sdo:rangeIncludes :Person, :Family, :Meeting, :Organization, :Jurisdiction, :Subject, :Work .
     #rdfs:range :Identity . includes concept, makes for too many faulty choices.
 
 


### PR DESCRIPTION
Place was wrongly added as range for subject because of bib 653 ind2=5 is mapped as subject with type Place. But this mapping is wrong and will be corrected to subject with type Geographic.