### PR TITLE
Feature/separate classification topic schemes

### DIFF
--- a/source/schemes.ttl
+++ b/source/schemes.ttl
@@ -217,6 +217,10 @@
 
 #@base <https://id.kb.se/ext/term/> . # ?
 
+<agrissc> a :ClassificationScheme;
+    skos:notation "agrissc";
+    foaf:homepage <http://http://agris.fao.org/agris-search/index.do> .
+
 <agrovoc> a :TopicScheme;
     dc:title "AgroVoc"@en;
     skos:notation "agrovoc" .
@@ -224,10 +228,6 @@
 <bnb> a skos:ConceptScheme;
     skos:notation "bnb";
     dc:title "British National Bibliography"@en .
-
-<fao> a skos:ConceptScheme;
-    skos:notation "fao"; #, "agrissc"; #?
-    foaf:homepage <http://agris.fao.org/?InfoT=Subject&Language=EN> .
 
 <fiaf> a :ClassificationScheme;
     skos:notation "fiaf"; #"fiaf/2" #?

--- a/source/schemes.ttl
+++ b/source/schemes.ttl
@@ -46,7 +46,7 @@
     foaf:page <http://www.kb.se/katalogisering/Svenska-amnesord/om/>;
     void:inDataset </> .
 
-<saogf> a skos:ConceptScheme;
+<saogf> a :GenreFormScheme;
     skos:notation "saogf";
     dc:alternative "SAOGF";
     dc:title "SAOGF - Genre och form"@sv;
@@ -72,14 +72,14 @@
     foaf:page <http://www.kb.se/katalogisering/Svenska-amnesord/om/>;
     void:inDataset </> .
 
-<barngf> a skos:ConceptScheme;
+<barngf> a :GenreFormScheme;
     skos:notation "barngf";
     dc:alternative "BarnGF";
     dc:title "Barn - Genre och form"@sv;
     rdfs:seeAlso <barn>;
     void:inDataset </> .
 
-<gmgpc-swe> a skos:ConceptScheme;
+<gmgpc-swe> a :GenreFormScheme;
     owl:sameAs <gmgpc>, <gmgpc%2F%2Fswe>;
     skos:notation "gmgpc//swe";
     dc:title "Tesaurus för grafiskt material"@sv;
@@ -197,7 +197,7 @@
     dc:title "Svenska filminstitutets tesaurus"@sv;
     dc:alternative "SFIT" .
 
-<sgp> a skos:ConceptScheme;
+<sgp> a :GenreFormScheme;
     skos:notation "sgp";
     dc:title "Svenska genrebeteckningar för periodika"@sv;
     foaf:homepage <http://www.kb.se/katalogisering/Svenska-amnesord/genrer-form/tidskrifter/> .
@@ -255,7 +255,7 @@
     rdfs:seeAlso <http://neurocommons.org/page/Bundles/mesh/mesh-skos>;
     foaf:homepage <http://www.nlm.nih.gov/mesh/meshhome.html> .
 
-<nal> a skos:ConceptScheme;
+<nal> a :TopicScheme;
     dc:title "National Agricultural Library Subject Headings/NAL"@en;
     skos:notation "nal";
     foaf:homepage <https://www.nal.usda.gov/> .

--- a/source/schemes.ttl
+++ b/source/schemes.ttl
@@ -6,6 +6,7 @@
 @prefix dc: <http://purl.org/dc/terms/> .
 @prefix sdo: <http://schema.org/> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix : <https://id.kb.se/vocab/> .
 
 @base <https://id.kb.se/term/> .
 
@@ -212,6 +213,13 @@
     skos:notation "swemesh";
     dc:title "Svensk MeSH"@sv, "Swedish MeSH"@sv;
     foaf:homepage <https://mesh.kib.ki.se/> .
+
+<kssb> a :ClassificationScheme;
+    skos:notation "kssb";
+    dc:title "SAB-klassifikation"@sv .
+    # upplagor: 2, 5, 6, 7, 8, 9
+    # variant? (folkbibliotek, musikalier, musikinspelningar)
+    #<#usedWithProperty> dc:type .
 
 
 # Aliases for external schemes

--- a/source/schemes.ttl
+++ b/source/schemes.ttl
@@ -28,7 +28,7 @@
 
 # "ours"
 
-<sao> a skos:TopicScheme;
+<sao> a :TopicScheme;
     skos:notation "sao";
     dc:alternative "SAO";
     dc:title "Svenska ämnesord (SAO)"@sv;
@@ -60,7 +60,7 @@
     foaf:page <http://www.kb.se/katalogisering/Svenska-amnesord/om/>;
     void:inDataset </> .
 
-<barn> a skos:TopicScheme;
+<barn> a :TopicScheme;
     skos:notation "barn";
     dc:alternative "Barn";
     dc:title "Barnämnesord"@sv;
@@ -157,11 +157,11 @@
 
 # "others"
 
-<albt> a skos:TopicScheme;
+<albt> a :TopicScheme;
     skos:notation "albt//swe";
     dc:title "Arbetslivsbibliotekets tesaurus"@sv .
 
-<kao> a skos:TopicScheme;
+<kao> a :TopicScheme;
     skos:notation "kao";
     dc:title "KVINNSAM"@sv;
     dc:language [ skos:notation "sv"];
@@ -171,28 +171,28 @@
     #];
     foaf:homepage <http://www.ub.gu.se/kvinn/kvinnsam/listor/> .
 
-<kssb> a skos:ClassificationScheme;
+<kssb> a :ClassificationScheme;
     skos:notation "kssb";
     dc:title "SAB-klassifikation"@sv .
     # upplagor: 2, 5, 6, 7, 8, 9
     # variant? (folkbibliotek, musikalier, musikinspelningar)
     #<#usedWithProperty> dc:type .
 
-<prvt> a skos:TopicScheme;
+<prvt> a :TopicScheme;
     skos:notation "prvt";
     dc:title "Patent- och registreringsverkets tesaurus"@sv;
     dc:alternative "PRVT" .
 
-<quiding> a skos:TopicScheme;
+<quiding> a :TopicScheme;
     skos:notation "quiding";
     dc:title "Quiding, Nils Herman. Svenskt allmänt författningsregister för tiden från år 1522 till och med år 1862"@sv .
 
-<sbiao> a skos:TopicScheme;
+<sbiao> a :TopicScheme;
     skos:notation "sbiao";
     dc:title "Svenska barnboksinstitutets ämnesordsindex för teoretisk litteratur"@sv;
     foaf:homepage <http://www.sbi.kb.se/sv/Biblioteket/Soka/Amnesordsindex/Teoretiska-amnesord/> .
 
-<sfit> a skos:TopicScheme;
+<sfit> a :TopicScheme;
     skos:notation "sfit";
     dc:title "Svenska filminstitutets tesaurus"@sv;
     dc:alternative "SFIT" .
@@ -202,12 +202,12 @@
     dc:title "Svenska genrebeteckningar för periodika"@sv;
     foaf:homepage <http://www.kb.se/katalogisering/Svenska-amnesord/genrer-form/tidskrifter/> .
 
-<shbe> a skos:TopicScheme;
+<shbe> a :TopicScheme;
     skos:notation "shbe";
     dc:title "Subject headings in business and economics"@en;
     rdfs:comment "Handelshögskolans i Stockholm bibliotek"@sv .
 
-<swemesh> a skos:TopicScheme;
+<swemesh> a :TopicScheme;
     skos:notation "swemesh";
     dc:title "Svensk MeSH"@sv, "Swedish MeSH"@sv;
     foaf:homepage <https://mesh.kib.ki.se/> .
@@ -217,7 +217,7 @@
 
 #@base <https://id.kb.se/ext/term/> . # ?
 
-<agrovoc> a skos:TopicScheme;
+<agrovoc> a :TopicScheme;
     dc:title "AgroVoc"@en;
     skos:notation "agrovoc" .
 
@@ -229,26 +229,26 @@
     skos:notation "fao"; #, "agrissc"; #?
     foaf:homepage <http://agris.fao.org/?InfoT=Subject&Language=EN> .
 
-<fiaf> a skos:ClassificationScheme;
+<fiaf> a :ClassificationScheme;
     skos:notation "fiaf"; #"fiaf/2" #?
     dc:title "International Federation of Film Archives"@en .
 
-<lcsh> a skos:TopicScheme;
+<lcsh> a :TopicScheme;
     skos:notation "lcsh";
     dc:alternative "LCSH";
     dc:title "Library of Congress Subject Headings"@en;
     foaf:homepage <http://id.loc.gov/authorities/subjects/> .
 
-<mipfesd> a skos:TopicScheme;
+<mipfesd> a :TopicScheme;
     skos:notation "mipfesd"; #"mipfesd/5"
     dc:title "Marcrothesaurus for information processing in the field of economic and social development (OECD)"@en .
 
-<msc> a skos:ClassificationScheme;
+<msc> a :ClassificationScheme;
     skos:notation "msc";
     dc:title "Mathematical subject classification"@en;
     rdfs:comment "Providence, RI: American Mathematical Society"@en .
 
-<mesh> a skos:TopicScheme;
+<mesh> a :TopicScheme;
     skos:notation "mesh";
     dc:title "Medical Subject Headings"@en;
     dc:alternative "MeSH";
@@ -260,17 +260,17 @@
     skos:notation "nal";
     foaf:homepage <https://www.nal.usda.gov/> .
 
-<nlm> a skos:ClassificationScheme;
+<nlm> a :ClassificationScheme;
     skos:notation "nlm";
     dc:alternative "NLM";
     dc:title "National Library of Medicine"@en .
 
-<rswk> a skos:TopicScheme;
+<rswk> a :TopicScheme;
     skos:notation "rswk";
     dc:title "Regeln für den Schlagwortkatalog (Deutsches Bibliotheksinstitut)"@de;
     foaf:homepage <http://deposit.ddb.de/ep/netpub/89/96/96/967969689/_data_stat/www.dbi-berlin.de/dbi_pub/einzelpu/regelw/rswk/rswk_00.htm> .
 
-<sipri> a skos:TopicScheme;
+<sipri> a :TopicScheme;
     skos:notation "sipri";
     dc:title "SIPRI Library thesaurus"@en;
     foaf:homepage <http://www.sipri.org/library/thesaurus/thesaurus.html/> .

--- a/source/schemes.ttl
+++ b/source/schemes.ttl
@@ -28,7 +28,7 @@
 
 # "ours"
 
-<sao> a skos:ConceptScheme;
+<sao> a skos:TopicScheme;
     skos:notation "sao";
     dc:alternative "SAO";
     dc:title "Svenska ämnesord (SAO)"@sv;
@@ -60,7 +60,7 @@
     foaf:page <http://www.kb.se/katalogisering/Svenska-amnesord/om/>;
     void:inDataset </> .
 
-<barn> a skos:ConceptScheme;
+<barn> a skos:TopicScheme;
     skos:notation "barn";
     dc:alternative "Barn";
     dc:title "Barnämnesord"@sv;
@@ -155,15 +155,13 @@
     void:inDataset </> .
 
 
-#<kaab/8> ?
-
 # "others"
 
-<albt> a skos:ConceptScheme;
+<albt> a skos:TopicScheme;
     skos:notation "albt//swe";
     dc:title "Arbetslivsbibliotekets tesaurus"@sv .
 
-<kao> a skos:ConceptScheme;
+<kao> a skos:TopicScheme;
     skos:notation "kao";
     dc:title "KVINNSAM"@sv;
     dc:language [ skos:notation "sv"];
@@ -173,28 +171,28 @@
     #];
     foaf:homepage <http://www.ub.gu.se/kvinn/kvinnsam/listor/> .
 
-<kssb> a skos:ConceptScheme;
+<kssb> a skos:ClassificationScheme;
     skos:notation "kssb";
     dc:title "SAB-klassifikation"@sv .
     # upplagor: 2, 5, 6, 7, 8, 9
     # variant? (folkbibliotek, musikalier, musikinspelningar)
     #<#usedWithProperty> dc:type .
 
-<prvt> a skos:ConceptScheme;
+<prvt> a skos:TopicScheme;
     skos:notation "prvt";
     dc:title "Patent- och registreringsverkets tesaurus"@sv;
     dc:alternative "PRVT" .
 
-<quiding> a skos:ConceptScheme;
+<quiding> a skos:TopicScheme;
     skos:notation "quiding";
     dc:title "Quiding, Nils Herman. Svenskt allmänt författningsregister för tiden från år 1522 till och med år 1862"@sv .
 
-<sbiao> a skos:ConceptScheme;
+<sbiao> a skos:TopicScheme;
     skos:notation "sbiao";
     dc:title "Svenska barnboksinstitutets ämnesordsindex för teoretisk litteratur"@sv;
     foaf:homepage <http://www.sbi.kb.se/sv/Biblioteket/Soka/Amnesordsindex/Teoretiska-amnesord/> .
 
-<sfit> a skos:ConceptScheme;
+<sfit> a skos:TopicScheme;
     skos:notation "sfit";
     dc:title "Svenska filminstitutets tesaurus"@sv;
     dc:alternative "SFIT" .
@@ -204,29 +202,22 @@
     dc:title "Svenska genrebeteckningar för periodika"@sv;
     foaf:homepage <http://www.kb.se/katalogisering/Svenska-amnesord/genrer-form/tidskrifter/> .
 
-<shbe> a skos:ConceptScheme;
+<shbe> a skos:TopicScheme;
     skos:notation "shbe";
     dc:title "Subject headings in business and economics"@en;
     rdfs:comment "Handelshögskolans i Stockholm bibliotek"@sv .
 
-<swemesh> a skos:ConceptScheme;
+<swemesh> a skos:TopicScheme;
     skos:notation "swemesh";
     dc:title "Svensk MeSH"@sv, "Swedish MeSH"@sv;
     foaf:homepage <https://mesh.kib.ki.se/> .
-
-<kssb> a :ClassificationScheme;
-    skos:notation "kssb";
-    dc:title "SAB-klassifikation"@sv .
-    # upplagor: 2, 5, 6, 7, 8, 9
-    # variant? (folkbibliotek, musikalier, musikinspelningar)
-    #<#usedWithProperty> dc:type .
 
 
 # Aliases for external schemes
 
 #@base <https://id.kb.se/ext/term/> . # ?
 
-<agrovoc> a skos:ConceptScheme;
+<agrovoc> a skos:TopicScheme;
     dc:title "AgroVoc"@en;
     skos:notation "agrovoc" .
 
@@ -238,26 +229,26 @@
     skos:notation "fao"; #, "agrissc"; #?
     foaf:homepage <http://agris.fao.org/?InfoT=Subject&Language=EN> .
 
-<fiaf> a skos:ConceptScheme;
+<fiaf> a skos:ClassificationScheme;
     skos:notation "fiaf"; #"fiaf/2" #?
     dc:title "International Federation of Film Archives"@en .
 
-<lcsh> a skos:ConceptScheme;
+<lcsh> a skos:TopicScheme;
     skos:notation "lcsh";
     dc:alternative "LCSH";
     dc:title "Library of Congress Subject Headings"@en;
     foaf:homepage <http://id.loc.gov/authorities/subjects/> .
 
-<mipfesd> a skos:ConceptScheme;
+<mipfesd> a skos:TopicScheme;
     skos:notation "mipfesd"; #"mipfesd/5"
     dc:title "Marcrothesaurus for information processing in the field of economic and social development (OECD)"@en .
 
-<msc> a skos:ConceptScheme;
+<msc> a skos:ClassificationScheme;
     skos:notation "msc";
     dc:title "Mathematical subject classification"@en;
     rdfs:comment "Providence, RI: American Mathematical Society"@en .
 
-<mesh> a skos:ConceptScheme;
+<mesh> a skos:TopicScheme;
     skos:notation "mesh";
     dc:title "Medical Subject Headings"@en;
     dc:alternative "MeSH";
@@ -269,17 +260,17 @@
     skos:notation "nal";
     foaf:homepage <https://www.nal.usda.gov/> .
 
-<nlm> a skos:ConceptScheme;
+<nlm> a skos:ClassificationScheme;
     skos:notation "nlm";
     dc:alternative "NLM";
     dc:title "National Library of Medicine"@en .
 
-<rswk> a skos:ConceptScheme;
+<rswk> a skos:TopicScheme;
     skos:notation "rswk";
     dc:title "Regeln für den Schlagwortkatalog (Deutsches Bibliotheksinstitut)"@de;
     foaf:homepage <http://deposit.ddb.de/ep/netpub/89/96/96/967969689/_data_stat/www.dbi-berlin.de/dbi_pub/einzelpu/regelw/rswk/rswk_00.htm> .
 
-<sipri> a skos:ConceptScheme;
+<sipri> a skos:TopicScheme;
     skos:notation "sipri";
     dc:title "SIPRI Library thesaurus"@en;
     foaf:homepage <http://www.sipri.org/library/thesaurus/thesaurus.html/> .

--- a/source/schemes.ttl
+++ b/source/schemes.ttl
@@ -233,6 +233,11 @@
     skos:notation "fiaf"; #"fiaf/2" #?
     dc:title "International Federation of Film Archives"@en .
 
+<kao-eng> a :TopicScheme;
+    skos:notation "kao//eng";
+    dc:title "KVINNSAM subject headings, engelskspråkig version"@sv;
+    foaf:homepage <http://www.ub.gu.se/kvinn/kvinnsam/listor/> .
+
 <lcsh> a :TopicScheme;
     skos:notation "lcsh";
     dc:alternative "LCSH";

--- a/source/schemes.ttl
+++ b/source/schemes.ttl
@@ -43,6 +43,7 @@
 
         Underhållet av Svenska ämnesord sköts av en redaktionskommitté vid Kungl. biblioteket.
     """@sv;
+    skos:exactMatch <http://id.loc.gov/vocabulary/subjectSchemes/sao>;
     foaf:page <http://www.kb.se/katalogisering/Svenska-amnesord/om/>;
     void:inDataset </> .
 
@@ -57,6 +58,7 @@
 
         Form talar om att verket har en särskild form och/eller särskilt syfte. Eftersom det ofta är svårt att skilja form från genre är de sammanförda till samma fasett.
        """@sv;
+    skos:exactMatch <http://id.loc.gov/vocabulary/genreFormSchemes/saogf>;
     foaf:page <http://www.kb.se/katalogisering/Svenska-amnesord/om/>;
     void:inDataset </> .
 
@@ -69,6 +71,7 @@
 
         Nya ämnesord för barnlistan godkänns av Svenska barnboksinstitutets redaktion för barnämnesord och förs därefter in i databasen.
     """@sv;
+    skos:exactMatch <http://id.loc.gov/vocabulary/subjectSchemes/barn>;
     foaf:page <http://www.kb.se/katalogisering/Svenska-amnesord/om/>;
     void:inDataset </> .
 
@@ -76,6 +79,7 @@
     skos:notation "barngf";
     dc:alternative "BarnGF";
     dc:title "Barn - Genre och form"@sv;
+    skos:exactMatch <http://id.loc.gov/vocabulary/genreFormSchemes/barngf>;
     rdfs:seeAlso <barn>;
     void:inDataset </> .
 
@@ -91,6 +95,7 @@
         Underhållet av TGM sköts av en redaktionskommitté vid Kungl. biblioteket tillsammans med bildexperter på biblioteket. Det finns också en referensgrupp för TGM med representanter för bibliotek, arkiv och museer.
     """@sv;
     void:inDataset </>;
+    skos:broadMatch <http://id.loc.gov/vocabulary/genreFormSchemes/gmgpc>;
     foaf:page <http://www.kb.se/katalogisering/Svenska-amnesord/om/>;
     foaf:homepage <http://www.kb.se/katalogisering/Svenska-amnesord/genrer-form/tesaurus/> .
 
@@ -159,7 +164,8 @@
 
 <albt> a :TopicScheme;
     skos:notation "albt//swe";
-    dc:title "Arbetslivsbibliotekets tesaurus"@sv .
+    dc:title "Arbetslivsbibliotekets tesaurus"@sv;
+    skos:exactMatch <http://id.loc.gov/vocabulary/subjectSchemes/albt>.
 
 <kao> a :TopicScheme;
     skos:notation "kao";
@@ -169,10 +175,12 @@
     #    skos:notation "kao//eng";
     #    dc:language [ skos:notation "en" ];
     #];
+    skos:exactMatch <http://id.loc.gov/vocabulary/subjectSchemes/kao>;
     foaf:homepage <http://www.ub.gu.se/kvinn/kvinnsam/listor/> .
 
 <kssb> a :ClassificationScheme;
     skos:notation "kssb";
+    skos:exactMatch <http://id.loc.gov/vocabulary/classSchemes/kssb>;
     dc:title "SAB-klassifikation"@sv .
     # upplagor: 2, 5, 6, 7, 8, 9
     # variant? (folkbibliotek, musikalier, musikinspelningar)
@@ -181,35 +189,42 @@
 <prvt> a :TopicScheme;
     skos:notation "prvt";
     dc:title "Patent- och registreringsverkets tesaurus"@sv;
-    dc:alternative "PRVT" .
+    dc:alternative "PRVT";
+    skos:exactMatch <http://id.loc.gov/vocabulary/subjectSchemes/prvt>.
 
 <quiding> a :TopicScheme;
     skos:notation "quiding";
+    skos:exactMatch <http://id.loc.gov/vocabulary/subjectSchemes/quiding>;
     dc:title "Quiding, Nils Herman. Svenskt allmänt författningsregister för tiden från år 1522 till och med år 1862"@sv .
 
 <sbiao> a :TopicScheme;
     skos:notation "sbiao";
     dc:title "Svenska barnboksinstitutets ämnesordsindex för teoretisk litteratur"@sv;
+    skos:exactMatch <http://id.loc.gov/vocabulary/subjectSchemes/sbiao>;
     foaf:homepage <http://www.sbi.kb.se/sv/Biblioteket/Soka/Amnesordsindex/Teoretiska-amnesord/> .
 
 <sfit> a :TopicScheme;
     skos:notation "sfit";
     dc:title "Svenska filminstitutets tesaurus"@sv;
+    skos:exactMatch <http://id.loc.gov/vocabulary/subjectSchemes/sfit>;
     dc:alternative "SFIT" .
 
 <sgp> a :GenreFormScheme;
     skos:notation "sgp";
     dc:title "Svenska genrebeteckningar för periodika"@sv;
+    skos:exactMatch <http://id.loc.gov/vocabulary/genreFormSchemes/sgp>;
     foaf:homepage <http://www.kb.se/katalogisering/Svenska-amnesord/genrer-form/tidskrifter/> .
 
 <shbe> a :TopicScheme;
     skos:notation "shbe";
     dc:title "Subject headings in business and economics"@en;
+    skos:exactMatch <http://id.loc.gov/vocabulary/subjectSchemes/shbe>;
     rdfs:comment "Handelshögskolans i Stockholm bibliotek"@sv .
 
 <swemesh> a :TopicScheme;
     skos:notation "swemesh";
     dc:title "Svensk MeSH"@sv, "Swedish MeSH"@sv;
+    skos:exactMatch <http://id.loc.gov/vocabulary/subjectSchemes/swemesh>;
     foaf:homepage <https://mesh.kib.ki.se/> .
 
 
@@ -219,10 +234,12 @@
 
 <agrissc> a :ClassificationScheme;
     skos:notation "agrissc";
-    foaf:homepage <http://http://agris.fao.org/agris-search/index.do> .
+    skos:exactMatch <http://id.loc.gov/vocabulary/classSchemes/agrissc>;
+    foaf:homepage <http://agris.fao.org/agris-search/index.do> .
 
 <agrovoc> a :TopicScheme;
     dc:title "AgroVoc"@en;
+    skos:exactMatch <http://id.loc.gov/vocabulary/subjectSchemes/agrovoc>;
     skos:notation "agrovoc" .
 
 <bnb> a skos:ConceptScheme;
@@ -231,26 +248,31 @@
 
 <fiaf> a :ClassificationScheme;
     skos:notation "fiaf"; #"fiaf/2" #?
+    skos:exactMatch <http://id.loc.gov/vocabulary/classSchemes/fiaf>;
     dc:title "International Federation of Film Archives"@en .
 
 <kao-eng> a :TopicScheme;
     skos:notation "kao//eng";
     dc:title "KVINNSAM subject headings, engelskspråkig version"@sv;
+    skos:broadMatch <http://id.loc.gov/vocabulary/subjectSchemes/kao>;
     foaf:homepage <http://www.ub.gu.se/kvinn/kvinnsam/listor/> .
 
 <lcsh> a :TopicScheme;
     skos:notation "lcsh";
     dc:alternative "LCSH";
     dc:title "Library of Congress Subject Headings"@en;
+    skos:exactMatch <http://id.loc.gov/vocabulary/subjectSchemes/lcsh>;
     foaf:homepage <http://id.loc.gov/authorities/subjects/> .
 
 <mipfesd> a :TopicScheme;
     skos:notation "mipfesd"; #"mipfesd/5"
+    skos:exactMatch <http://id.loc.gov/vocabulary/subjectSchemes/mipfesd>;
     dc:title "Marcrothesaurus for information processing in the field of economic and social development (OECD)"@en .
 
 <msc> a :ClassificationScheme;
     skos:notation "msc";
     dc:title "Mathematical subject classification"@en;
+    skos:exactMatch <http://id.loc.gov/vocabulary/classSchemes/msc>;
     rdfs:comment "Providence, RI: American Mathematical Society"@en .
 
 <mesh> a :TopicScheme;
@@ -258,26 +280,31 @@
     dc:title "Medical Subject Headings"@en;
     dc:alternative "MeSH";
     rdfs:seeAlso <http://neurocommons.org/page/Bundles/mesh/mesh-skos>;
+    skos:exactMatch <http://id.loc.gov/vocabulary/subjectSchemes/mesh>;
     foaf:homepage <http://www.nlm.nih.gov/mesh/meshhome.html> .
 
 <nal> a :TopicScheme;
     dc:title "National Agricultural Library Subject Headings/NAL"@en;
     skos:notation "nal";
+    skos:exactMatch <http://id.loc.gov/vocabulary/subjectSchemes/nal>;
     foaf:homepage <https://www.nal.usda.gov/> .
 
 <nlm> a :ClassificationScheme;
     skos:notation "nlm";
     dc:alternative "NLM";
+    skos:exactMatch <http://id.loc.gov/vocabulary/classSchemes/nlm>;
     dc:title "National Library of Medicine"@en .
 
 <rswk> a :TopicScheme;
     skos:notation "rswk";
     dc:title "Regeln für den Schlagwortkatalog (Deutsches Bibliotheksinstitut)"@de;
+    skos:exactMatch <http://id.loc.gov/vocabulary/subjectSchemes/rswk>;
     foaf:homepage <http://deposit.ddb.de/ep/netpub/89/96/96/967969689/_data_stat/www.dbi-berlin.de/dbi_pub/einzelpu/regelw/rswk/rswk_00.htm> .
 
 <sipri> a :TopicScheme;
     skos:notation "sipri";
     dc:title "SIPRI Library thesaurus"@en;
+    skos:exactMatch <http://id.loc.gov/vocabulary/subjectSchemes/sipri>;
     foaf:homepage <http://www.sipri.org/library/thesaurus/thesaurus.html/> .
 
 # LoC

--- a/source/vocab/concepts.ttl
+++ b/source/vocab/concepts.ttl
@@ -307,6 +307,10 @@
     owl:equivalentClass madsrdf:GenreForm;
     owl:equivalentClass bf2:GenreForm . # added after merge of Class with same name from things.ttl
 
+:GenreFormScheme a owl:Class;
+    rdfs:label "Genre/Form scheme"@en, "Genre/form-system"@sv;
+    rdfs:subClassOf :ConceptScheme .
+
 :Temporal a owl:Class;
     rdfs:label "Kronologiskt ämnesord"@sv;
     owl:equivalentClass bf2:Temporal, madsrdf:Temporal;

--- a/source/vocab/concepts.ttl
+++ b/source/vocab/concepts.ttl
@@ -61,11 +61,15 @@
     owl:equivalentClass skos:Collection .
 
 :ConceptScheme a owl:Class;
-    rdfs:label "Concept scheme"@en, "Termlista"@sv;
+    rdfs:label "Concept scheme"@en, "Konceptsystem"@sv;
     #owl:equivalentClass madsrdf:MADSScheme;
     rdfs:subClassOf :Source;
     owl:equivalentClass skos:ConceptScheme .
     #owl:hasKey (:code) .
+
+:TopicScheme a owl:Class;
+    rdfs:label "Topic scheme"@en, "Ämnesordssystem"@sv;
+    rdfs:subClassOf :ConceptScheme .
 
 :altLabel a owl:DatatypeProperty;
     rdfs:label "alternativ benämning"@sv; #NOTE: alternativ term inom concept
@@ -114,12 +118,19 @@
     owl:equivalentProperty skos:historyNote .
 
 :inScheme a owl:ObjectProperty;
-    rdfs:label "termlista"@sv;
+    rdfs:label "ingår i system"@sv;
     rdfs:domain :Identity ;
     rdfs:range :ConceptScheme ;
     rdfs:subPropertyOf :source;
     owl:equivalentProperty skos:inScheme ;
     owl:equivalentProperty madsrdf:isMemberOfMADSScheme .
+# Range restrictions:
+:Classification rdfs:subClassOf [ a owl:Restriction;
+         owl:onProperty :inScheme;
+         owl:allValuesFrom :ClassificationScheme ] .
+:Subject rdfs:subClassOf [ a owl:Restriction;
+         owl:onProperty :inScheme;
+         owl:allValuesFrom :TopicScheme ] .
 
 :narrower a owl:ObjectProperty;
     rdfs:label "smalare"@sv;
@@ -245,6 +256,10 @@
             owl:onProperty :inScheme;
             owl:hasValue <http://udcdata.info/udc-schema> ] ;
     owl:equivalentClass bf2:ClassificationUdc .
+
+:ClassificationScheme a owl:Class;
+    rdfs:label "Classification scheme"@en, "Klassifikationssystem"@sv;
+    rdfs:subClassOf :ConceptScheme .
 
 :classificationPortion a owl:DatatypeProperty;
     rdfs:label "klassifikationsdel"@sv;

--- a/source/vocab/concepts.ttl
+++ b/source/vocab/concepts.ttl
@@ -127,10 +127,13 @@
 # Range restrictions:
 :Classification rdfs:subClassOf [ a owl:Restriction;
          owl:onProperty :inScheme;
-         owl:allValuesFrom :ClassificationScheme ] .
+         owl:someValuesFrom :ClassificationScheme ] .
+:GenreForm rdfs:subClassOf [ a owl:Restriction;
+         owl:onProperty :inScheme;
+         owl:someValuesFrom :GenreFormScheme ] .
 :Subject rdfs:subClassOf [ a owl:Restriction;
          owl:onProperty :inScheme;
-         owl:allValuesFrom :TopicScheme ] .
+         owl:someValuesFrom :TopicScheme ] .
 
 :narrower a owl:ObjectProperty;
     rdfs:label "smalare"@sv;

--- a/sys/context/base.jsonld
+++ b/sys/context/base.jsonld
@@ -27,6 +27,7 @@
     "ConceptCollection": "skos:Collection",
     "ConceptScheme": "skos:ConceptScheme",
     "ClassificationScheme": "https://id.kb.se/vocab/ClassificationScheme",
+    "GenreFormScheme": "https://id.kb.se/vocab/GenreFormScheme",
     "TopicScheme": "https://id.kb.se/vocab/TopicScheme",
 
     "label": "rdfs:label",

--- a/sys/context/base.jsonld
+++ b/sys/context/base.jsonld
@@ -26,8 +26,8 @@
     "Concept": "skos:Concept",
     "ConceptCollection": "skos:Collection",
     "ConceptScheme": "skos:ConceptScheme",
-    "ClassificationScheme": "skos:ClassificationScheme",
-    "TopicScheme": "skos:TopicScheme",
+    "ClassificationScheme": "https://id.kb.se/vocab/ClassificationScheme",
+    "TopicScheme": "https://id.kb.se/vocab/TopicScheme",
 
     "label": "rdfs:label",
     "labelByLang": {"@id": "rdfs:label", "@container": "@language"},

--- a/sys/context/base.jsonld
+++ b/sys/context/base.jsonld
@@ -26,6 +26,8 @@
     "Concept": "skos:Concept",
     "ConceptCollection": "skos:Collection",
     "ConceptScheme": "skos:ConceptScheme",
+    "ClassificationScheme": "skos:ClassificationScheme",
+    "TopicScheme": "skos:TopicScheme",
 
     "label": "rdfs:label",
     "labelByLang": {"@id": "rdfs:label", "@container": "@language"},


### PR DESCRIPTION
* Add ClassificationScheme, GenreFormScheme and TopicScheme as subclasses of ConceptScheme
* Add restrictions to inScheme for types Classification, GenreForm and Subject. Use someValuesFrom 
  (instead of allValuesFrom) to not exclude the possibility to add schemes of type ConceptScheme 
* Change labels of inScheme and ConceptScheme
* Update schemes to subclass where it is applicable
* Add kao//eng as TopicScheme
* Remove scheme 'fao' in favour of 'agrissc'. (NB. There is no existing bib/hold records with link to 'fao' 
   and only few, 6 records, with local entity with prefLabel='fao' and inScheme='agrovoc')

Tested locally:
* Link to to scheme with restriction
* Link to new schemes: 'agrissc' and 'kao//eng'
* Revert ("Förhandsgranska Marc")

This PR needs to be aligned with PR in lxlviewer of corresponding updates of snippets and templates.
