### PR TITLE
Add sameAs URIs for deprecated term leaf segments

### DIFF
--- a/source/schemes.ttl
+++ b/source/schemes.ttl
@@ -128,17 +128,19 @@
     void:inDataset </> .
 
 <fack> a skos:Collection;
+    owl:sameAs <Fack>;
     skos:notation "Fack";
     dc:title "Facktermer"@sv;
     void:inDataset </> .
 
 <skon> a skos:Collection;
+    owl:sameAs <Skon>;
     skos:notation "Skon";
     dc:title "Skönlitterära termer"@sv;
     void:inDataset </> .
 
 <musik> a skos:Collection;
-    owl:sameAs <musik>;
+    owl:sameAs <Musik>;
     skos:notation "Musik";
     dc:title "Musiktermer"@sv;
     void:inDataset </> .
@@ -149,6 +151,7 @@
     void:inDataset </> .
 
 <nlt> a skos:Collection;
+    owl:sameAs <NLT>;
     skos:notation "nlt";
     dc:alternative "NLT";
     dc:title "NLT (termer för Nya Lundstedt - tidskrifter)"@sv;


### PR DESCRIPTION
These URIs are constructed from local codes in the MARC records. Until
the day when we normalize those just before the link-finding step, we
re-add these as sameAs aliases to keep things working.