### PR TITLE
Add Cartographic as chips

### DIFF
--- a/source/vocab/display.jsonld
+++ b/source/vocab/display.jsonld
@@ -237,6 +237,12 @@
           "@type": "fresnel:Lens",
           "classLensDomain": "marc:EnumeratedTerm",
           "showProperties": [ "prefLabel" ]
+        },
+        "Cartographic": {
+          "@id": "Cartographic-chips",
+          "@type": "fresnel:Lens",
+          "classLensDomain": "Cartographic",
+          "showProperties": [ "prefLabel" ]
         }
       }
     },


### PR DESCRIPTION
Chips of enumerations of type marc:MapsReliefType displays inconsistently with prefLabel or as '{Namnlös}'. 
The behavior occurs because of marc:MapsRelief is subclass to both EnumeratedTerm (declared as chip) and Cartographic (not declared as chip). This fix adds Cartographic as chip.

See LXL-2584 for more info.