### PR TITLE
Feature/house keeping fixes

### DIFF
--- a/source/marc/construct-enums.rq
+++ b/source/marc/construct-enums.rq
@@ -1188,7 +1188,7 @@ construct {
         (marc:MapsReliefType	marc:BathymetrySounding	marc:MapsReliefType-e	"e"	UNDEF	UNDEF	"Djuplodning"@sv	"Bathymetry/soundings"@en)
         (marc:MapsReliefType	marc:LandForm	marc:MapsReliefType-j	"j"	UNDEF	UNDEF	"Landformationer"@sv	"Land forms"@en)
         (marc:MapsReliefType	marc:SpotHeight	marc:MapsReliefType-g	"g"	UNDEF	UNDEF	"Höjdpunkter"@sv	"Spot heights"@en)
-        (marc:MapsReliefType	marc:BathymetryIsoline	marc:MapsReliefType-k	"k"	UNDEF	UNDEF	"Konturer (djupmätning, djupkskiktsfärg)"@sv	"Bathymetry/isolines"@en)
+        (marc:MapsReliefType	marc:BathymetryIsoline	marc:MapsReliefType-k	"k"	UNDEF	UNDEF	"Konturer (djupmätning, djupskiktsfärg)"@sv	"Bathymetry/isolines"@en)
         (marc:MapsReliefType	marc:FormLine	marc:MapsReliefType-f	"f"	UNDEF	UNDEF	"Formlinjer"@sv	"Form lines"@en)
 
         (marc:AudienceType	marc:PreAdolescent	marc:AudienceType-c	"c"	UNDEF	UNDEF	"Barn (ca 10-12 år) / Läromedel"@sv	"Pre-adolescent"@en)

--- a/source/marc/terms.ttl
+++ b/source/marc/terms.ttl
@@ -730,6 +730,10 @@ marc:city a owl:DatatypeProperty ;
     rdfs:label "Stad, kommun"@sv ;
     rdfs:domain marc:AddedEntryHierarchicalPlaceName .
 
+marc:displayText a owl:DatatypeProperty;
+    rdfs:label "Relationsbeteckning"@sv .
+    
+
 # 856:
 
 marc:versionOfResource a owl:ObjectProperty ;

--- a/source/marc/unlabelled.ttl
+++ b/source/marc/unlabelled.ttl
@@ -76,6 +76,7 @@ marc:attributeAccuracyExplanation a owl:DatatypeProperty .
 marc:attributeAccuracyReport a owl:DatatypeProperty .
 marc:attributeAccuracyValue a owl:DatatypeProperty .
 marc:authorityRecordControlNumber a owl:DatatypeProperty .
+marc:availabilityDate a owl:DatatypeProperty .
 marc:beginningOfDateValid a owl:DatatypeProperty .
 marc:bib880-0 a owl:DatatypeProperty .
 marc:bib880-1 a owl:DatatypeProperty .
@@ -380,6 +381,7 @@ marc:sourceOfTaxonomicIdentification a owl:DatatypeProperty .
 marc:sourceOfTerm a owl:DatatypeProperty .
 marc:subjectLevel a owl:ObjectProperty .
 marc:sungOrSpokenText a owl:ObjectProperty .
+marc:supplyingAgency a owl:DatatypeProperty .
 marc:tableIdentificationTableNumber a owl:DatatypeProperty .
 marc:tapeConfig a owl:DatatypeProperty .
 marc:taskNumber a owl:DatatypeProperty .
@@ -404,6 +406,7 @@ marc:typeOfRecording a owl:DatatypeProperty .
 marc:typeOfReproduction a owl:DatatypeProperty .
 marc:undifferentiatedNumber a owl:DatatypeProperty .
 marc:uniformTitle a owl:DatatypeProperty .
+marc:useAndReproductionRights a owl:DatatypeProperty .
 marc:unparsedFingerprint a owl:DatatypeProperty .
 marc:version a owl:DatatypeProperty .
 marc:verticalPositionalAccuracyExplanation a owl:DatatypeProperty .

--- a/source/vocab/base.ttl
+++ b/source/vocab/base.ttl
@@ -143,7 +143,7 @@ rdf:type a owl:ObjectProperty;
 
 :comment a owl:DatatypeProperty;
     rdfs:label "comment"@en, "kommentar"@sv;
-    sdo:domainIncludes :Agent, :Title, :ToCEntry ;
+    sdo:domainIncludes :Agent, :Title, :ToCEntry, :EAN, :UPC ;
     owl:equivalentProperty rdfs:comment .
 
 :code a owl:DatatypeProperty;

--- a/source/vocab/details.ttl
+++ b/source/vocab/details.ttl
@@ -504,6 +504,7 @@
 
 :acquisitionTerms a owl:DatatypeProperty;
     owl:equivalentProperty bf2:acquisitionTerms;
+    sdo:domainIncludes :AcquisitionSource, :Identifier;
     rdfs:label "Anskaffningsvillkor"@sv .
 
 :AcquisitionSource a owl:Class;

--- a/source/vocab/details.ttl
+++ b/source/vocab/details.ttl
@@ -884,6 +884,7 @@
     owl:equivalentProperty bf2:credits .
 
 :participantNote a owl:DatatypeProperty;
+    # previously note domain, has been used in error and should probably be deprecated after analysis.
     rdfs:label "Anmärkning om medverkan"@sv .
 
 :ContentAccessibility a owl:Class;

--- a/source/vocab/details.ttl
+++ b/source/vocab/details.ttl
@@ -884,8 +884,7 @@
     owl:equivalentProperty bf2:credits .
 
 :participantNote a owl:DatatypeProperty;
-    rdfs:label "Anmärkning om medverkan"@sv;
-    rdfs:domain :Note .
+    rdfs:label "Anmärkning om medverkan"@sv .
 
 :ContentAccessibility a owl:Class;
     rdfs:label "Content accessibility information"@en, "Anmärkning om komplement för ökad tillgänglighet"@sv;


### PR DESCRIPTION
* Add domainIncludes AcquisitionSource and Identifier for acquisitionTerms.
* Add domainIncludes EAN and UPC for comment.
* Fix typo in Swedish label for MapsReliefType-k.
* Remove faulty domain from participantNote.
* Add Swedish label for marc:displayText.
* Add unlabelled marc properties.
