### PR TITLE
Use regular record structure for vocab dataset records

### DIFF
--- a/datasets.py
+++ b/datasets.py
@@ -56,6 +56,14 @@ compiler = Compiler(base_dir=SCRIPT_DIR,
                     union='definitions.jsonld.lines')
 
 
+def _insert_record(graph, created_ms):
+    entity = graph[0]
+    record = {'@type': 'Record'}
+    record[compiler.record_thing_link] = {'@id': entity['@id']}
+    graph.insert(0, record)
+    record['@id'] = compiler.generate_record_id(created_ms, entity['@id'])
+
+
 #@compiler.dataset
 #def datasets():
 #    graph = Graph().parse(compiler.path('source/index.ttl'), format='turtle')
@@ -128,29 +136,21 @@ def vocab():
     data['@graph'] = sorted(data['@graph'], key=lambda node:
             (not node.get('@id', '').startswith(vocab_base), node.get('@id')))
 
-    def add_record_system_id(record):
-        record_id = record['@id']
-        record['@id'] = compiler.generate_record_id(vocab_created_ms, record_id)
-        record.setdefault('sameAs', []).append(
-                {'@id': record_id})
-
-    vocab_record = data['@graph'][0]
     vocab_created_ms = compiler.ztime_to_millis("2014-01-01T00:00:00.000Z")
-    add_record_system_id(vocab_record)
-
+    _insert_record(data['@graph'], vocab_created_ms)
+    vocab_node = data['@graph'][1]
     version = _get_repo_version()
     if version:
-        vocab_record['version'] = version
+        vocab_node['version'] = version
 
     lib_context = make_context(graph, vocab_base, DEFAULT_NS_PREF_ORDER)
     add_overlay(lib_context, compiler.load_json('sys/context/base.jsonld'))
     add_overlay(lib_context, compiler.load_json('source/vocab-overlay.jsonld'))
-    faux_record = {'@id': BASE + 'vocab/context'}
-    add_record_system_id(faux_record)
-    lib_context['@graph'] = [faux_record]
+    lib_context['@graph'] = [{'@id': BASE + 'vocab/context'}]
+    _insert_record(lib_context['@graph'], vocab_created_ms)
 
     display = compiler.load_json('source/vocab/display.jsonld')
-    add_record_system_id(display['@graph'][0])
+    _insert_record(display['@graph'], vocab_created_ms)
 
     compiler.write(data, "vocab")
     compiler.write(lib_context, 'vocab/context')

--- a/source/vocab/display.jsonld
+++ b/source/vocab/display.jsonld
@@ -20,10 +20,6 @@
       "descriptionByLang": {"@id": "description", "@container": "@language"}
   },
   "@graph": [
-    {
-      "@id": "https://id.kb.se/vocab/display.jsonld",
-      "mainEntity": {"@id": "https://id.kb.se/vocab/display"}
-    },
     {"@id": "https://id.kb.se/vocab/display"}
   ],
   "lensGroups": {


### PR DESCRIPTION
This adjusts data shape assumptions, thus preventing an issue with
embellish which re-embeds the vocab in itself.