### PR TITLE
Update swedish label for ToCEntry

### DIFF
--- a/source/vocab/unstable.ttl
+++ b/source/vocab/unstable.ttl
@@ -35,7 +35,7 @@
     rdfs:label "Systemteknisk anmärkning"@sv .
 
 :ToCEntry a owl:Class;
-    rdfs:label "Table of Contents Entry"@en, "Utökad innehållsanmärkning"@sv .
+    rdfs:label "Table of Contents Entry"@en, "Utökad innehållsförteckning"@sv .
 
 # RECORD
 


### PR DESCRIPTION
"Utökad Innehållsanmärkning" becomes "Utökad Innehållsförteckning" to align with the terminology for basic Table of Contents.