### PR TITLE
Remove HoldingEncLevelTypes

### DIFF
--- a/source/marc/construct-enums.rq
+++ b/source/marc/construct-enums.rq
@@ -1558,7 +1558,7 @@ construct {
         # Added to marc/enums.ttl: (marc:HoldingEncLevelType	marc:HoldingsLevel4	marc:HoldingEncLevelType-4	"4"	UNDEF	UNDEF	"Nivå 4 (detaljerat bestånd i 853-855 och/eller 86X)"@sv	"Holdings level 4"@en)
         # Added to marc/enums.ttl: (marc:HoldingEncLevelType	marc:HoldingsLevel3	marc:HoldingEncLevelType-3	"3"	UNDEF	UNDEF	"Nivå 3 (summariskt bestånd i 853-855 och/eller 86X)"@sv	"Holdings level 3"@en)
         # Added to marc/enums.ttl: (marc:HoldingEncLevelType	marc:HoldingsLevel4WithPieceDesignation	marc:HoldingEncLevelType-5	"5"	UNDEF	UNDEF	"Nivå 5 (detaljerat bestånd, inkl. exemplarinformation)"@sv	"Holdings level 4 with piece designation"@en)
-        (marc:HoldingEncLevelType	marc:MixedLevels	marc:HoldingEncLevelType-m	"m"	UNDEF	UNDEF	UNDEF	"Mixed levels"@en)
+        # (marc:HoldingEncLevelType	marc:MixedLevels	marc:HoldingEncLevelType-m	"m"	UNDEF	UNDEF	UNDEF	"Mixed levels"@en)
         # Added to marc/enums.ttl: (marc:HoldingEncLevelType	marc:HoldingsLevel1	marc:HoldingEncLevelType-1	"1"	UNDEF	UNDEF	"Grundnivå (endast 852)"@sv	"Holdings level 1"@en)
         # Added to marc/enums.ttl: (marc:HoldingEncLevelType	marc:HoldingsLevel2	marc:HoldingEncLevelType-2	"2"	UNDEF	UNDEF	"Nivå 2 (används t.v. ej)"@sv	"Holdings level 2"@en)
         # Added to marc/enums.ttl: (marc:HoldingEncLevelType	marc:OtherLevel	marc:HoldingEncLevelType-z	"z"	UNDEF	UNDEF	"Annan nivå"@sv	"Other level"@en)

--- a/source/marc/enums.ttl
+++ b/source/marc/enums.ttl
@@ -886,38 +886,38 @@
 
 # CATEGORY HOLD:
 
-:HoldingsLevel1 a :HoldingEncLevelType ;
-    #owl:sameAs :HoldingEncLevelType-1 ;
-    skos:notation "1" ;
-    skos:prefLabel "Holdings level 1"@en, "Beståndsnivå 1 (grundnivå, endast 852)"@sv .
-
-:HoldingsLevel2 a :HoldingEncLevelType ;
-    #owl:sameAs :HoldingEncLevelType-2 ;
-    kbv:category kbv:pending ;
-    rdfs:comment "Används t.v. ej"@sv;
-    skos:notation "2" ;
-    skos:prefLabel "Holdings level 2"@en, "Beståndsnivå 2"@sv .
-
-:HoldingsLevel3 a :HoldingEncLevelType ;
-    #owl:sameAs :HoldingEncLevelType-3 ;
-    skos:notation "3" ;
-    skos:prefLabel "Holdings level 3"@en, "Beståndsnivå 3 (summariskt bestånd i 853-855 och/eller 86X)"@sv .
-
-:HoldingsLevel4 a :HoldingEncLevelType ;
-    #owl:sameAs :HoldingEncLevelType-4 ;
-    skos:notation "4" ;
-    skos:prefLabel "Holdings level 4"@en, "Beståndsnivå 4 (detaljerat bestånd i 853-855 och/eller 86X)"@sv .
-
-:HoldingsLevel4WithPieceDesignation a :HoldingEncLevelType ;
-    #owl:sameAs :HoldingEncLevelType-5 ;
-    skos:notation "5" ;
-    skos:prefLabel "Holdings level 4 with piece designation"@en, "Beståndsnivå 5 (detaljerat bestånd, inkl. exemplarinformation)"@sv .
-
-:OtherLevel a :HoldingEncLevelType ;
-    #owl:sameAs :HoldingEncLevelType-z ;
-    kbv:category kbv:pending ;
-    skos:notation "z" ;
-    skos:prefLabel "Other level"@en, "Beståndsnivå annan"@sv .
+# :HoldingsLevel1 a :HoldingEncLevelType ;
+#     #owl:sameAs :HoldingEncLevelType-1 ;
+#     skos:notation "1" ;
+#     skos:prefLabel "Holdings level 1"@en, "Beståndsnivå 1 (grundnivå, endast 852)"@sv .
+# 
+# :HoldingsLevel2 a :HoldingEncLevelType ;
+#     #owl:sameAs :HoldingEncLevelType-2 ;
+#     kbv:category kbv:pending ;
+#     rdfs:comment "Används t.v. ej"@sv;
+#     skos:notation "2" ;
+#     skos:prefLabel "Holdings level 2"@en, "Beståndsnivå 2"@sv .
+# 
+# :HoldingsLevel3 a :HoldingEncLevelType ;
+#     #owl:sameAs :HoldingEncLevelType-3 ;
+#     skos:notation "3" ;
+#     skos:prefLabel "Holdings level 3"@en, "Beståndsnivå 3 (summariskt bestånd i 853-855 och/eller 86X)"@sv .
+# 
+# :HoldingsLevel4 a :HoldingEncLevelType ;
+#     #owl:sameAs :HoldingEncLevelType-4 ;
+#     skos:notation "4" ;
+#     skos:prefLabel "Holdings level 4"@en, "Beståndsnivå 4 (detaljerat bestånd i 853-855 och/eller 86X)"@sv .
+# 
+# :HoldingsLevel4WithPieceDesignation a :HoldingEncLevelType ;
+#     #owl:sameAs :HoldingEncLevelType-5 ;
+#     skos:notation "5" ;
+#     skos:prefLabel "Holdings level 4 with piece designation"@en, "Beståndsnivå 5 (detaljerat bestånd, inkl. exemplarinformation)"@sv .
+# 
+# :OtherLevel a :HoldingEncLevelType ;
+#     #owl:sameAs :HoldingEncLevelType-z ;
+#     kbv:category kbv:pending ;
+#     skos:notation "z" ;
+#     skos:prefLabel "Other level"@en, "Beståndsnivå annan"@sv .
 
 :MultipartItemHolding a :HoldingType ;
     #owl:sameAs :HoldingType-v ;
@@ -974,11 +974,11 @@
     skos:notation "HoldingCharacterCodingType" ;
     skos:prefLabel "Teckenuppsättning"@sv .
 
-:HoldingEncLevelType a :CollectionClass ;
-    rdfs:comment "Enligt ISO 10324 resp. ANSI/NISO Z39.57 & Z39.81."@sv;
-    rdfs:subClassOf :EncLevelType ;
-    skos:notation "HoldingEncLevelType" ;
-    skos:prefLabel "Encoding Level"@en, "Beståndsnivå"@sv .
+# :HoldingEncLevelType a :CollectionClass ;
+#     rdfs:comment "Enligt ISO 10324 resp. ANSI/NISO Z39.57 & Z39.81."@sv;
+#     rdfs:subClassOf :EncLevelType ;
+#     skos:notation "HoldingEncLevelType" ;
+#     skos:prefLabel "Encoding Level"@en, "Beståndsnivå"@sv .
 
 :HoldingSoundKindOfMaterialType a :CollectionClass ;
     rdfs:subClassOf :EnumeratedTerm ;
@@ -1757,13 +1757,9 @@
          "Direkt referensmetod"@sv .
 
 :encLevel a owl:ObjectProperty ;
-    sdo:rangeIncludes :AuthorityEncLevelType,
-        :EncLevelType,
-        :HoldingEncLevelType ;
+    sdo:rangeIncludes :EncLevelType ;
     skos:prefLabel "Encoding Level"@en,
-        "Beståndsnivå"@sv,
-        "Fullständighetsnivå"@sv,
-        "Fullständighetsnivå för katalogiseringen"@sv .
+        "Fullständighetsnivå"@sv .
 
 :entryMap a owl:ObjectProperty ;
     sdo:rangeIncludes :EntryMapType ;


### PR DESCRIPTION
Remove enums and classes for HoldingEncLevelType since these are to be removed and use a fixed default in MarcFrame.