### PR TITLE
Remove temporary fix of subClassOf for Music and ProjectedImage

### DIFF
--- a/source/vocab/things.ttl
+++ b/source/vocab/things.ttl
@@ -298,8 +298,7 @@
 
 :Music a owl:Class;
     rdfs:label "Music"@en, "Musik"@sv;
-    # TODO: Work should not be necessary to set as subClassOf since Audio is subClass of Work. Should be removed with LXL-2735
-    rdfs:subClassOf :Audio, :Work .
+    rdfs:subClassOf :Audio .
 
 :StillImage a owl:Class;
     rdfs:label "Stillbild"@sv;
@@ -524,8 +523,7 @@
     rdfs:label "Projected Image"@en, "Projicerad bild"@sv;
     skos:exactMatch rdamedia:1005 ; # "projected" ("projected graphic", "motion picture")
     :inCollection marc:typeOfRecord;
-    # TODO: Work should not be necessary to set as subClassOf since Visual is subClass of Work. Should be removed with LXL-2735
-    rdfs:subClassOf :Visual, :Work  .
+    rdfs:subClassOf :Visual  .
 
 #:PhysicalObject a owl:Class;
 #    rdfs:label "Föremål"@sv;


### PR DESCRIPTION
Will instead be solved with https://jira.kb.se/browse/LXL-2735 and reverts the following commit https://github.com/libris/definitions/commit/78aacc5ca38f38ad90f6519fbc65ca460755400d