### PR TITLE
Feature/sub class of from bf2

### DIFF
--- a/source/vocab/details.ttl
+++ b/source/vocab/details.ttl
@@ -97,9 +97,9 @@
     rdfs:subClassOf :Title;
     rdfs:label "Title variation"@en, "Varianttitel"@sv .
 
-:AbbreviatedTitle  a owl:Class;
+:AbbreviatedTitle a owl:Class;
     owl:equivalentClass bf2:AbbreviatedTitle;
-    rdfs:subClassOf :Title;
+    rdfs:subClassOf :VariantTitle;
     rdfs:label "Abbreviated title"@en, "Förkortad titel"@sv .
 
 :abbreviatedTitle a owl:DatatypeProperty;
@@ -395,7 +395,7 @@
 
 :LcOverseasAcq a owl:Class; # rdfs:Datatype ?
     rdfs:label "LC acquisition program"@en, "LC:s förvärvsprogram"@sv;
-    rdfs:subclassOf :Identifier;
+    rdfs:subClassOf :Identifier ;
     rdfs:comment "Används normalt ej"@sv;
     owl:equivalentClass bf2:LcOverseasAcq .
 
@@ -1265,12 +1265,12 @@
 
 :AccessPolicy a owl:Class;
     rdfs:label "Access policy"@en, "Villkor för åtkomst"@sv;
-    rdfs:subbClassOf :UsageAndAccessPolicy;
+    rdfs:subClassOf :UsageAndAccessPolicy;
     owl:equivalentClass bf2:AccessPolicy .
 
 :RetentionPolicy a owl:Class;
     rdfs:label "Retention policy"@en, "Villkor för bibehållande"@sv;
-    rdfs:subbClassOf :UsageAndAccessPolicy;
+    rdfs:subClassOf :UsageAndAccessPolicy;
     owl:equivalentClass bf2:RetentionPolicy .
 
 :UsePolicy a owl:Class;

--- a/source/vocab/update.rq
+++ b/source/vocab/update.rq
@@ -14,4 +14,11 @@ delete {
     ?s ?p ?o
     filter(?o != rdfs:Resource && strstarts(str(?o), str(:)))
     filter(?p in (rdfs:subClassOf, rdfs:domain, rdfs:range))
+};
+
+# remove redundant base classes
+delete {
+    ?c rdfs:subClassOf ?a .
+} where {
+    ?c rdfs:subClassOf / rdfs:subClassOf+ ?a .
 }


### PR DESCRIPTION
Cleanups of subClassOf values:
* If a class has more than one base class declared with subClassOf; keep only the most specific base class. This has occurred when bf2:subClassOf values have been included to our vocabulary and we have a more specific base class. See examples StillImage and MovingImage.
* Some minor corrections of misspelled 'subClassOf'