### PR TITLE
Feature/admin meta data terms

### DIFF
--- a/source/marc/construct-enums.rq
+++ b/source/marc/construct-enums.rq
@@ -1591,8 +1591,8 @@ construct {
         (marc:ModifiedRecordType	marc:DashedOnInformationOmitted	marc:ModifiedRecordType-d	"d"	UNDEF	UNDEF	"Bakgrundsinformation har förbigåtts"@sv	"Dashed-on information omitted"@en)
         (marc:ModifiedRecordType	marc:CompletelyRomanizedPrintedCardsInScript	marc:ModifiedRecordType-r	"r"	UNDEF	UNDEF	"Icke-latinska tecken finns i såväl originalform som translittererad form"@sv	"Completely romanized/printed cards in script"@en)
 
-        (marc:ReferenceType	marc:TracingsAreNotNecessarilyConsistentWithTheHeading	marc:ReferenceType-b	"b"	UNDEF	UNDEF	"Överensstämmer inte nödvändigtvis med sökelementet i 1XX"@sv	"Tracings are not necessarily consistent with the heading"@en)
-        (marc:ReferenceType	marc:TracingsAreConsistentWithTheHeading	marc:ReferenceType-a	"a"	UNDEF	UNDEF	"Överensstämmer med sökelementet i 1XX"@sv	"Tracings are consistent with the heading"@en)
+        #removed (marc:ReferenceType	marc:TracingsAreNotNecessarilyConsistentWithTheHeading	marc:ReferenceType-b	"b"	UNDEF	UNDEF	"Överensstämmer inte nödvändigtvis med sökelementet i 1XX"@sv	"Tracings are not necessarily consistent with the heading"@en)
+        #removed (marc:ReferenceType	marc:TracingsAreConsistentWithTheHeading	marc:ReferenceType-a	"a"	UNDEF	UNDEF	"Överensstämmer med sökelementet i 1XX"@sv	"Tracings are consistent with the heading"@en)
 
         (marc:HoldingReproductionType	marc:HoldingReproductionType-f	UNDEF	"f"	marc:Facsimile	UNDEF	"Faksimil"@sv	"Facsimile"@en)
 
@@ -1679,10 +1679,10 @@ construct {
         (marc:CatalogingSourceType	marc:NationalBibliographicAgency	marc:CatalogingSourceType-_	"_"	UNDEF	UNDEF	"Nationalbibliografi"@sv	"National bibliographic agency"@en) # "Nationalbibliografisk verksamhet"@sv
         (marc:AuthorityCatalogingSourceType	marc:NationalBibliographicAgency	marc:AuthorityCatalogingSourceType-_)
 
-        (marc:LevelType	marc:Provisional	marc:LevelType-c	"c"	UNDEF	UNDEF	"Kontrollerad/godkänd (sökelements utformning ej helt fastställt)"@sv	"Provisional"@en)
-        (marc:LevelType	marc:FullyEstablishedHeading	marc:LevelType-a	"a"	UNDEF	UNDEF	"Kontrollerad/godkänd"@sv	"Fully established heading"@en)
-        (marc:LevelType	marc:Preliminary	marc:LevelType-d	"d"	UNDEF	UNDEF	"Preliminär (ej kontrollerad)"@sv	"Preliminary"@en)
-        (marc:LevelType	marc:Memorandum	marc:LevelType-b	"b"	UNDEF	UNDEF	"Kontrollerad/godkänd (förekommer ej i bibliografisk post)"@sv	"Memorandum"@en)
+        #removed (marc:LevelType	marc:Provisional	marc:LevelType-c	"c"	UNDEF	UNDEF	"Kontrollerad/godkänd (sökelements utformning ej helt fastställt)"@sv	"Provisional"@en)
+        #removed (marc:LevelType	marc:FullyEstablishedHeading	marc:LevelType-a	"a"	UNDEF	UNDEF	"Kontrollerad/godkänd"@sv	"Fully established heading"@en)
+        #removed (marc:LevelType	marc:Preliminary	marc:LevelType-d	"d"	UNDEF	UNDEF	"Preliminär (ej kontrollerad)"@sv	"Preliminary"@en)
+        #removed (marc:LevelType	marc:Memorandum	marc:LevelType-b	"b"	UNDEF	UNDEF	"Kontrollerad/godkänd (förekommer ej i bibliografisk post)"@sv	"Memorandum"@en)
 
         (marc:LinkedType	marc:RecordHasLinks-Obsolete	marc:LinkedType-r	"r"	UNDEF	UNDEF	"Fält 760-787 finns i posten (OBSOLET)"@sv)
 

--- a/source/marc/enums.ttl
+++ b/source/marc/enums.ttl
@@ -1301,11 +1301,11 @@
 #    skos:prefLabel "Record Update"@en,
 #        "Uppdatering av posten"@sv .
 
-:ReferenceType a :CollectionClass ;
-    rdfs:subClassOf :EnumeratedTerm ;
-    skos:notation "ReferenceType" ;
-    skos:prefLabel "Reference Evaluation"@en,
-        "Formatering av icke auktoriserade sökelement"@sv .
+# :ReferenceType a :CollectionClass ;
+#     rdfs:subClassOf :EnumeratedTerm ;
+#     skos:notation "ReferenceType" ;
+#     skos:prefLabel "Reference Evaluation"@en,
+#         "Formatering av icke auktoriserade sökelement"@sv .
 
 :RemoteSensImageDataType a :CollectionClass ;
     rdfs:subClassOf :EnumeratedTerm ;

--- a/source/marc/enums.ttl
+++ b/source/marc/enums.ttl
@@ -1794,7 +1794,7 @@
     sdo:rangeIncludes :Boolean,
         :HeadingType ;
     skos:prefLabel "Heading Use - Series Added Entry"@en,
-        "Användningsområdeseriesökelement"@sv .
+        "Användningsområde - Seriesökelement"@sv .
 
 # :headingSubject a owl:ObjectProperty ;
 #     sdo:rangeIncludes :Boolean,

--- a/source/marc/enums.ttl
+++ b/source/marc/enums.ttl
@@ -1467,62 +1467,52 @@
 
 # STATUSTYPES FOR RECORD
 
-:CorrectedOrRevised a :AuthorityStatusType,
-        :HoldingStatusType,
-        :StatusType ;
+:CorrectedOrRevised a :AuthorityStatusType, :HoldingStatusType, :StatusType ;
     #owl:sameAs :AuthorityStatusType-c, :HoldingStatusType-c, :StatusType-c ;
     skos:notation "c" ;
-    skos:prefLabel "Corrected or revised"@en,
-        "Rättad eller reviderad post (sätts maskinellt)"@sv .
+    skos:prefLabel "Corrected or revised"@en, "Rättad eller reviderad"@sv .
 
-:Deleted a :AuthorityStatusType,
-        :HoldingStatusType,
-        :StatusType ;
+:Deleted a :AuthorityStatusType, :HoldingStatusType, :StatusType ;
     #owl:sameAs :AuthorityStatusType-d, :HoldingStatusType-d, :StatusType-d ;
     skos:notation "d" ;
-    skos:prefLabel "Deleted"@en,
-        "Borttagen post (används ej)"@sv .
+    rdfs:comment "Används ej"@sv;
+    skos:prefLabel "Deleted"@en, "Borttagen"@sv .
 
-:IncreaseInEncodingLevel a :AuthorityStatusType,
-        :StatusType ;
+:IncreaseInEncodingLevel a :StatusType ;
     #owl:sameAs :AuthorityStatusType-a, :StatusType-a ; skos:notation "a" ;
-    skos:prefLabel "Increase in encoding level"@en,
-        "Uppgraderad eller kompletterad post (jfr Fullständighetsnivå)"@sv .
+    skos:notation "a" ;
+    skos:prefLabel "Increase in encoding level"@en, "Uppgraderad eller kompletterad"@sv .
 
 :IncreaseInEncodingLevelFromPrepublication a :StatusType ;
     #owl:sameAs :StatusType-p ;
     skos:notation "p" ;
-    skos:prefLabel "Increase in encoding level from prepublication"@en,
-        "Uppgraderad CIP-post (jfr Fullständighetsnivå)"@sv .
+    skos:prefLabel "Increase in encoding level from prepublication"@en, "Uppgraderad från förhandsinformation"@sv .
 
-:New a :AuthorityStatusType,
-        :HoldingStatusType,
-        :StatusType ;
+:New a :AuthorityStatusType, :HoldingStatusType, :StatusType ;
     #owl:sameAs :AuthorityStatusType-n, :HoldingStatusType-n, :StatusType-n ;
     skos:notation "n" ;
-    skos:prefLabel "New"@en,
-        "Ny post"@sv .
+    skos:prefLabel "New"@en, "Ny post"@sv .
 
-:Obsolete a :AuthorityStatusType,
-    :StatusType ;
-    #owl:sameAs :AuthorityStatusType-o ;
-    skos:notation "o" ;
-    skos:prefLabel "Obsolete"@en,
-        "Obsolet"@sv .
+# :Obsolete a :AuthorityStatusType,
+#     :StatusType ;
+#     #owl:sameAs :AuthorityStatusType-o ;
+#     skos:notation "o" ;
+#     skos:prefLabel "Obsolete"@en,
+#         "Obsolet"@sv .
 
-:DeletedHeadingReplacedByAnotherHeading a :AuthorityStatusType,
-    :StatusType ;
-    #owl:sameAs :AuthorityStatusType-x ;
-    skos:notation "x" ;
-    skos:prefLabel "Deleted, heading replaced by another heading"@en,
-        "Makulerad: ersatt av en annat sökelement"@sv .
-
-:DeletedHeadingSplitIntoTwoOrMoreHeading a :AuthorityStatusType,
-    :StatusType ;
-    #owl:sameAs :AuthorityStatusType-s ;
-    skos:notation "s" ;
-    skos:prefLabel "Deleted, heading split into two or more headings"@en,
-        "Makulerad: uppdelat på två/flera andra sökelement"@sv .
+# :DeletedHeadingReplacedByAnotherHeading a :AuthorityStatusType,
+#     :StatusType ;
+#     #owl:sameAs :AuthorityStatusType-x ;
+#     skos:notation "x" ;
+#     skos:prefLabel "Deleted, heading replaced by another heading"@en,
+#         "Makulerad: ersatt av en annat sökelement"@sv .
+# 
+# :DeletedHeadingSplitIntoTwoOrMoreHeading a :AuthorityStatusType,
+#     :StatusType ;
+#     #owl:sameAs :AuthorityStatusType-s ;
+#     skos:notation "s" ;
+#     skos:prefLabel "Deleted, heading split into two or more headings"@en,
+#         "Makulerad: uppdelat på två/flera andra sökelement"@sv .
 
 ##
 

--- a/source/vocab/agents.ttl
+++ b/source/vocab/agents.ttl
@@ -293,6 +293,7 @@
     owl:equivalentClass sdo:Library .
 
 :bibliography a owl:ObjectProperty ;
+    rdfs:comment "Bibliografi som resursen ingår i."@sv ;
     rdfs:domain :Record ;
     rdfs:range :Library ;
     rdfs:label "bibliografi"@sv .

--- a/source/vocab/platform.ttl
+++ b/source/vocab/platform.ttl
@@ -67,7 +67,8 @@
 
 :recordStatus a owl:ObjectProperty;
     rdfs:subPropertyOf :status;
-    rdfs:label "Poststatus"@sv;
+    rdfs:label "Record status"@en, "Poststatus"@sv;
+    rdfs:comment "Postens status, sätts automatiskt."@sv;
     rdfs:domain :Record;
     sdo:rangeIncludes marc:StatusType .
 

--- a/source/vocab/platform.ttl
+++ b/source/vocab/platform.ttl
@@ -99,6 +99,7 @@
 
 :descriptionCreator a owl:ObjectProperty;
     rdfs:label "Description creator"@en, "Skapad av"@sv ;
+    rdfs:comment "Entitet som upprättat beskrivningen."@sv ;
     rdfs:domain :Record;
     rdfs:subPropertyOf :descriptionModifier ;
     rdfs:range :Agent .


### PR DESCRIPTION
Some adminMetaData cleanups in vocab:

* Remove LevelType and ReferenceType which should not be in data after recent auth cleanings.
* Fix SeriesHeading label (So it looks nice until we delete it ;).
* Update StatusTypes (including removing unused ones in auth).
* Add missing Swedish comments to recordStatus, bibliography and descriptionCreator.
