### PR TITLE
Add class former title

### DIFF
--- a/source/vocab/details.ttl
+++ b/source/vocab/details.ttl
@@ -145,6 +145,10 @@
     rdfs:subClassOf :VariantTitle;
     rdfs:label "Distinctive title"@en, "Titelvariant"@sv .
 
+:FormerTitle a owl:Class;
+    rdfs:subClassOf :VariantTitle;
+    rdfs:label "Former title"@en, "Tidigare titel"@sv .
+
 :RunningTitle a owl:Class;
     rdfs:subClassOf :VariantTitle;
     rdfs:label "Running title"@en, "Kolumntitel"@sv .


### PR DESCRIPTION
Add "Former Title" class for integrating resources who do not use previous/succeeded relations. (NOTE: this should later replace the current bib 247 mapping so this is just for creating correct data, not getting it in MARC as of yet, issue for that exist and I will update it accordingly.)