### PR TITLE
Comment out marc:personalName and related in vocab

### DIFF
--- a/source/marc/construct-enums.rq
+++ b/source/marc/construct-enums.rq
@@ -1697,8 +1697,8 @@ construct {
         (marc:SerialsTypeOfEntryType	marc:SuccessiveEntry	marc:SerialsTypeOfEntryType-0	"0"	UNDEF	UNDEF	"Titeländring ger upphov till ny post"@sv	"Successive entry"@en)
         (marc:SerialsTypeOfEntryType	marc:IntegratingEntry	marc:SerialsTypeOfEntryType-2	"2"	UNDEF	UNDEF	"Katalogposten avser integrerande resurs"@sv	"Integrating entry"@en)
 
-        (marc:PersonalNameType	marc:DifferentiatedPersonalName	marc:PersonalNameType-a	"a"	UNDEF	UNDEF	"Namn avser en enda person"@sv	"Differentiated personal name"@en)
-        (marc:PersonalNameType	marc:UndifferentiatedPersonalName	marc:PersonalNameType-b	"b"	UNDEF	UNDEF	"Namn avser fler än en person"@sv	"Undifferentiated personal name"@en)
+        # removed (marc:PersonalNameType	marc:DifferentiatedPersonalName	marc:PersonalNameType-a	"a"	UNDEF	UNDEF	"Namn avser en enda person"@sv	"Differentiated personal name"@en)
+        # removed (marc:PersonalNameType	marc:UndifferentiatedPersonalName	marc:PersonalNameType-b	"b"	UNDEF	UNDEF	"Namn avser fler än en person"@sv	"Undifferentiated personal name"@en)
 
         # removed (marc:SubjectSubdivisionType	marc:Language	marc:SubjectSubdivisionType-e	"e"	UNDEF	UNDEF	"Språkrelaterad"@sv	"Language"@en)
         # removed (marc:SubjectSubdivisionType	marc:Geographic	marc:SubjectSubdivisionType-d	"d"	UNDEF	UNDEF	"Geografisk"@sv	"Geographic"@en)

--- a/source/marc/enums.ttl
+++ b/source/marc/enums.ttl
@@ -1190,11 +1190,11 @@
     skos:prefLabel "Numbered or Unnumbered Series"@en,
         "Numrering i serie"@sv .
 
-:PersonalNameType a :CollectionClass ;
-    rdfs:subClassOf :EnumeratedTerm ;
-    skos:notation "PersonalNameType" ;
-    skos:prefLabel "Undifferentiated Personal Name"@en,
-        "Differentiering av person"@sv .
+# :PersonalNameType a :CollectionClass ;
+#     rdfs:subClassOf :EnumeratedTerm ;
+#     skos:notation "PersonalNameType" ;
+#     skos:prefLabel "Undifferentiated Personal Name"@en,
+#         "Differentiering av person"@sv .
 
 
 :PublicationStatusType a :CollectionClass ;
@@ -1915,10 +1915,10 @@
     skos:prefLabel "Other physical details"@en,
         "Övriga fysiska detaljer"@sv .
 
-:personalName a owl:ObjectProperty ;
-    sdo:rangeIncludes :PersonalNameType ;
-    skos:prefLabel "Undifferentiated Personal Name"@en,
-        "Differentiering av person"@sv .
+# :personalName a owl:ObjectProperty ;
+#     sdo:rangeIncludes :PersonalNameType ;
+#     skos:prefLabel "Undifferentiated Personal Name"@en,
+#         "Differentiering av person"@sv .
 
 :projection a owl:ObjectProperty ;
     sdo:domainIncludes kbv:Cartography ;


### PR DESCRIPTION
- [x] Built datasets.py

Comment out marc:personalName and related vocab thingies since it is handled in conversion as per https://github.com/libris/librisxl/pull/536