### PR TITLE
Fix tabs and label in oth and 9pu

### DIFF
--- a/source/funktionskoder.tsv
+++ b/source/funktionskoder.tsv
@@ -169,7 +169,7 @@ opn	Opponent	Person som opponerar vid akademisk disputation	Opponent
 org	Ursprunglig upphovsman	Persone etc. associerad med verkets intellektuella innehåll	Originator					
 orm	Mötesarrangör		Organizer of meetin					
 osp	Introduktör/presentatör av faktafilm		Onscreen presenter		on-screen presenter			
-oth	Medarbetare	Ospecificerad	Other	unspecifiedContributor				Endeavour
+oth	Medarbetare (Ospecificerad)	Other	Unspecified contributor				Endeavour
 own	Ägare		Owner		owner			Embodiment
 pan	Deltagare i paneldiskussion		Panelist		panelist			
 pat	Mecenat		Patron					
@@ -263,4 +263,4 @@ wat	Kompletterande text	Icke-språkliga resurser	Writer of added text		writer of
 wdc	Träsnidare	Träsnitt = grafisk högtrycksmetod där de upphöjda partierna på den plana delen av stocken bär själva bildytan	Woodcutter					
 wde	Xylograf	Xylografi/trägravyr = grafisk reproduktionsmetod med utskurna träplattor som tryckform	Wood-engraver					
 wit	Vittne		Witness					
-9pu	Primärt upphovsansvarig	LIBRIS-definierad kod		primaryRightsHolder				
+9pu	Primärt upphovsansvarig	LIBRIS-definierad kod	Primary Rights Holder					


### PR DESCRIPTION
Fix relator codes 9ph och oth from producing extra label by correct tabbing.