### PR TITLE
Add termComponentList to Concept-card

### DIFF
--- a/source/vocab/display.jsonld
+++ b/source/vocab/display.jsonld
@@ -590,7 +590,7 @@
           "@type": "fresnel:Lens",
           "@id": "Concept-cards",
           "classLensDomain": "Concept",
-          "showProperties": [ "prefLabel", "inScheme", "inCollection", "altLabel", "broader", "exactMatch", "closeMatch", "broadMatch",  {"inverseOf": "broader"}, "hasVariant", "related", "scopeNote", "label", "code", "keyword" ]
+          "showProperties": [ "prefLabel", "inScheme", "inCollection", "altLabel", "broader", "exactMatch", "closeMatch", "broadMatch",  {"inverseOf": "broader"}, "hasVariant", "related", "scopeNote", "label", "code", "keyword", "termComponentList" ]
         },
         "Contribution": {
           "@id": "Contribution-cards",


### PR DESCRIPTION
## Checklist:
- [x] I have built datasets. `python3 datasets.py -l`

### Tickets involved
https://jira.kb.se/browse/LXL-3088

### Solves
To enable termComponentList to be embellished for ComplexSubjects. This fix will affect the presentation of ComplexSubjects and we need to follow up on what consequences it may result in.

