### PR TITLE
Add additionalName and marc:subordinateUnit as subProperties to name

### DIFF
--- a/source/marc/terms.ttl
+++ b/source/marc/terms.ttl
@@ -149,6 +149,7 @@ marc:affiliation a owl:DatatypeProperty;
 
 marc:subordinateUnit a owl:DatatypeProperty;
     rdfs:label "Namn på underordnad enhet"@sv;
+    rdfs:subPropertyOf kbv:name;
     rdfs:comment "OBS! 'Namn på underordnad enhet' används endast tillsammans med egenskapen 'Är del av' för att skapa Organisationer i flera led. Egenskapen 'Namn' raderas om 'Är del av' och 'Namn på underordnad enhet' används."@sv;
     sdo:domainIncludes kbv:Jurisdiction, kbv:Organization, kbv:Meeting .
 

--- a/source/vocab/agents.ttl
+++ b/source/vocab/agents.ttl
@@ -32,6 +32,7 @@
 :additionalName a owl:DatatypeProperty ;
     owl:equivalentProperty sdo:additionalName;
     rdfs:domain :Meeting;
+    rdfs:subPropertyOf :name;
     rdfs:label "additional name"@en, "tilläggsnamn"@sv .
 
 :fullerFormOfName a owl:DatatypeProperty; 


### PR DESCRIPTION
## Checklist:

1. [x] I have built datasets. `python3 datasets.py`
2. [x] I have run integTest. `gradlew integTest` (with changes made in https://github.com/libris/librisxl/pull/602)

## Description
By making them subProperties of name we enables them to be exported as name in linkfields

### Tickets involved
[LXL-3063](https://jira.kb.se/browse/LXL-3063)

### Related PR
https://github.com/libris/librisxl/pull/602
