### PR TITLE
Add range to a bunch of non-bf2 properties

### DIFF
--- a/source/vocab/agents.ttl
+++ b/source/vocab/agents.ttl
@@ -26,18 +26,21 @@
     rdfs:comment "Namn i rak följd och fraser som ej lämpar sig att invertera (Kan ej kombineras med egenskaperna förnamn och efternamn.)"@sv;
     # hur tala om: Del av föredraget namn som är det namn eller den namnform som väljs som grund för den auktoriserade sökingångar. 
     rdfs:domain :Agent;
+    rdfs:range rdfs:Literal ;
     rdfs:subPropertyOf :label;
     owl:equivalentProperty foaf:name .
 
 :additionalName a owl:DatatypeProperty ;
     owl:equivalentProperty sdo:additionalName;
     rdfs:domain :Meeting;
+    rdfs:range rdfs:Literal ;
     rdfs:subPropertyOf :name;
     rdfs:label "additional name"@en, "tilläggsnamn"@sv .
 
 :fullerFormOfName a owl:DatatypeProperty; 
     rdfs:label "has fuller form of name"@en, "fullständigare namnform"@sv; 
-    rdfs:domain :Person; 
+    rdfs:domain :Person;
+    rdfs:range rdfs:Literal ;
     owl:equivalentProperty rdau:P60530, rdau:fullerFormOfName.en . 
 
 :Agent a owl:Class;
@@ -89,6 +92,7 @@
     rdfs:label "family name"@en, "efternamn"@sv;
     skos:altLabel "familjenamn"@sv;
     rdfs:domain :Person;
+    rdfs:range rdfs:Literal ;
     rdfs:comment "Enkelt eller sammansatt släktnamn. Kan ej kombineras med egenskapen 'namn' som har rak ordföljd"@sv;
     # hur tala om: (Del av föredraget namn som är det namn eller den namnform som väljs som grund för den auktoriserade sökingången.)
     owl:equivalentProperty sdo:familyName, foaf:familyName, rdaa:P50291, rdaa:surname.en .
@@ -96,6 +100,7 @@
 :givenName a owl:DatatypeProperty;
     rdfs:label "given name"@en, "förnamn"@sv;
     rdfs:domain :Person;
+    rdfs:range rdfs:Literal ;
     rdfs:comment "Förnamn, kan ej kombineras med egenskapen 'namn' som har rak ordföljd."@sv;
     # hur tala om: (Del av föredraget namn som är det namn eller den namnform som väljs som grund för den auktoriserade sökingången.)
     owl:equivalentProperty sdo:givenName, foaf:givenName, rdaa:P50292, rdaa:givenName.en .
@@ -140,6 +145,7 @@
 :birthDate a owl:DatatypeProperty;
     rdfs:label "födelsedatum"@sv;
     rdfs:domain :Person;
+    rdfs:range :Date ;
     owl:equivalentProperty sdo:birthDate, madsrdf:birthDate  .
 
 # in favor of lifeSpan.
@@ -152,6 +158,7 @@
 :deathDate a owl:DatatypeProperty;
     rdfs:label "dödsdatum"@sv;
     rdfs:domain :Person;
+    rdfs:range :Date ;
     owl:equivalentProperty sdo:deathDate, madsrdf:deathDate .
 
 # in favor of lifeSpan.
@@ -174,7 +181,8 @@
 :address a owl:DatatypeProperty;
     :category :pending ;
     rdfs:label "Address"@en, "Adress"@sv;
-    sdo:domainIncludes :Person, :Organization;
+    rdfs:range rdfs:Literal ;
+    sdo:domainIncludes :Organization;
     owl:equivalentProperty sdo:address .
 
 :birthPlace a owl:ObjectProperty;
@@ -194,21 +202,25 @@
 :activityStartDate a owl:DatatypeProperty;
     rdfs:label "Start date"@en, "Verksamhetens starttid"@sv;
     rdfs:domain :Agent;
+    rdfs:range :Date ;
     owl:equivalentProperty madsrdf:activityStartDate .
 
 :activityEndDate a owl:DatatypeProperty;
     rdfs:label "End date"@en, "Verksamhetens sluttid"@sv;
     rdfs:domain :Agent;
+    rdfs:range :Date ;
     owl:equivalentProperty madsrdf:activityEndDate .
 
 :establishDate a owl:DatatypeProperty;
     rdfs:label "Established"@en, "Tid för grundande"@sv;
     sdo:domainIncludes :Organization, :Jurisdiction;
+    rdfs:range :Date ;
     owl:equivalentProperty madsrdf:establishDate .
 
 :terminateDate a owl:DatatypeProperty;
     rdfs:label "Terminated"@en, "Tid för upphörande"@sv;
     sdo:domainIncludes :Organization, :Jurisdiction;
+    rdfs:range :Date ;
     owl:equivalentProperty madsrdf:terminateDate .
 
 :hasAffiliation a owl:ObjectProperty;
@@ -265,7 +277,8 @@
 :lifeSpan a owl:DatatypeProperty;
     rdfs:label "Date Associated"@en, "Födelsetid och/eller dödstid"@sv;
     rdfs:comment "Associerade datum som kan agera särskiljande för namn på agent. Exempel: '1854-1932' eller '1963-'."@sv;
-    rdfs:domain :Agent.
+    rdfs:domain :Agent;
+    rdfs:range rdfs:Literal .
 
 :Occupation a owl:Class;
     rdfs:label "Occupation"@en, "Yrke eller sysselsättning"@sv;
@@ -308,4 +321,5 @@
 :sigel a owl:DatatypeProperty;
     rdfs:label "Sigel"@sv ;
     rdfs:subPropertyOf :code;
-    rdfs:domain :Library .
+    rdfs:domain :Library ;
+    rdfs:range rdfs:Literal .

--- a/source/vocab/base.ttl
+++ b/source/vocab/base.ttl
@@ -137,11 +137,13 @@ rdf:type a owl:ObjectProperty;
 :label a owl:DatatypeProperty;
     rdfs:label "label"@en, "benämning"@sv;
     rdfs:domain :Resource ;
+    rdfs:range rdfs:Literal ;
     owl:equivalentProperty rdfs:label, sdo:name .
 
 :comment a owl:DatatypeProperty;
     rdfs:label "comment"@en, "kommentar"@sv;
     sdo:domainIncludes :Agent, :Title, :ToCEntry, :EAN, :UPC ;
+    rdfs:range rdfs:Literal ;
     owl:equivalentProperty rdfs:comment .
 
 :code a owl:DatatypeProperty;
@@ -154,7 +156,6 @@ rdf:type a owl:ObjectProperty;
 
 :count a owl:DatatypeProperty;
     rdfs:label "Number of units"@en, "Antal enheter"@sv;
-    rdfs:range rdfs:Literal;
     owl:equivalentProperty bf2:count .
 
 :Unit a owl:Class;
@@ -169,6 +170,7 @@ rdf:type a owl:ObjectProperty;
 :value a owl:DatatypeProperty;
     rdfs:label "value"@en, "värde"@sv;
     rdfs:domain :Resource;
+    rdfs:range rdfs:Literal ;
     owl:equivalentProperty rdf:value .
 
 :seeAlso a owl:ObjectProperty;

--- a/source/vocab/concepts.ttl
+++ b/source/vocab/concepts.ttl
@@ -77,6 +77,7 @@
     skos:definition "En alternativ lexikal benämning för en resurs."@sv;
     skos:scopeNote "Används vanligen som se-hänvisning";
     sdo:domainIncludes :Concept ;
+    rdfs:range rdfs:Literal ;
     owl:equivalentProperty skos:altLabel .
 
 :broader a owl:ObjectProperty;
@@ -104,6 +105,7 @@
 :definition a owl:DatatypeProperty;
     rdfs:label "definition"@en, "definition"@sv ;
     sdo:domainIncludes :Concept ;
+    rdfs:range rdfs:Literal ;
     owl:equivalentProperty skos:definition ;
     owl:equivalentProperty madsrdf:definitionNote .
 
@@ -117,6 +119,7 @@
 :example a owl:DatatypeProperty;
     rdfs:label "example"@en, "exempel"@sv ;
     sdo:domainIncludes :Concept ;
+    rdfs:range rdfs:Literal ;
     owl:equivalentProperty skos:example ;
     owl:equivalentProperty madsrdf:exampleNote .
 
@@ -124,12 +127,14 @@
     rdfs:label "hidden label"@en, "dold benämning"@sv; #NOTE: dold term inom concept
     rdfs:comment "En benämning för en resurs som bör döljas när man skapar visuella visningar av resursen, men som fortfarande ska vara tillgänglig för fri textsökning."@sv;
     sdo:domainIncludes :Concept ;
+    rdfs:range rdfs:Literal ;
     owl:equivalentProperty skos:hiddenLabel ;
     owl:equivalentProperty madsrdf:deprecatedLabel .
 
 :historyNote a owl:DatatypeProperty;
     rdfs:label "history note"@en, "anmärkning om tillämpningshistorik"@sv;
     sdo:domainIncludes :Concept ;
+    rdfs:range rdfs:Literal ;
     skos:definition "Information om tidigare status/användning/innebörd av ett begrepp."@sv;
     owl:equivalentProperty skos:historyNote .
 
@@ -169,6 +174,7 @@
     rdfs:label "preferred label"@en, "föredragen benämning"@sv; #NOTE: föredragen term inom concept
     rdfs:subPropertyOf :label;
     sdo:domainIncludes :Concept ;
+    rdfs:range rdfs:Literal ;
     owl:equivalentProperty skos:prefLabel ;
     owl:equivalentProperty madsrdf:authoritativeLabel .
 
@@ -207,12 +213,14 @@
 :scopeNote a owl:DatatypeProperty;
     rdfs:label "scope note"@en, "anmärkning om användning"@sv;
     sdo:domainIncludes :Concept ;
+    rdfs:range rdfs:Literal ;
     skos:definition "Information som förtydligar betydelsen av och/eller användningen av ett begrepp."@sv;
     owl:equivalentProperty skos:scopeNote .
 
 :editorialNote a owl:DatatypeProperty;
     rdfs:label "editorial note"@en, "redaktionell anmärkning"@sv;
     rdfs:domain :Concept;
+    rdfs:range rdfs:Literal ;
     skos:definition "Information avsedd för redaktör, översättare elleter förvaltare av begreppsmodellen."@sv;
     owl:equivalentProperty skos:editorialNote .
 
@@ -291,6 +299,7 @@
 :classificationPortion a owl:DatatypeProperty;
     rdfs:label "klassifikationsdel"@sv;
     rdfs:domain :Classification ;
+    rdfs:range rdfs:Literal ;
     owl:equivalentProperty bf2:classificationPortion .
 
 :edition a owl:DatatypeProperty;
@@ -299,10 +308,12 @@
     owl:equivalentProperty bf2:edition .
 
 :itemPortion a owl:DatatypeProperty;
+    # TODO: swedish label
     rdfs:domain :Classification ;
     owl:equivalentProperty bf2:itemPortion .
 
 :schedulePart a owl:DatatypeProperty;
+    # TODO: swedish label
     rdfs:domain :Classification ;
     owl:equivalentProperty bf2:schedulePart .
 

--- a/source/vocab/details.ttl
+++ b/source/vocab/details.ttl
@@ -58,13 +58,14 @@
     rdfs:label "huvudtitel"@sv;
     rdfs:comment "Huvudsaklig titelkomponent"@sv;
     rdfs:subPropertyOf :value;
-    owl:equivalentProperty bf2:mainTitle;
-    rdfs:domain :Title .
+    rdfs:domain :Title ;
+    owl:equivalentProperty bf2:mainTitle .
 
 :titleRemainder a owl:DatatypeProperty ;
     :category :pending ;
     rdfs:comment "Catch for unmatched 245$b properties at conversion from MARC21. Use ':subtitle' as preferred property."@en, "Egenskap som fångar upp omatchade 245$b vid konvertering från MARC21. Använd ':subtitle' som föredragen egenskap."@sv;
     rdfs:domain :Title ;
+    rdfs:range :Literal ;
     rdfs:label "Övrig titelinformation"@sv .
 
 :subtitle a owl:DatatypeProperty;
@@ -185,7 +186,6 @@
     :category :shorthand;
     rdfs:label "identifier"@en, "identifikator"@sv;
     rdfs:subPropertyOf :label;
-    rdfs:range :Identifier;
     owl:equivalentProperty dc:identifier, bibo:identifier;
     owl:propertyChainAxiom ( :identifiedBy :value ) .
 
@@ -537,7 +537,7 @@
 
 :status a owl:ObjectProperty;
     rdfs:label "status"@sv;
-    rdfs:range bf2:Status;
+    rdfs:range :Status;
     owl:equivalentProperty bf2:status .
 
 :acquisitionTerms a owl:DatatypeProperty;
@@ -600,6 +600,7 @@
     rdfs:label "has numbering of serials"@en, "har numrering av seriell resurs"@sv;
     rdfs:comment "Alfanumeriska och/eller kronologiska volymbeteckningar"@sv;
     rdfs:domain :Instance;
+    rdfs:range :Literal;
     rdfs:range :NumberingOfSerials;
     owl:equivalentProperty rdau:P60533, rdau:numberingOfSerials.en .
 
@@ -634,6 +635,7 @@
 :citationNote a owl:DatatypeProperty;
     rdfs:label "Citation Note"@en, "Uppgift från källa"@sv;
     rdfs:domain :SourceData;
+    rdfs:range :Literal;
     owl:equivalentProperty madsrdf:citationNote .
 
 # Provision Activity
@@ -784,16 +786,19 @@
 :otherYear a owl:DatatypeProperty;
     sdo:domainIncludes :PrimaryProvisionActivity ;
     rdfs:label "kompletterande datum"@sv;
+    rdfs:range :AnyDateTime ;
     rdfs:subPropertyOf :date .
 
 :startYear a owl:DatatypeProperty;
     sdo:domainIncludes :PrimaryProvisionActivity ;
     rdfs:label "startår"@sv;
+    rdfs:range :Year ;
     rdfs:subPropertyOf :year, :startDate .
 
 :endYear a owl:DatatypeProperty;
     sdo:domainIncludes :PrimaryProvisionActivity ;
     rdfs:label "slutår"@sv;
+    rdfs:range :Year ;
     rdfs:subPropertyOf :year, :endDate .
 
 :country a owl:ObjectProperty;

--- a/source/vocab/platform.ttl
+++ b/source/vocab/platform.ttl
@@ -176,7 +176,6 @@
     rdfs:label "Date generated"@en, "Konverteringsdatum"@sv;
     rdfs:comment "Datum för konvertering"@sv;
     rdfs:domain :AdminMetadata;
-    rdfs:range rdfs:Literal;
     rdfs:subPropertyOf :date;
     owl:equivalentProperty bf2:generationDate .
 
@@ -217,6 +216,7 @@
 
 :controlNumber a owl:DatatypeProperty;
     rdfs:domain :Record;
+    rdfs:range rdfs:Literal;
     rdfs:label "kontrollnummer"@sv;
     owl:equivalentProperty :identifier .
 

--- a/source/vocab/relations.ttl
+++ b/source/vocab/relations.ttl
@@ -439,6 +439,7 @@
     owl:equivalentProperty dc:source, bf2:source .
 
 :sourceNote a owl:DatatypeProperty;
+    rdfs:range rdfs:Literal ;
     rdfs:label "källinformation"@sv;
     owl:propertyChainAxiom (:source :note) .
 

--- a/source/vocab/things.ttl
+++ b/source/vocab/things.ttl
@@ -141,6 +141,7 @@
 :IssuanceType owl:equivalentClass bf2:Issuance .
 
 :termGroup a owl:DatatypeProperty;
+    rdfs:range rdfs:Literal ;
     sdo:domainIncludes :ContentType, :MediaType, :CarrierType ;
     rdfs:label "Termgroup"@en, "Termgrupp"@sv .
 


### PR DESCRIPTION
- [x] I have built vocab with datasets.py

A bunch of non BF2-datatypeproperties equipped with rdfs:range.

Issue: [LXL-196](https://jira.kb.se/browse/LXL-196)

