### PR TITLE
Change domain of geographicCoverage to also include Instance

### DIFF
--- a/source/vocab/details.ttl
+++ b/source/vocab/details.ttl
@@ -1210,7 +1210,7 @@
 
 :geographicCoverage a owl:ObjectProperty;
     rdfs:label "Geographic coverage"@en, "Geografisk täckning"@sv;
-    rdfs:domain :Work;
+    rdfs:domain :Creation;
     rdfs:range :GeographicCoverage;
     owl:equivalentProperty bf2:geographicCoverage .
 


### PR DESCRIPTION
## Checklist:
- [x] I have built datasets

## Description
We will start mapping bib 052 to geographicCoverage (aligned with bf2) but also move it to instance (see https://jira.kb.se/browse/LXL-3293 for more info). This means that we need to change the domain for geographicCoverage to also include instance.

### Tickets involved
https://jira.kb.se/browse/LXL-3293

### PR involved
Changes of mapping and global changes of existing data: https://github.com/libris/librisxl/pull/694/files
