### PR TITLE
Remove obsolete issn marc properties

### DIFF
--- a/source/marc/construct-enums.rq
+++ b/source/marc/construct-enums.rq
@@ -1108,11 +1108,11 @@ construct {
         (marc:VideoDimensionsType	marc:VideoDimensionsType-o	UNDEF	"o"	marc:12In	UNDEF	"1/2 tum"@sv	"1/2 in."@en)
         (marc:VideoDimensionsType	marc:34In	marc:VideoDimensionsType-r	"r"	UNDEF	UNDEF	"3/4 tum"@sv	"3/4 in."@en)
 
-        (marc:SerialsISSNType	marc:UnitedStates	marc:SerialsISSNType-1	"1"	UNDEF	UNDEF	"USA (obsolet)"@sv	"United States"@en)
-        (marc:SerialsISSNType	marc:InternationalCenter	marc:SerialsISSNType-0	"0"	UNDEF	UNDEF	"Internationella ISSN-centralen, Paris (obsolet)"@sv	"International Center"@en)
-        (marc:SerialsISSNType	marc:Canada	marc:SerialsISSNType-4	"4"	UNDEF	UNDEF	"Kanada (obsolet)"@sv	"Canada"@en)
-        (marc:SerialsISSNType	marc:Sweden-Obsolete	marc:SerialsISSNType-f	"f"	UNDEF	UNDEF	"Sverige (obsolet)"@sv)
-        (marc:SerialsISSNType	marc:UnitedKingdom	marc:SerialsISSNType-2	"2"	UNDEF	UNDEF	"Storbritannien (obsolet)"@sv	"United Kingdom"@en)
+        # (marc:SerialsISSNType	marc:UnitedStates	marc:SerialsISSNType-1	"1"	UNDEF	UNDEF	"USA (obsolet)"@sv	"United States"@en)
+        # (marc:SerialsISSNType	marc:InternationalCenter	marc:SerialsISSNType-0	"0"	UNDEF	UNDEF	"Internationella ISSN-centralen, Paris (obsolet)"@sv	"International Center"@en)
+        # (marc:SerialsISSNType	marc:Canada	marc:SerialsISSNType-4	"4"	UNDEF	UNDEF	"Kanada (obsolet)"@sv	"Canada"@en)
+        # (marc:SerialsISSNType	marc:Sweden-Obsolete	marc:SerialsISSNType-f	"f"	UNDEF	UNDEF	"Sverige (obsolet)"@sv)
+        # (marc:SerialsISSNType	marc:UnitedKingdom	marc:SerialsISSNType-2	"2"	UNDEF	UNDEF	"Storbritannien (obsolet)"@sv	"United Kingdom"@en)
 
         #(marc:MotionPicColorStockType	marc:ThreeLayerStockLowFade	marc:MotionPicColorStockType-c	"c"	UNDEF	UNDEF	"Förfinad trelagersteknik (ca 1983-)"@sv	"Three layer stock, low fade"@en)
         #(marc:MotionPicColorStockType	marc:ThreeLayerStock	marc:MotionPicColorStockType-b	"b"	UNDEF	UNDEF	"Integrerad trelagersteknik (ca 1950-)"@sv	"Three layer stock"@en)

--- a/source/marc/enums.ttl
+++ b/source/marc/enums.ttl
@@ -1368,12 +1368,12 @@
     skos:prefLabel "Frequency"@en,
         "Frekvens"@sv .
 
-:SerialsISSNType a :CollectionClass ;
-    rdfs:subClassOf :EnumeratedTerm ;
-    skos:broadMatch kbv:Serial ;
-    skos:notation "SerialsISSNType" ;
-    skos:prefLabel "ISSN Center (OBSOLETE)"@en,
-        "Odefinierad (tidigare ISSN-central se 022 $2)"@sv .
+# :SerialsISSNType a :CollectionClass ;
+#     rdfs:subClassOf :EnumeratedTerm ;
+#     skos:broadMatch kbv:Serial ;
+#     skos:notation "SerialsISSNType" ;
+#     skos:prefLabel "ISSN Center (OBSOLETE)"@en,
+#         "Odefinierad (tidigare ISSN-central se 022 $2)"@sv .
 
 :SerialsNatureType a :CollectionClass ;
     rdfs:subClassOf :EnumeratedTerm ;


### PR DESCRIPTION
## Checklist:

- [x] I have run datasets.py

## Description:

Removes obsolete ISSN properties from definitions related to cleanup https://github.com/libris/librisxl/pull/540
