### PR TITLE
Add Class and category pending to swepub identifiers

### DIFF
--- a/source/vocab/details.ttl
+++ b/source/vocab/details.ttl
@@ -519,20 +519,48 @@
     owl:equivalentClass bf2:VideoRecordingNumber .
 
 ## Used by SwePub {{{
-:CORDIS rdfs:subClassOf :Identifier .
-:FundRef rdfs:subClassOf :Identifier .
-:GRID rdfs:subClassOf :Identifier .
-:ISI rdfs:subClassOf :Identifier .
-:IssueNumber rdfs:subClassOf :Identifier .
-:LibrisNumber rdfs:subClassOf :Identifier .
-:ORCID rdfs:subClassOf :Identifier .
-:PatentNumber rdfs:subClassOf :Identifier .
-:PMID rdfs:subClassOf :Identifier .
-:Ringgold rdfs:subClassOf :Identifier .
-:ScopusID rdfs:subClassOf :Identifier.
-:SweCRIS rdfs:subClassOf :Identifier.
-:URI rdfs:subClassOf :Identifier .
-:WorldCatNumber rdfs:subClassOf :Identifier .
+:CORDIS a owl:Class;
+    :category :pending ;
+    rdfs:subClassOf :Identifier .
+:FundRef a owl:Class;
+    :category :pending ;
+    rdfs:subClassOf :Identifier .
+:GRID a owl:Class;
+    :category :pending ;
+    rdfs:subClassOf :Identifier .
+:ISI a owl:Class;
+    :category :pending ;
+    rdfs:subClassOf :Identifier .
+:IssueNumber a owl:Class;
+    :category :pending ;
+    rdfs:subClassOf :Identifier .
+:LibrisNumber a owl:Class;
+    :category :pending ;
+    rdfs:subClassOf :Identifier .
+:ORCID a owl:Class;
+    :category :pending ;
+    rdfs:subClassOf :Identifier .
+:PatentNumber a owl:Class;
+    :category :pending ;
+    rdfs:subClassOf :Identifier .
+:PMID a owl:Class;
+    :category :pending ;
+    rdfs:subClassOf :Identifier .
+:Ringgold a owl:Class;
+    :category :pending ;
+    rdfs:subClassOf :Identifier .
+:ScopusID a owl:Class;
+    :category :pending ;
+    rdfs:subClassOf :Identifier.
+:SweCRIS a owl:Class;
+    :category :pending ;
+    rdfs:subClassOf :Identifier.
+:URI a owl:Class;
+    :category :pending ;
+    rdfs:subClassOf :Identifier .
+:WorldCatNumber a owl:Class;
+    :category :pending ;
+    rdfs:subClassOf :Identifier .
 ## }}}
 
 ##

--- a/source/vocab/details.ttl
+++ b/source/vocab/details.ttl
@@ -427,7 +427,7 @@
     rdfs:comment "Används normalt ej"@sv;
     owl:equivalentClass bf2:LcOverseasAcq .
 
-:LibrisIIINumber a owl:Class; # rdfs:Datatype ?
+:LibrisIIINumber a owl:Class; # rdfs:Datatype ? - Disjoint with or subClassOf LibrisNumber?
     rdfs:comment "[FÅR EJ MAKULERAS] Åtta- eller tioställigt identifikationsnummer på LIBRIS-poster som konverterats från ett ursprungligt LIBRISIII-format (ISBN, ISSN eller ett tioställigt nummer som inleds med siffrorna '99'). Avser postens unika identitet i det gamla LIBRIS-systemet."@sv;
     rdfs:domain :Record;
     rdfs:subClassOf :SystemNumber;


### PR DESCRIPTION
## Checklist:
- [x] I have run datasets.py

## Description:
Not sure why we left these identifiers "hanging"? I guess if we want them to be properly usable on id.kb.se the owl:Class is needed (now they act quite broken). I added category:pending as advice to their status.

## Issues:
[LXL-3021](https://jira.kb.se/browse/LXL-3021)