### PR TITLE
Update markdown dependency from 2.6.5. to 3.1.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ wheel
 rdflib==4.2.2
 rdflib-jsonld==0.3
 pathlib2==2.1.0
-Markdown==2.6.5
+Markdown==3.1.1


### PR DESCRIPTION
Bump markdown from 2.6.5 to 3.1.1

Last version to support Python 2.7 (also supports 3.5-3.7)

Mostly bugfixes: https://python-markdown.github.io/change_log/