### PR TITLE
Add specific ImageBitDepth chip because of value property

### DIFF
--- a/source/vocab/display.jsonld
+++ b/source/vocab/display.jsonld
@@ -146,6 +146,12 @@
           "classLensDomain": "Identifier",
           "showProperties": [ "value", "typeNote", "marc:hiddenValue" ]
         },
+        "ImageBitDepth": {
+          "@id": "ImageBitDepth-chips",
+          "@type": "fresnel:Lens",
+          "classLensDomain": "ImageBitDepth",
+          "showProperties": [ "value" ]
+        },
         "ISBN": {
           "@id": "ISBN-chips",
           "@type": "fresnel:Lens",


### PR DESCRIPTION
- [x] built vocab datasets.py

Add ImageBithDepth chip to display (usually DigitalCharecteristic things have labels, this one has value)