### PR TITLE
Add lcschac scheme

### DIFF
--- a/source/schemes.ttl
+++ b/source/schemes.ttl
@@ -500,6 +500,15 @@
                     <https://www.wikidata.org/entity/Q1823134>;
     foaf:homepage <http://id.loc.gov/authorities/subjects/> .
 
+<lcshac> a :TopicScheme;
+    skos:notation "lcshac";
+    dc:alternative "LCSHAC";
+    dc:title "Library of Congress Children's Subject Headings"@en;
+    dc:title "Library of Congress Children's Subject Headings";
+    skos:exactMatch <https://id.loc.gov/vocabulary/subjectSchemes/lcshac>,
+                    <http://www.wikidata.org/entity/Q98713532>;
+    foaf:homepage <https://id.loc.gov/authorities/childrensSubjects> .
+
 <local> a skos:ConceptScheme;
     skos:notation "local";
     dc:title "Locally assigned term"@en, "Lokalt tilldelad term"@sv;
@@ -822,7 +831,6 @@
 
 # LoC
 
-<http://id.loc.gov/authorities/childrensSubjects> a skos:ConceptScheme .
 <http://id.loc.gov/authorities/genreForms> a skos:ConceptScheme .
 <http://id.loc.gov/vocabulary/graphicMaterials> a skos:ConceptScheme .
 


### PR DESCRIPTION
- [x] I built definitions with datasets.py

Add lcschac scheme (Children's subject heading). Also needed for indicator 2 = 1 in JSONLD>MARC conversion.