### PR TITLE
Bump lxltools dependency to 0.9.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 wheel
--e git+https://github.com/libris/lxltools.git@0.8.2#egg=lxltools
+-e git+https://github.com/libris/lxltools.git@0.9.0#egg=lxltools
 rdflib==4.2.2
 rdflib-jsonld==0.3
 pathlib2==2.1.0


### PR DESCRIPTION
Removes generation of broken (cyclic) reverse definitions (fixed in
https://github.com/libris/lxltools/commit/3ddf8fba44c776058887c9d88133d667641a8f11).