### PR TITLE
Add ISO639 datatypes and use in languages dataset

### DIFF
--- a/source/construct-languages.rq
+++ b/source/construct-languages.rq
@@ -11,15 +11,12 @@ construct {
         skos:prefLabel ?prefLabel ;
         skos:altLabel ?altLabel ;
         rdfs:comment ?comment ;
-        skos:notation ?not;
-        skos:notation ?langCode;
-        kbv:ISO639-2-B ?bibliographicLangCode;
-        kbv:ISO639-2-T ?termLangCode;
-        kbv:ISO639-3 ?iso_639_3;
+        skos:notation ?code;
+        skos:notation ?langTag ;
+        skos:notation ?langCode ;
         dc:isReplacedBy ?replacement;
         skos:exactMatch ?locLang ;
-        skos:closeMatch ?locVariant ;
-        skos:notation ?langTag .
+        skos:closeMatch ?locVariant .
 
 } where {
     graph <https://id.kb.se/dataset/languages> {
@@ -37,17 +34,22 @@ construct {
                 bind(replace(replace(?altLabels, ?skipN, ""), " *\\|.*$", "") as ?altLabel)
             }
             optional { ?s rdfs:comment ?comment }
-            optional { ?s kbv:ISO639-2-T ?termLangCode . }
-            optional { ?s kbv:ISO639-3 ?iso_639_3 . }
         } union {
-            {?s skos:notation ?locCode .} union {?s kbv:ISO639-2-T ?locCode .}  
-            bind(iri(concat('http://id.loc.gov/vocabulary/iso639-2/', ?locCode)) as ?locLang)
+            ?s skos:notation ?code .
+            filter(datatype(?code) = xsd:string)
+            bind(strdt(?code, kbv:ISO639-2) as ?langCode)
+        } union {
+            ?s skos:notation ?locCode .
+            filter(
+                datatype(?locCode) = kbv:ISO639-2-T ||
+                datatype(?locCode) = xsd:string
+            )
+            bind(iri(concat('http://id.loc.gov/vocabulary/iso639-2/', str(?locCode))) as ?locLang)
             graph <http://id.loc.gov/vocabulary/languages> {
-                optional {
+                {
                     filter(!contains(?prefLabel, "|"))
                     ?locLang skos:prefLabel ?prefLabel
-                }
-                optional {
+                } union {
                     filter(contains(?prefLabels, "|"))
                     ?locLang skos:prefLabel ?prefLabels
                     bind(replace(?prefLabels, " *\\|.*$", "") as ?prefLabel)
@@ -62,20 +64,19 @@ construct {
                     bind('http://id.loc.gov/vocabulary/iso639-1/' as ?iso639_1_base)
                     filter(strstarts(str(?locVariant), ?iso639_1_base))
                     bind(substr(str(?locVariant), strlen(?iso639_1_base) + 1) as ?shortcode)
-                    bind(strdt(?shortcode, dc:ISO639-1) as ?langTag)
+                    bind(strdt(?shortcode, kbv:ISO639-1) as ?langTag)
                 }
             }
         } union {
-            optional { 
+            ?s skos:notation ?code .
+        } union {
+            optional {
                 ?s dc:isReplacedBy ?map_to_codes .
                 values ?n { 0 1 2 3 }
                 bind(concat("^([^|]+\\|){", str(?n) ,"} *") as ?skipN)
                 bind(replace(replace(?map_to_codes, ?skipN, ""), " *\\|.*$", "") as ?map_to_code)
                 ?replacement skos:notation ?map_to_code .
             }
-        } union {
-            ?s skos:notation ?not .
-            bind(strdt(?not, dc:ISO639-2) as ?langCode)
         }
     }
 }

--- a/source/spraakkoder.tsv
+++ b/source/spraakkoder.tsv
@@ -1,5 +1,5 @@
-code	label_sv	altLabel_sv	comment_sv	bibliographicLangCode	termLangCode	iso_639_3	map_to_code
-9fd	Forndanska		-1500 (Librisdefinierad kod)				
+code	label_sv	altLabel_sv	comment_sv	iso_639_2_b	iso_639_2_t	iso_639_3	map_to_code
+fd	Forndanska		-1500 (Librisdefinierad kod)				
 9fs	Fornsvenska		-1500 (Librisdefinierad kod)				
 9ft	Fornlågtyska		"Obsolet Librisdefinierad kod: använd ""osx"""				osx
 9mk	Meänkieli		"Obsolet Librisdefinierad kod: använd ""fit"""				fit

--- a/source/spraakkoder.tsv
+++ b/source/spraakkoder.tsv
@@ -1,5 +1,5 @@
 code	label_sv	altLabel_sv	comment_sv	iso_639_2_b	iso_639_2_t	iso_639_3	map_to_code
-fd	Forndanska		-1500 (Librisdefinierad kod)				
+9fd	Forndanska		-1500 (Librisdefinierad kod)				
 9fs	Fornsvenska		-1500 (Librisdefinierad kod)				
 9ft	Fornlågtyska		"Obsolet Librisdefinierad kod: använd ""osx"""				osx
 9mk	Meänkieli		"Obsolet Librisdefinierad kod: använd ""fit"""				fit

--- a/source/table-context.jsonld
+++ b/source/table-context.jsonld
@@ -1,12 +1,12 @@
 {
   "@context": ["sys/context/ns.jsonld", {
     "code": "skos:notation",
+    "iso_639_2_b": {"@id": "code", "@type": "kbv:ISO639-2-B"},
+    "iso_639_2_t": {"@id": "code", "@type": "kbv:ISO639-2-T"},
+    "iso_639_3": {"@id": "code", "@type": "kbv:ISO639-3"},
     "label_sv": {"@id": "skos:prefLabel", "@language": "sv"},
-    "altLabel_sv": {"@id": "skos:altLabel", "@language": "sv"},
     "comment_sv": {"@id": "rdfs:comment", "@language": "sv"},
-    "map_to_code": "dc:isReplacedBy",
-    "termLangCode": "kbv:ISO639-2-T",
-    "bibliographicLangCode": "kbv:ISO639-2-B",
-    "iso_639_3": "kbv:ISO639-3"
+    "altLabel_sv": {"@id": "skos:altLabel", "@language": "sv"},
+    "map_to_code": "dc:isReplacedBy"
   }]
 }

--- a/source/vocab/details.ttl
+++ b/source/vocab/details.ttl
@@ -534,6 +534,30 @@
     rdfs:subClassOf :Identifier;
     rdfs:comment "Wikidata item." .
 
+:ISO639-1 a rdfs:Datatype ;
+    rdfs:label "ISO 639-1" ;
+    owl:equivalentClass dc:ISO639-1 .
+
+:ISO639-2 a rdfs:Datatype ;
+    rdfs:label "ISO 639-2" ;
+    owl:equivalentClass dc:ISO639-2 .
+
+:ISO639-2-B a rdfs:Datatype ;
+    rdfs:label "ISO 639-2/B" ;
+    rdfs:comment "Bibliografisk språkkod"@sv ;
+    rdfs:subClassOf :ISO639-2 .
+
+:ISO639-2-T a rdfs:Datatype ;
+    rdfs:label "ISO 639-2/T" ;
+    rdfs:comment "Terminologisk språkkod"@sv ;
+    rdfs:subClassOf :ISO639-2 .
+
+:ISO639-3 a rdfs:Datatype ;
+    rdfs:label "ISO 639-3" ;
+    rdfs:comment "Ur komplett, omfattande språkkodslista."@sv ;
+    rdfs:seeAlso <https://iso639-3.sil.org/about/relationships>;
+    owl:equivalentClass dc:ISO639-3 .
+
 ## Used by SwePub {{{
 
 :CORDIS a owl:Class;

--- a/sys/context/base.jsonld
+++ b/sys/context/base.jsonld
@@ -107,9 +107,11 @@
     "CarrierType": "http://id.loc.gov/ontologies/bibframe/Carrier",
     "IssuanceType": "http://id.loc.gov/ontologies/bibframe/Issuance",
 
-    "langCode": {"@id": "code", "@type": "dc:ISO639-2"},
-    "termLangCode": {"@id": "@vocab:ISO639-2-T"},
-    "langTag": {"@id": "code", "@type": "dc:ISO639-1"},
+    "langTag": {"@id": "code", "@type": "ISO639-1"},
+    "langCode": {"@id": "code", "@type": "ISO639-2"},
+    "langCodeBib": {"@id": "code", "@type": "ISO639-2-B"},
+    "langCodeTerm": {"@id": "code", "@type": "ISO639-2-T"},
+    "langCodeFull": {"@id": "code", "@type": "ISO639-3"},
 
     "isMemberOfRelation": {"@type": "@vocab"},
     "memberClass": {"@type": "@vocab", "@container": "@set"},


### PR DESCRIPTION
Fixes use of the datatypes as properties, and uses datatyped literals consequently in the table mapping and construct query.

Note that this changes the public language data a bit by renaming the specific properties involved in the fix.

Also note that the datatypes are consequently in the KBV namespace. This is mostly since two sub-datatypes of dc:ISO639-2 (for B and T) are not defined in DC Terms. (We may finally replace the mix of namespaces within the unified KBV namespace here, but that is a larger change.)
