### PR TITLE
Fix broken links to loc for countries and relators

### DIFF
--- a/source/construct-countries.rq
+++ b/source/construct-countries.rq
@@ -10,18 +10,18 @@ construct {
         dc:isReplacedBy ?replacement;
         skos:notation ?notation;
         rdfs:comment ?comment;
-        skos:prefLabel ?label ;
+        skos:prefLabel ?label;
         skos:prefLabel ?prefLabel .
+
 } where {
     graph <https://id.kb.se/dataset/countries> {
         {
             ?s skos:notation ?notation ; skos:prefLabel ?label .
-                optional { ?s rdfs:comment ?comment }
-            bind(strdt(?notation, xsd:string) as ?strnot)
+            optional { ?s rdfs:comment ?comment }
             optional {
                 graph <http://id.loc.gov/vocabulary/countries> {
-                    ?loc skos:notation ?strnot
-                    optional { ?loc skos:prefLabel ?prefLabel }
+                    ?loc skos:prefLabel ?prefLabel .
+                    filter strends(str(?loc), concat('/', ?notation))
                 }
             }
         } union {

--- a/source/construct-relators.rq
+++ b/source/construct-relators.rq
@@ -1,16 +1,16 @@
 prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-prefix owl: <http://www.w3.org/2002/07/owl#>
 prefix skos: <http://www.w3.org/2004/02/skos/core#>
 prefix bf2: <http://id.loc.gov/ontologies/bibframe/>
+prefix madsrdf: <http://www.loc.gov/mads/rdf/v1#>
 prefix : <https://id.kb.se/vocab/>
 
 construct {
     ?idrel a bf2:Role;
         skos:notation ?notation;
         ?p ?o;
-        owl:equivalentProperty ?locrel;
+        skos:exactMatch ?locrel;
         rdfs:domain ?domain;
-        rdfs:subPropertyOf ?superrel .
+
 } where {
     graph <https://id.kb.se/dataset/relators> {
         {
@@ -22,17 +22,8 @@ construct {
         } union {
             ?idrel skos:notation ?notation .
             graph <http://id.loc.gov/vocabulary/relators> {
-                ?locrel skos:notation ?notation .
-                optional {
-                    ?locrel rdfs:subPropertyOf ?locsuperrel .
-                    optional {
-                        ?locsuperrel skos:notation ?supernot .
-                        graph <https://id.kb.se/dataset/relators> {
-                            ?idsuperrel skos:notation ?supernot .
-                        }
-                    }
-                    bind(coalesce(?idsuperrel, ?locsuperrel) as ?superrel)
-                }
+                ?locrel madsrdf:authoritativeLabel ?authLabel .
+                filter strends(str(?locrel), concat('/', ?notation))
             }
         } optional { ?idrel rdfs:domain ?domain . }
           bind (if(bound(?domain), ?domain, :Work) as ?domain)


### PR DESCRIPTION
Adds exactMatch with LOC links to country and relator definitions. For example Färöarna (https://libris.kb.se/katalogisering/0bvcdfl3251bd8st) gets
```
"exactMatch": [
   {
       "@id": "http://id.loc.gov/vocabulary/countries/fa"
   }
]
```
Also add english prefLabelByLang:
```
"prefLabelByLang": {
   "en": "Faroe Islands",
   "sv": "Färöarna"
}
```