### PR TITLE
Update requirements rdflib-jsonld to 0.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 rdflib==4.2.2
-rdflib-jsonld==0.3
+rdflib-jsonld==0.5
 pathlib2==2.1.0
 Markdown==3.1.1


### PR DESCRIPTION
## Checklist:

- [x] I have run datasets.py

## Description:

Bump RDFLibJson-LD from 0.3 to 0.5.
datasets.py builds without problem. Tested a diff between definitions/build dir between 0.3 and 0.5 from what I can see only slight changes of order in certain lists like rangeIncludes and domainIncludes but I guess that is something that is not predictable in the build process... would be great if someone else also could give it a testrun locally before merging.
