### PR TITLE
Add modified timestamp to datasets

### DIFF
--- a/datasets.py
+++ b/datasets.py
@@ -130,7 +130,9 @@ def vocab():
     vocab_created_ms = w3c_dtz_to_ms("2014-01-01T00:00:00.000Z")
 
     vocab_ds_url = urljoin(compiler.dataset_id, 'vocab')
-    compiler._create_dataset_description(vocab_ds_url, vocab_created_ms)
+    vocab_func = compiler.datasets['vocab'][0]
+    vocab_modified_ms = compiler.last_modified_ms(vocab_func)
+    compiler._create_dataset_description(vocab_ds_url, vocab_created_ms, vocab_modified_ms)
 
     _insert_record(data['@graph'], vocab_created_ms, vocab_ds_url)
     vocab_node = data['@graph'][1]


### PR DESCRIPTION
This adds a modified timestamp to each record representing a generated dataset. The timestamp corresponds to the modification time of the most recently updated file used in the generation of the dataset.

I'm not sure if the solution is sustainable. I wanted to avoid hard coding (which could be an option) the names of all the resources that a "dataset function" uses. Instead we look for file/directory name strings stated as constants in the functions. This works for now but we make assumptions that might not hold if/when those functions changes.

Also, the definitions dataset itself does not get a timestamp (should it?). This can of course be implemented, but would probably require a bit more shuffling in the code. Chose to skip it for now anyway. 

 