### PR TITLE
Feature/lxl 3442 add modified timestamp for datasets 2

### DIFF
--- a/datasets.py
+++ b/datasets.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals, print_function
 import os
 import re
 from rdflib import Graph, ConjunctiveGraph, RDF, Namespace
-from lxltools.datacompiler import Compiler, w3c_dtz_to_ms
+from lxltools.datacompiler import Compiler, w3c_dtz_to_ms, last_modified_ms
 from lxltools.contextmaker import DEFAULT_NS_PREF_ORDER, make_context, add_overlay
 try:
     from urllib.parse import urljoin
@@ -130,8 +130,7 @@ def vocab():
     vocab_created_ms = w3c_dtz_to_ms("2014-01-01T00:00:00.000Z")
 
     vocab_ds_url = urljoin(compiler.dataset_id, 'vocab')
-    vocab_func = compiler.datasets['vocab'][0]
-    vocab_modified_ms = compiler.last_modified_ms(vocab_func)
+    vocab_modified_ms = last_modified_ms(compiler.current_ds_resources)
     compiler._create_dataset_description(vocab_ds_url, vocab_created_ms, vocab_modified_ms)
 
     _insert_record(data['@graph'], vocab_created_ms, vocab_ds_url)

--- a/datasets.py
+++ b/datasets.py
@@ -130,7 +130,9 @@ def vocab():
     vocab_created_ms = w3c_dtz_to_ms("2014-01-01T00:00:00.000Z")
 
     vocab_ds_url = urljoin(compiler.dataset_id, 'vocab')
-    compiler._create_dataset_description(vocab_ds_url, vocab_created_ms)
+    vocab_func = compiler.datasets['vocab'][0]
+    vocab_modified_ms = compiler.last_modified_ms(vocab_func)
+    compiler._create_dataset_description(vocab_ds_url, vocab_created_ms, vocab_modified_ms)
 
     _insert_record(data['@graph'], vocab_created_ms, vocab_ds_url)
     vocab_node = data['@graph'][1]


### PR DESCRIPTION
This is an alternative to https://github.com/libris/definitions/pull/257 based on what @niklasl suggested in https://github.com/libris/definitions/pull/257#issuecomment-777064674.

I'm not sure if it's much more intuitive. Unfortunately attributes of Path are read-only so monkey-patching the glob method had to be done on the class instead of the instances, adding a bit of hassle.

This version takes also the cached documents from external sources into consideration when deciding modified time, whereas definitions.jsonld still doesn't get a modified timestamp.