### PR TITLE
Add inverseOf reproduction/supplementTo to Instance card

### DIFF
--- a/source/vocab/display.jsonld
+++ b/source/vocab/display.jsonld
@@ -393,7 +393,9 @@
             "intendedAudience",
             "associatedMedia",
             "usageAndAccessPolicy",
-            {"inverseOf": "itemOf"}
+            {"inverseOf": "itemOf"},
+            {"inverseOf": "reproductionOf"},
+            {"inverseOf": "supplementTo"}
           ]
         },
         "Work": {


### PR DESCRIPTION
Display reproductions and supplements without requiring two-way links.