### PR TITLE
Remove obsolete marc types for auth008 series

### DIFF
--- a/source/marc/construct-enums.rq
+++ b/source/marc/construct-enums.rq
@@ -609,9 +609,9 @@ construct {
         (marc:ReproductionPolicyType	marc:WillReproduce	marc:ReproductionPolicyType-a	"a"	UNDEF	UNDEF	"Får reproduceras"@sv	"Will reproduce"@en)
         (marc:ReproductionPolicyType	marc:WillNotReproduce	marc:ReproductionPolicyType-b	"b"	UNDEF	UNDEF	"Får ej reproduceras"@sv	"Will not reproduce"@en)
 
-        (marc:NumberedSeriesType	marc:UnnumberedSeries	marc:NumberedSeriesType-b	"b"	UNDEF	UNDEF	"Onumrerad"@sv	"Unnumbered series"@en)
-        (marc:NumberedSeriesType	marc:SeriesNumberingVary	marc:NumberedSeriesType-c	"c"	UNDEF	UNDEF	"Varierad numrering"@sv	"Series numbering varies"@en)
-        (marc:NumberedSeriesType	marc:NumberedSeries	marc:NumberedSeriesType-a	"a"	UNDEF	UNDEF	"Numrerad"@sv	"Numbered series"@en)
+        # (marc:NumberedSeriesType	marc:UnnumberedSeries	marc:NumberedSeriesType-b	"b"	UNDEF	UNDEF	"Onumrerad"@sv	"Unnumbered series"@en)
+        # (marc:NumberedSeriesType	marc:SeriesNumberingVary	marc:NumberedSeriesType-c	"c"	UNDEF	UNDEF	"Varierad numrering"@sv	"Series numbering varies"@en)
+        # (marc:NumberedSeriesType	marc:NumberedSeries	marc:NumberedSeriesType-a	"a"	UNDEF	UNDEF	"Numrerad"@sv	"Numbered series"@en)
 
         (marc:IndexType	marc:IndexPresent	marc:IndexType-1	"1"	UNDEF	UNDEF	"Index finns"@sv	"Index present"@en)
         (marc:IndexType	marc:NoIndex	marc:IndexType-0	"0"	UNDEF	UNDEF	"Index saknas"@sv	"No index"@en)
@@ -925,9 +925,9 @@ construct {
         (marc:GlobeMediumType	marc:Leather	marc:GlobeMediumType-v)
         (marc:NonProjectedType	marc:Leather	marc:NonProjectedType-v)
 
-        (marc:TypeOfSeriesType	marc:TypeOfSeriesType-a	UNDEF	"a"	marc:MonographicSeries	UNDEF	"Monografiserie"@sv	"Monographic series"@en)
-        (marc:TypeOfSeriesType	marc:SeriesLikePhrase	marc:TypeOfSeriesType-c	"c"	UNDEF	UNDEF	"Serieliknande fras"@sv	"Series-like phrase"@en)
-        (marc:TypeOfSeriesType	marc:MultipartItem	marc:TypeOfSeriesType-b	"b"	UNDEF	UNDEF	"Monografi i flera delar"@sv	"Multipart item"@en)
+        # (marc:TypeOfSeriesType	marc:TypeOfSeriesType-a	UNDEF	"a"	marc:MonographicSeries	UNDEF	"Monografiserie"@sv	"Monographic series"@en)
+        # (marc:TypeOfSeriesType	marc:SeriesLikePhrase	marc:TypeOfSeriesType-c	"c"	UNDEF	UNDEF	"Serieliknande fras"@sv	"Series-like phrase"@en)
+        # (marc:TypeOfSeriesType	marc:MultipartItem	marc:TypeOfSeriesType-b	"b"	UNDEF	UNDEF	"Monografi i flera delar"@sv	"Multipart item"@en)
 
         # (marc:ComputerFrequencyType	marc:Daily-Obsolete	marc:ComputerFrequencyType-d	"d"	UNDEF	true	UNDEF	"Daily (OBSOLETE)"@en)
         # (marc:ComputerFrequencyType	marc:Triennial-Obsolete	marc:ComputerFrequencyType-h	"h"	UNDEF	true	UNDEF	"Triennial (OBSOLETE)"@en)
@@ -1363,7 +1363,7 @@ construct {
         (marc:SoundCaptureType	marc:Other	marc:SoundCaptureType-z)
         (marc:NonProjectedType	marc:Other	marc:NonProjectedType-z)
         (marc:MapsMaterialType	marc:Other	marc:MapsMaterialType-z)
-        (marc:TypeOfSeriesType	marc:Other	marc:TypeOfSeriesType-z)
+        # (marc:TypeOfSeriesType	marc:Other	marc:TypeOfSeriesType-z)
         (marc:ReproductionType	marc:Other	marc:ReproductionType-z)
         (marc:TextMaterialType	marc:Other	marc:TextMaterialType-z)
         (marc:ComputerColorType	marc:Other	marc:ComputerColorType-z)

--- a/source/marc/enums.ttl
+++ b/source/marc/enums.ttl
@@ -1192,11 +1192,11 @@
     skos:notation "NumberUnitsType" ;
     skos:prefLabel "Specific Retention Policy - Number of Units"@en .
 
-:NumberedSeriesType a :CollectionClass ;
-    rdfs:subClassOf :EnumeratedTerm ;
-    skos:notation "NumberedSeriesType" ;
-    skos:prefLabel "Numbered or Unnumbered Series"@en,
-        "Numrering i serie"@sv .
+# :NumberedSeriesType a :CollectionClass ;
+#     rdfs:subClassOf :EnumeratedTerm ;
+#     skos:notation "NumberedSeriesType" ;
+#     skos:prefLabel "Numbered or Unnumbered Series"@en,
+#         "Numrering i serie"@sv .
 
 # :PersonalNameType a :CollectionClass ;
 #     rdfs:subClassOf :EnumeratedTerm ;
@@ -1554,11 +1554,11 @@
     skos:prefLabel "Type of Record"@en,
         "Medietyp"@sv .
 
-:TypeOfSeriesType a :CollectionClass ;
-    rdfs:subClassOf :EnumeratedTerm ;
-    skos:notation "TypeOfSeriesType" ;
-    skos:prefLabel "Type of Series"@en,
-        "Typ av serie"@sv .
+# :TypeOfSeriesType a :CollectionClass ;
+#     rdfs:subClassOf :EnumeratedTerm ;
+#     skos:notation "TypeOfSeriesType" ;
+#     skos:prefLabel "Type of Series"@en,
+#         "Typ av serie"@sv .
 
 :VideoColorType a :CollectionClass ;
     rdfs:subClassOf :EnumeratedTerm ;
@@ -1788,11 +1788,11 @@
 #         :HeadingType ;
 #     skos:prefLabel "Heading Use - Main or Added Entry"@en .
 
-:headingSeries a owl:ObjectProperty ;
-    sdo:rangeIncludes :Boolean,
-        :HeadingType ;
-    skos:prefLabel "Heading Use - Series Added Entry"@en,
-        "Användningsområde - Seriesökelement"@sv .
+# :headingSeries a owl:ObjectProperty ;
+#     sdo:rangeIncludes :Boolean,
+#         :HeadingType ;
+#     skos:prefLabel "Heading Use - Series Added Entry"@en,
+#         "Användningsområde - Seriesökelement"@sv .
 
 # :headingSubject a owl:ObjectProperty ;
 #     sdo:rangeIncludes :Boolean,
@@ -1896,10 +1896,10 @@
     skos:prefLabel "Nature of Entire Work"@en,
         "Innehållsgenre (hela resursen)"@sv .
 
-:numberedSeries a owl:ObjectProperty ;
-    sdo:rangeIncludes :NumberedSeriesType ;
-    skos:prefLabel "Numbered or Unnumbered Series"@en,
-        "Numrering i serie"@sv .
+# :numberedSeries a owl:ObjectProperty ;
+#     sdo:rangeIncludes :NumberedSeriesType ;
+#     skos:prefLabel "Numbered or Unnumbered Series"@en,
+#         "Numrering i serie"@sv .
 
 :objectCount a owl:ObjectProperty ;
     # TODO: domain and range
@@ -2093,10 +2093,10 @@
 #    skos:prefLabel "Type of Record"@en,
 #        "Medietyp"@sv .
 
-:typeOfSeries a owl:ObjectProperty ;
-    sdo:rangeIncludes :TypeOfSeriesType ;
-    skos:prefLabel "Type of Series"@en,
-        "Typ av serie"@sv .
+# :typeOfSeries a owl:ObjectProperty ;
+#     sdo:rangeIncludes :TypeOfSeriesType ;
+#     skos:prefLabel "Type of Series"@en,
+#         "Typ av serie"@sv .
 
 :typeOfUnit a owl:ObjectProperty ;
    # TODO: domain and range


### PR DESCRIPTION
Remove obsolete/incorrect marc series properties having default values in auth 008:

```
marc:typeOfSeries
marc:numberedSeries
marc:headingSeries
```

These have been removed from data  > https://github.com/libris/librisxl/pull/918