### PR TITLE
Change notation terms construction

### DIFF
--- a/datasets.py
+++ b/datasets.py
@@ -191,15 +191,35 @@ def enumterms():
 
     return "/term/enum/", "2018-05-29T12:36:01.337Z", graph
 
+
 @compiler.dataset
 def musnotationterms():
-    graph = Graph().parse(str(compiler.path('source/musicnotation.ttl')), format='turtle')
+    graph = compiler.construct(sources=[
+        {
+            "source": Graph().parse(str(compiler.path('source/musicnotation.ttl')), format='turtle'),
+            "dataset": BASE + "dataset/musnotationterms"
+        },
+        {
+            "source": "http://rdaregistry.info/termList/MusNotation.nt"
+        }
+    ],
+        query="source/construct-musnotationsterms.rq")
 
     return "/term/rda/musnotation/", "2021-05-21T23:59:01.337Z", graph
 
+
 @compiler.dataset
 def tacnotationterms():
-    graph = Graph().parse(str(compiler.path('source/tactilenotation.ttl')), format='turtle')
+    graph = compiler.construct(sources=[
+        {
+            "source": Graph().parse(str(compiler.path('source/tactilenotation.ttl')), format='turtle'),
+            "dataset": BASE + "dataset/tacnotationterms"
+        },
+        {
+            "source": "http://www.rdaregistry.info/nt/termList/TacNotation.nt"
+        }
+    ],
+        query="source/construct-tacnotationterms.rq")
 
     return "/term/rda/tacnotation/", "2021-05-21T23:59:10.456Z", graph
 

--- a/datasets.py
+++ b/datasets.py
@@ -216,7 +216,7 @@ def tacnotationterms():
             "dataset": BASE + "dataset/tacnotationterms"
         },
         {
-            "source": "http://www.rdaregistry.info/nt/termList/TacNotation.nt"
+            "source": "http://rdaregistry.info/termList/TacNotation.nt"
         }
     ],
         query="source/construct-tacnotationterms.rq")

--- a/source/construct-musnotationsterms.rq
+++ b/source/construct-musnotationsterms.rq
@@ -2,13 +2,15 @@ prefix skos: <http://www.w3.org/2004/02/skos/core#>
 
 construct {
     ?s ?p ?o ;
-        skos:prefLabel ?prefLabel .
+        skos:prefLabel ?prefLabel ;
+        skos:definition ?definition .
 } where {
     graph <https://id.kb.se/dataset/musnotationterms> {
         ?s ?p ?o ; skos:exactMatch ?rda .
         optional {
             graph <http://rdaregistry.info/termList/MusNotation.nt> {
-                ?rda skos:prefLabel ?prefLabel .
+                ?rda skos:prefLabel ?prefLabel ;
+                    skos:definition ?definition .
                 filter(lang(?prefLabel) != 'sv')
             }
         }

--- a/source/construct-musnotationsterms.rq
+++ b/source/construct-musnotationsterms.rq
@@ -1,0 +1,16 @@
+prefix skos: <http://www.w3.org/2004/02/skos/core#>
+
+construct {
+    ?s ?p ?o ;
+        skos:prefLabel ?prefLabel .
+} where {
+    graph <https://id.kb.se/dataset/musnotationterms> {
+        ?s ?p ?o ; skos:exactMatch ?rda .
+        optional {
+            graph <http://rdaregistry.info/termList/MusNotation.nt> {
+                ?rda skos:prefLabel ?prefLabel .
+                filter(lang(?prefLabel) != 'sv')
+            }
+        }
+    }
+}

--- a/source/construct-tacnotationterms.rq
+++ b/source/construct-tacnotationterms.rq
@@ -8,7 +8,7 @@ construct {
     graph <https://id.kb.se/dataset/tacnotationterms> {
         ?s ?p ?o ; skos:exactMatch ?rda .
         optional {
-            graph <http://www.rdaregistry.info/nt/termList/TacNotation.nt> {
+            graph <http://rdaregistry.info/termList/TacNotation.nt> {
                 ?rda skos:prefLabel ?prefLabel ;
                     skos:definition ?definition .
                 filter(lang(?prefLabel) != 'sv')

--- a/source/construct-tacnotationterms.rq
+++ b/source/construct-tacnotationterms.rq
@@ -2,13 +2,15 @@ prefix skos: <http://www.w3.org/2004/02/skos/core#>
 
 construct {
     ?s ?p ?o ;
-        skos:prefLabel ?prefLabel .
+        skos:prefLabel ?prefLabel ;
+        skos:definition ?definition .
 } where {
     graph <https://id.kb.se/dataset/tacnotationterms> {
         ?s ?p ?o ; skos:exactMatch ?rda .
         optional {
             graph <http://www.rdaregistry.info/nt/termList/TacNotation.nt> {
-                ?rda skos:prefLabel ?prefLabel .
+                ?rda skos:prefLabel ?prefLabel ;
+                    skos:definition ?definition .
                 filter(lang(?prefLabel) != 'sv')
             }
         }

--- a/source/construct-tacnotationterms.rq
+++ b/source/construct-tacnotationterms.rq
@@ -1,0 +1,16 @@
+prefix skos: <http://www.w3.org/2004/02/skos/core#>
+
+construct {
+    ?s ?p ?o ;
+        skos:prefLabel ?prefLabel .
+} where {
+    graph <https://id.kb.se/dataset/tacnotationterms> {
+        ?s ?p ?o ; skos:exactMatch ?rda .
+        optional {
+            graph <http://www.rdaregistry.info/nt/termList/TacNotation.nt> {
+                ?rda skos:prefLabel ?prefLabel .
+                filter(lang(?prefLabel) != 'sv')
+            }
+        }
+    }
+}


### PR DESCRIPTION
This adds prefLabels from RDAregistry to our notation terms.

A more generalized solution would be possible, however this consistent with the other datasets, i.e. each is constructed separately.