### PR TITLE
Add lens group search-cards to display.jsonld

### DIFF
--- a/source/vocab/display.jsonld
+++ b/source/vocab/display.jsonld
@@ -965,6 +965,20 @@
         }
 
       }
+    },
+    "search-cards": {
+      "@id": "search-cards",
+      "@type": "fresnel:Group",
+      "lenses": {
+        "Instance": {
+          "fresnel:extends": {"@id": "Instance-cards"},
+          "showProperties": [ "fresnel:super", "hasNote" ]
+        },
+        "Work": {
+          "fresnel:extends": {"@id": "Work-cards"},
+          "showProperties": [ "fresnel:super", "hasNote", "summary" ]
+        }
+      }
     }
   }
 }

--- a/source/vocab/display.jsonld
+++ b/source/vocab/display.jsonld
@@ -791,7 +791,7 @@
         "ShelfMarkSequence": {
           "@id": "ShelfMarkSequence-cards",
           "fresnel:extends": {"@id": "ShelfMarkSequence-chips"},
-          "showProperties": [ "fresnel:super", "description", "hasNote", "shelfMarkStatus" ]
+          "showProperties": [ "fresnel:super", "description", "hasNote" ]
         }
       }
     },
@@ -977,6 +977,10 @@
         "Work": {
           "fresnel:extends": {"@id": "Work-cards"},
           "showProperties": [ "fresnel:super", "hasNote", "summary" ]
+        },
+        "ShelfMarkSequence": {
+          "fresnel:extends": {"@id": "ShelfMarkSequence-cards"},
+          "showProperties": [ "fresnel:super", "shelfMarkStatus" ]
         }
       }
     }


### PR DESCRIPTION
Used if available for ES indexing.

So that we can have things that are indexed but not displayed in cards.

* Add hasNote and summary for MTM
* Move shelfMarkStatus (already hidden by lxlviewer)