### PR TITLE
Add term_status unstable to BibliographicAgent

### DIFF
--- a/source/vocab/agents.ttl
+++ b/source/vocab/agents.ttl
@@ -3,6 +3,7 @@
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix ptg: <http://protege.stanford.edu/plugins/owl/protege#> .
+@prefix vs: <http://www.w3.org/2003/06/sw-vocab-status/ns#> .
 
 @prefix prov: <http://www.w3.org/ns/prov#> .
 @prefix dc: <http://purl.org/dc/terms/> .
@@ -51,6 +52,7 @@
 :BibliographicAgent a owl:Class;
     rdfs:label "Agent"@en, "Agent"@sv;
     ptg:abstract true;
+    vs:term_status "unstable";
     :rdfs:subClassOf :Agent.
 
 :Person a owl:Class;


### PR DESCRIPTION
Pending breaks functionality. Add vs_status to mark BibliographicAgent as an unstable term.