### PR TITLE
Broaden domain of url to also include Dataset

### DIFF
--- a/source/vocab/items.ttl
+++ b/source/vocab/items.ttl
@@ -240,7 +240,7 @@
 
 :url a owl:DatatypeProperty;
     rdfs:label "URL"@en, "URL"@sv ;
-    sdo:domainIncludes :Item, :Agent ; # Make this even broader?
+    sdo:domainIncludes :Item, :Agent, :Dataset ; # Make this even broader?
     rdfs:range xsd:anyURI ;
     owl:equivalentProperty sdo:url .
 


### PR DESCRIPTION
We will need to add `url` to `Dataset` for NB, auth and bibstat to be able to set correct `dcat:accessURL` (even though it belongs to `distribution`).

- [x] I have built dataset  