### PR TITLE
Lxl 3641 material

### DIFF
--- a/source/vocab/enums.ttl
+++ b/source/vocab/enums.ttl
@@ -199,7 +199,7 @@
 
 :baseMaterial a owl:ObjectProperty;
     rdfs:domain :Instance; # Ta bort?
-    rdfs:range :BaseMaterial; # Ändra till Resource?
+    rdfs:range :Material; # Ändra till Resource?
     rdfs:label "bärande material"@sv, "Base material"@en;
     rdfs:comment "Det underliggande fysiska materialet för en resurs."@sv;
     rdfs:subPropertyOf :material;
@@ -212,7 +212,7 @@
 
 :appliedMaterial a owl:ObjectProperty;
     rdfs:domain :Instance; # Ta bort?
-    rdfs:range :AppliedMaterial; # Ändra till Resource?
+    rdfs:range :Material; # Ändra till Resource?
     rdfs:label "Applied material"@en, "applicerat material"@sv;
     rdfs:comment "Substans som är applicerad på ett bärande material för en resurs."@sv;
     rdfs:subPropertyOf :material;

--- a/source/vocab/enums.ttl
+++ b/source/vocab/enums.ttl
@@ -188,7 +188,7 @@
     owl:equivalentClass bf2:Generation .
 
 :material a owl:ObjectProperty;
-    rdfs:range :Material; # eller Resource (enligt bf)?
+    rdfs:range :Material;
     rdfs:label "Material"@en, "material"@sv;
     rdfs:comment "Material som resursen använder, består av, integrerar etc."@sv;
     owl:equivalentProperty bf2:material .
@@ -198,8 +198,8 @@
     owl:equivalentClass bf2:Material .
 
 :baseMaterial a owl:ObjectProperty;
-    rdfs:domain :Instance; # Ta bort?
-    rdfs:range :Material; # Ändra till Resource?
+    rdfs:domain :Instance
+    rdfs:range :Material;
     rdfs:label "bärande material"@sv, "Base material"@en;
     rdfs:comment "Det underliggande fysiska materialet för en resurs."@sv;
     rdfs:subPropertyOf :material;
@@ -211,8 +211,8 @@
     owl:equivalentClass bf2:BaseMaterial .
 
 :appliedMaterial a owl:ObjectProperty;
-    rdfs:domain :Instance; # Ta bort?
-    rdfs:range :Material; # Ändra till Resource?
+    rdfs:domain :Instance;
+    rdfs:range :Material
     rdfs:label "Applied material"@en, "applicerat material"@sv;
     rdfs:comment "Substans som är applicerad på ett bärande material för en resurs."@sv;
     rdfs:subPropertyOf :material;

--- a/source/vocab/enums.ttl
+++ b/source/vocab/enums.ttl
@@ -190,7 +190,7 @@
 :material a owl:ObjectProperty;
     rdfs:range :Material; # eller Resource (enligt bf)?
     rdfs:label "Material"@en, "material"@sv;
-    rdfs:comment "Material som resursen använder, består av, integrerar etc."
+    rdfs:comment "Material som resursen använder, består av, integrerar etc."@sv;
     owl:equivalentProperty bf2:material .
 
 :Material a owl:Class;

--- a/source/vocab/enums.ttl
+++ b/source/vocab/enums.ttl
@@ -187,26 +187,40 @@
     rdfs:label "Generation"@sv, "Generation"@en;
     owl:equivalentClass bf2:Generation .
 
+:material a owl:ObjectProperty;
+    rdfs:range :Material; # eller Resource (enligt bf)?
+    rdfs:label "Material"@en, "material"@sv;
+    rdfs:comment "Material som resursen använder, består av, integrerar etc."
+    owl:equivalentProperty bf2:material .
+
+:Material a owl:Class;
+    rdfs:label "Material"@sv, "Material"@en;
+    owl:equivalentClass bf2:Material .
+
 :baseMaterial a owl:ObjectProperty;
-    rdfs:range :BaseMaterial;
+    rdfs:domain :Instance; # Ta bort?
+    rdfs:range :BaseMaterial; # Ändra till Resource?
     rdfs:label "bärande material"@sv, "Base material"@en;
     rdfs:comment "Det underliggande fysiska materialet för en resurs."@sv;
-    rdfs:domain :Instance;
+    rdfs:subPropertyOf :material;
     owl:equivalentProperty bf2:baseMaterial .
 
 :BaseMaterial a owl:Class;
-    owl:equivalentClass bf2:BaseMaterial;
-    rdfs:label "Bärande material"@sv, "Base material"@en .
+    rdfs:label "Bärande material"@sv, "Base material"@en;
+    rdfs:subClassOf :Material;
+    owl:equivalentClass bf2:BaseMaterial .
 
 :appliedMaterial a owl:ObjectProperty;
-    rdfs:domain :Instance;
-    rdfs:range :AppliedMaterial;
-    rdfs:comment "Substans som är applicerad på ett bärande material för en resurs."@sv;
+    rdfs:domain :Instance; # Ta bort?
+    rdfs:range :AppliedMaterial; # Ändra till Resource?
     rdfs:label "Applied material"@en, "applicerat material"@sv;
+    rdfs:comment "Substans som är applicerad på ett bärande material för en resurs."@sv;
+    rdfs:subPropertyOf :material;
     owl:equivalentProperty bf2:appliedMaterial .
 
 :AppliedMaterial a owl:Class;
     rdfs:label "Applied material"@en, "Applicerat material"@sv;
+    rdfs:subClassOf :Material;
     owl:equivalentClass bf2:AppliedMaterial .
 
 :productionMethod a owl:ObjectProperty;


### PR DESCRIPTION
This is a bit different from the bf2 implementation, where ranges are unnecessarily wide for our need. 
Should we also set `:Instance` as the domain for `:material` to be consistent with `:baseMaterial` / `:appliedMaterial` as they are? Or should we rather remove the domain from the latter and be more consistent with the bf2 implementation? Do we have a need to describe materials of other resource types than Instance? 