### PR TITLE
Widen domain for identifiedBy

### DIFF
--- a/source/vocab/details.ttl
+++ b/source/vocab/details.ttl
@@ -241,7 +241,7 @@
     owl:equivalentProperty bf2:identifiedBy;
     owl:inverseOf :identifies;
     rdfs:comment "Teckensträng knuten till en resurs som används för att unikt särskilja resursen från andra."@sv;
-    sdo:domainIncludes :Agent, :Document;
+    rdfs:domain :Resource;
     rdfs:range :Identifier .
 
 :indirectlyIdentifiedBy a owl:ObjectProperty ;


### PR DESCRIPTION
This is mainly to make identifiedBy selectable for ImmediateAcquisition entities in the cataloging interface. 

We should put individual restrictions on different identifiers so that they get selectable only when the entity is of "right type": https://jira.kb.se/browse/LXL-3662