### PR TITLE
Remove termComponentList from ComplexSubject chip

### DIFF
--- a/source/vocab/display.jsonld
+++ b/source/vocab/display.jsonld
@@ -325,7 +325,7 @@
           "@id": "ComplexSubject-chips",
           "@type": "fresnel:Lens",
           "classLensDomain": "ComplexSubject",
-          "showProperties": [ "prefLabel", "termComponentList", "inScheme" ]
+          "showProperties": [ "prefLabel", "inScheme" ]
         },
         "Contribution": {
           "@id": "Contribution-chips",


### PR DESCRIPTION
Should solve the problem with data being doubled in the chips of `ComplexSubject`.