### PR TITLE
Add chip for ConceptScheme, containing only "title"

### DIFF
--- a/source/vocab/display.jsonld
+++ b/source/vocab/display.jsonld
@@ -85,7 +85,7 @@
           "@id": "ConceptScheme-chips",
           "@type": "fresnel:Lens",
           "classLensDomain": "ConceptScheme",
-          "showProperties": [ "prefLabel" ]
+          "showProperties": [ "title" ]
         },
         "ContentType": {
           "@id": "ContentType-chips",

--- a/source/vocab/display.jsonld
+++ b/source/vocab/display.jsonld
@@ -81,6 +81,12 @@
           "classLensDomain": "MediaType",
           "showProperties": [ "prefLabel", "label" ]
         },
+        "ConceptScheme": {
+          "@id": "ConceptScheme-chips",
+          "@type": "fresnel:Lens",
+          "classLensDomain": "ConceptScheme",
+          "showProperties": [ "prefLabel" ]
+        },
         "ContentType": {
           "@id": "ContentType-chips",
           "@type": "fresnel:Lens",


### PR DESCRIPTION
Before this change, `ConceptScheme` lacks a proper chip, resulting in the fallback to `Resource`-chip, which contains multiple properties that doesn't need to be displayed for ConceptSchemes, resulting in overly verbose chips containing *both* the label, and the code.

Basically, this changes chips looking like
`Barnämnesord • barn` => `Barnämnesord`
`Tesaurus för grafiskt material • gmgpc/swe` => `Tesaurus för grafiskt material`

Smaller representations of these entities will still use the Token-definition for `ConceptScheme`, resulting in only the use of the `code`-property.