### PR TITLE
Add more mappings to common vocabularies

### DIFF
--- a/source/vocab/concepts.ttl
+++ b/source/vocab/concepts.ttl
@@ -253,6 +253,7 @@
     owl:equivalentProperty bf2:classification;
     rdfs:domain :Endeavour ;
     rdfs:range :Classification ;
+    rdfs:subPropertyOf dc:type, sdo:genre ;
     rdfs:label "Classification"@en, "klassifikation"@sv .
 
 :additionalClassificationDdc a owl:ObjectProperty;

--- a/source/vocab/details.ttl
+++ b/source/vocab/details.ttl
@@ -199,13 +199,17 @@
 :isbn a owl:DatatypeProperty ;
     :category :shorthand;
     rdfs:label "ISBN";
-    rdfs:subPropertyOf :identifier ; #TODO? relate to https://schema.org/isbn
+    rdfs:subPropertyOf :identifier ;
+    owl:equivalentProperty sdo:isbn , bibo:isbn ;
+    owl:propertyChainAxiom ( [ rdfs:subPropertyOf :identifiedBy ; rdfs:range :ISBN ] :value ) ;
     rdfs:range :ISBN .
 
 :issn a owl:DatatypeProperty ;
     :category :shorthand;
     rdfs:label "ISSN";
-    rdfs:subPropertyOf :identifier ; #TODO? relate to https://schema.org/issn
+    rdfs:subPropertyOf :identifier ;
+    owl:equivalentProperty sdo:isnn , bibo:isnn ;
+    owl:propertyChainAxiom ( [ rdfs:subPropertyOf :identifiedBy ; rdfs:range :ISSN ] :value ) ;
     rdfs:range :ISSN .
 
 :doi a owl:DatatypeProperty ;
@@ -946,6 +950,17 @@
     rdfs:subPropertyOf :place ;
     rdfs:range :Country .
 
+:datePublished a owl:DatatypeProperty;
+    :category :shorthand;
+    owl:equivalentProperty sdo:datePublished;
+    rdfs:subPropertyOf dc:issued;
+    owl:propertyChainAxiom ( :publication :date ) .
+
+:publisher a owl:ObjectProperty;
+    :category :shorthand;
+    owl:equivalentProperty dc:publisher, sdo:publisher;
+    owl:propertyChainAxiom ( :publication :agent ) .
+
 :firstIssue a owl:DatatypeProperty;
     rdfs:label "Multipart first issue"@en, "Numrering av seriella resurser (första)"@sv;
     rdfs:comment "Används för närvarande ej i Libris."@sv;
@@ -967,7 +982,8 @@
     # TODO: remove "klammer" form in favour of placing :responsibilityStatement
     # in relevant entity (e.g. :TitlePage)
     #rdfs:comment "Om upphov står på annan plats än primärkällan (ofta titelsidan), lägg det inom klammer. Exempel: text: Eva Andersson, Bengt Larsson ; [foto: Sofia Lundgren, Lisa Ek]"@sv;
-    owl:equivalentProperty bf2:responsibilityStatement, rdael:statementOfResponsibility .
+    owl:equivalentProperty bf2:responsibilityStatement, rdael:statementOfResponsibility ;
+    rdfs:subPropertyOf rdfs:comment .
 
 :editionStatement a owl:DatatypeProperty ;
     rdfs:label "edition statement"@en, "upplageuppgift"@sv;
@@ -1045,8 +1061,9 @@
 
 :note a owl:DatatypeProperty;
     rdfs:label "anmärkning"@sv, "note"@en;
-    :category :pending;
+    :category :pending, :shorthand ;
     rdfs:domain :Resource;
+    owl:propertyChainAxiom (:hasNote :label) ;
     owl:equivalentProperty skos:note .
 
 :hasNote a owl:ObjectProperty;
@@ -1070,6 +1087,7 @@
     rdfs:label "Physical details note"@en, "Övriga fysiska detaljer"@sv ;
     rdfs:domain :Instance ;
     rdfs:range rdfs:Literal ;
+    rdfs:subPropertyOf skos:note ;
     skos:changeNote "2020-05-29: Ändrad från marc:otherPhysicalDetails."@sv;
     rdfs:comment "Anmärkning om fysiska karakteristika som till exempel illustrationer, färg, uppspelningshastighet, spårkarakteristika, närvaro eller typ av ljud, antal kanaler, filmprojektionssystem."@sv .
 
@@ -1243,7 +1261,7 @@
     rdfs:domain :Instance ;
     rdfs:range :Duration ;
     skos:closeMatch rdau:duration.en .
-    
+
 :Duration a owl:Class;
     rdfs:subClassOf :StructuredValue, dc:SizeOrDuration ;
     rdfs:label "Duration"@en, "Speltid"@sv .
@@ -1253,6 +1271,11 @@
     rdfs:label "duration"@en, "speltid"@sv;
     owl:propertyChainAxiom ( :hasDuration :value );
     owl:equivalentProperty bf2:duration .
+
+:extentLabel a owl:DatatypeProperty ;
+    :category :abstract, :shorthand ;
+    rdfs:subPropertyOf skos:note ;
+    owl:propertyChainAxiom ( :extent :label ) .
 
 :extent a owl:ObjectProperty;
     rdfs:domain :Instance ;
@@ -1276,7 +1299,8 @@
 # NOTE: SDO-experimental mapping.
 #:numberOfPages a owl:DatatypeProperty ;
 #    owl:equivalentProperty sdo:numberOfPages;
-#    rdfs:subPropertyOf :extent;
+##    rdfs:subPropertyOf :extent;
+#    owl:propertyChainAxiom ( [ rdfs:subPropertyOf :extent ; rdfs:range :PageExtent ] :value ) ;
 #    rdfs:label "number of pages"@en, "sidantal"@sv .
 
 :preferredCitation a owl:DatatypeProperty;
@@ -1294,6 +1318,7 @@
     rdfs:range rdfs:Literal;
     rdfs:label "mått"@sv, "dimensions"@en;
     #skos:altLabel "Dimensioner"@sv;
+    rdfs:subPropertyOf skos:note ;
     owl:propertyChainAxiom (:hasDimensions :label) ;
     owl:equivalentProperty bf2:dimensions .
 

--- a/source/vocab/platform.ttl
+++ b/source/vocab/platform.ttl
@@ -96,13 +96,14 @@
     rdfs:label "Description modifier"@en, "Ändrad av"@sv ;
     rdfs:domain :AdminMetadata;
     owl:equivalentProperty bf2:descriptionModifier ;
+    rdfs:subPropertyOf dc:contributor ;
     rdfs:range :Agent .
 
 :descriptionCreator a owl:ObjectProperty;
     rdfs:label "Description creator"@en, "Skapad av"@sv ;
     rdfs:comment "Entitet som upprättat beskrivningen."@sv ;
     rdfs:domain :Record;
-    rdfs:subPropertyOf :descriptionModifier ;
+    rdfs:subPropertyOf :descriptionModifier, dc:creator ;
     rdfs:range :Agent .
 
 :descriptionUpgrader a owl:ObjectProperty;
@@ -319,6 +320,7 @@
     rdfs:comment "in bibliography"@en, "bibliografi som resursen ingår i"@sv ;
     rdfs:domain :Record ;
     sdo:rangeIncludes :Bibliography ;
+    rdfs:subPropertyOf dc:isPartOf ;
     rdfs:label "bibliografi"@sv .
 
 :sigel a owl:DatatypeProperty;

--- a/source/vocab/relations.ttl
+++ b/source/vocab/relations.ttl
@@ -312,7 +312,7 @@ prefix relsubtype: <http://id.loc.gov/vocabulary/preservation/relationshipSubTyp
     rdfs:label "uttryck av"@sv;
     rdfs:domain :Work;
     rdfs:range :Work;
-    rdfs:subPropertyOf :versionOf;
+    rdfs:subPropertyOf :versionOf, sdo:exampleOfWork; # possibly skos:broader;
     owl:inverseOf :hasExpression;
     owl:equivalentProperty bf2:expressionOf .
 

--- a/source/vocab/things.ttl
+++ b/source/vocab/things.ttl
@@ -80,7 +80,7 @@
 :instanceOf a owl:ObjectProperty ;
     rdfs:label "instans av Verk"@sv;
     owl:equivalentProperty bf2:instanceOf;
-    rdfs:subPropertyOf sdo:exampleOfWork, rdfa:copy;
+    rdfs:subPropertyOf sdo:exampleOfWork, dc:isFormatOf, rdfa:copy;
     rdfs:comment "Verk som den beskrivna instansen manifesterar. Används för att koppla ihop instanser med verk i en Bibframe-struktur."@sv;
     sdo:rangeIncludes :Work .
 


### PR DESCRIPTION
These mappings are used to infer common forms (or "infer",  currently using [Target Vocabulary Maps](https://github.com/niklasl/trld#about-target-vocabulary-maps)).

More mappings will be added to this branch. Some of these may be "creative" as in not strictly reasonable, but possibly "useful enough", or just hand-waving depending on whose usage is considered. Opinions are very welcome! 🙂 