### PR TITLE
Feature/bibdb registrant

### DIFF
--- a/datasets.py
+++ b/datasets.py
@@ -236,6 +236,14 @@ def encodingFormatterms():
 
     return "/encodingFormat/", "2021-03-04T10:12:09.921Z", graph
 
+@compiler.dataset
+def bibdbterms():
+    graph = ConjunctiveGraph()
+    # graph = Graph()
+    for part in compiler.path('source/bibdb').glob('**/*.ttl'):
+        graph.parse(str(part), format='turtle')
+
+    return "/term/bibdb/", "2021-09-20T08:13:50.570Z", graph
 
 @compiler.dataset
 def swepubterms():

--- a/source/bibdb/terms.ttl
+++ b/source/bibdb/terms.ttl
@@ -1,0 +1,9 @@
+prefix owl: <http://www.w3.org/2002/07/owl#>
+prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+prefix skos: <http://www.w3.org/2004/02/skos/core#>
+prefix kbv: <https://id.kb.se/vocab/>
+prefix : <https://id.kb.se/term/bibdb/>
+
+:Registrant a skos:Concept ;
+    skos:prefLabel "Registrant"@en, "Registrerande"@sv ;
+    rdfs:comment "Biblioteket ska skapa och underhålla metadata i den gemensamma datamängden."@sv .


### PR DESCRIPTION
This creates the definition that is necessary for https://github.com/libris/definitions/pull/313.

`Concept` may not be the most accurate type but should be ok for now.

Although we only define one single term at this point, the structure (same as for e.g. swepub terms) allows for more bibdb-related terms to be added further down the line.

Note that the triples are added to a `ConjunctiveGraph()` instead of `Graph()`. Normally we use `Graph()`, however when a graph object contains only a single rdf-node (like in this case), this node is turned into a blank node (i.e. missing `@graph`) when converted to json-ld, unless it has a named graph associated with it. With `ConjunctiveGraph()` the triples are automatically assigned to a named graph and thus we get a correct conversion. This only applies to the very specific case with a single node in a graph so if/when we start adding more bibdb-related terms, `Graph()` will work perfectly fine.