### PR TITLE
Add labels for some core external vocabularies

### DIFF
--- a/source/vocab/external-labels.ttl
+++ b/source/vocab/external-labels.ttl
@@ -3,11 +3,11 @@ prefix owl: <http://www.w3.org/2002/07/owl#>
 prefix schema: <http://schema.org/>
 prefix ptg: <http://protege.stanford.edu/plugins/owl/protege#>
 
-rdfs:subClassOf rdfs:label "Härledd från"@sv, "Sub class of"@en ;
-    owl:inverseOf [ rdfs:label "Härleds till"@sv, "Base class of"@en ] .
+rdfs:subClassOf rdfs:label "Har basklass"@sv, "Sub class of"@en ;
+    owl:inverseOf [ rdfs:label "Basklass för"@sv, "Base class of"@en ] .
 
-rdfs:subPropertyOf rdfs:label "Härledd från"@sv, "Sub property of"@en ;
-    owl:inverseOf [ rdfs:label "Härleds till"@sv, "Base property of"@en ] .
+rdfs:subPropertyOf rdfs:label "Har basegenskap"@sv, "Sub property of"@en ;
+    owl:inverseOf [ rdfs:label "Basegenskap för"@sv, "Base property of"@en ] .
 
 rdfs:isDefinedBy rdfs:label "Definieras av"@sv, "Is defined by"@en .
 
@@ -17,10 +17,10 @@ owl:equivalentClass rdfs:label "Motsvarar"@sv, "Equivalent class"@en .
 
 rdfs:domain rdfs:label "Förekommer på"@sv, "Domain"@en .
 
-schema:domainIncludes rdfs:label "Förekommer på"@sv, "Domain"@en .
+schema:domainIncludes rdfs:label "Kan förekomma på"@sv, "Domain includes"@en .
 
-rdfs:range rdfs:label "Urval"@sv, "Range"@en .
+rdfs:range rdfs:label "Pekar på"@sv, "Range"@en .
 
-schema:rangeIncludes rdfs:label "Urval"@sv, "Range"@en .
+schema:rangeIncludes rdfs:label "Kan peka på"@sv, "Range includes"@en .
 
 owl:equivalentProperty rdfs:label "Motsvarar"@sv, "Equivalent property"@en .


### PR DESCRIPTION
Mainly to display RDFS and OWL predicates in our user interfaces.

This results in these terms being described in the vocab, with entries like this (in JSON-LD):
```json
    {
      "@id": "http://www.w3.org/2000/01/rdf-schema#subPropertyOf",
      "labelByLang": {
        "en": "Sub property of",
        "sv": "Härledd från"
      },    
      "owl:inverseOf": {
        "labelByLang": {
          "en": "Base property of",
          "sv": "Härleds till"
        }
      }     
    }, 
```

In a discussion with @oBlissing we concluded that this might be better than to keep them in the client repositories. The choice of translations is up for discussion!

While describing terms defined by others can be problematic, this is relatively innocuous (and we do far worse with OWL axioms anyway).