### PR TITLE
Remove chips and tokens from nations/lang related classes

### DIFF
--- a/source/vocab/display.jsonld
+++ b/source/vocab/display.jsonld
@@ -242,6 +242,14 @@
           "classLensDomain": "marc:AddedEntryHierarchicalPlaceName",
           "showProperties": [ "marc:countryOrLargerEntity", "marc:city" ]
         },
+        "Language": {
+          "@id": "Language-chips",
+          "@type": "fresnel:Lens",
+          "classLensDomain": "Language",
+          "showProperties": [
+            {"alternateProperties": ["prefLabel", "label", "code"]}
+          ]
+        },
         "marc:LanguageNote": {
           "@id": "LanguageNote-chips",
           "@type": "fresnel:Lens",

--- a/source/vocab/display.jsonld
+++ b/source/vocab/display.jsonld
@@ -56,13 +56,6 @@
           "showProperties": [
             "prefLabel"
           ]
-        },
-        "Language": {
-          "@type": "fresnel:Lens",
-          "classLensDomain": "Language",
-          "showProperties": [
-            "prefLabel"
-          ]
         }
       }
     },
@@ -237,18 +230,6 @@
           "classLensDomain": "SeriesMembership",
           "showProperties": [ "inSeries", "seriesStatement", "seriesEnumeration" ]
         },
-        "Country": {
-          "@id": "Country-chips",
-          "@type": "fresnel:Lens",
-          "classLensDomain": "Country",
-          "showProperties": [ "prefLabel" ]
-        },
-        "Nationality": {
-          "@id": "Nationality-chips",
-          "@type": "fresnel:Lens",
-          "classLensDomain": "Nationality",
-          "showProperties": [ "prefLabel" ]
-        },
         "marc:AddedEntryGeographicName": {
           "@id": "marc:AddedEntryGeographicName-chips",
           "@type": "fresnel:Lens",
@@ -260,12 +241,6 @@
           "@type": "fresnel:Lens",
           "classLensDomain": "marc:AddedEntryHierarchicalPlaceName",
           "showProperties": [ "marc:countryOrLargerEntity", "marc:city" ]
-        },
-        "Language": {
-          "@id": "Language-chips",
-          "@type": "fresnel:Lens",
-          "classLensDomain": "Language",
-          "showProperties": [ "prefLabel", "label" ]
         },
         "marc:LanguageNote": {
           "@id": "LanguageNote-chips",


### PR DESCRIPTION
All should be fine to just inherit from Resource now that we have alternateProperties on that.

* Removed chips for:
    * Language
    * Nationality
    * Country
* Removed tokens for:
    * Language.
