### PR TITLE
Feature/update display for identifiers

### DIFF
--- a/source/vocab/display.jsonld
+++ b/source/vocab/display.jsonld
@@ -426,6 +426,7 @@
           "showProperties": [
             "reproductionOf",
             "identifiedBy",
+            "indirectlyIdentifiedBy",
             "issuanceType",
             "mediaType",
             "carrierType",
@@ -442,7 +443,6 @@
             "copyright",
             "copyrightDate",
             "projectedProvisionDate",
-            "indirectlyIdentifiedBy",
             "extent",
             "hasDimensions",
             "hasDuration",

--- a/source/vocab/display.jsonld
+++ b/source/vocab/display.jsonld
@@ -210,6 +210,14 @@
           "classLensDomain": "ISBN",
           "showProperties": [ "value", "qualifier" ]
         },
+        "ISSN": {
+          "@id": "ISSN-chips",
+          "@type": "fresnel:Lens",
+          "classLensDomain": "ISSN",
+          "showProperties": [
+            {"alternateProperties": [ "value", "marc:canceledIssn", "marc:incorrectIssn", "marc:issnL" ]}
+          ]
+        },
         "Notation": {
           "@id": "Notation-chips",
           "@type": "fresnel:Lens",
@@ -569,6 +577,13 @@
           "classLensDomain": "ISBN",
           "fresnel:extends": {"@id": "ISBN-chips"},
           "showProperties": [ "fresnel:super" ]
+        },
+        "ISSN": {
+          "@id": "ISSN-cards",
+          "@type": "fresnel:Lens",
+          "classLensDomain": "ISSN",
+          "fresnel:extends": {"@id": "ISSN-chips"},
+          "showProperties": [ "fresnel:super", "source" ]
         },
         "Library": {
           "@id": "Library-cards",

--- a/source/vocab/display.jsonld
+++ b/source/vocab/display.jsonld
@@ -196,7 +196,11 @@
           "@id": "Identifier-chips",
           "@type": "fresnel:Lens",
           "classLensDomain": "Identifier",
-          "showProperties": [ "value", "typeNote", "marc:hiddenValue" ]
+          "showProperties": [
+            {"alternateProperties": [ "value", "marc:hiddenValue" ]},
+            "typeNote",
+            "hasNote" 
+          ]
         },
         "ImageBitDepth": {
           "@id": "ImageBitDepth-chips",
@@ -569,7 +573,7 @@
           "@id": "Identifier-cards",
           "classLensDomain": "Identifier",
           "fresnel:extends": {"@id": "Identifier-chips"},
-          "showProperties": [ "fresnel:super", "qualifier", "agent", "source" ]
+          "showProperties": [ "fresnel:super", "qualifier", "agent", "source", "assigner" ]
         },
         "ISBN": {
           "@id": "ISBN-cards",


### PR DESCRIPTION

- Cluster identifiedBy and indirectlyIdentifiedBy (LXL-3650).
- Add ISSN chips and cards.
- Make alternateproperties for Identifier chips and add missing properties to cards.