### PR TITLE
Add wikidata URIs to landskoder.tsv

### DIFF
--- a/source/landskoder.tsv
+++ b/source/landskoder.tsv
@@ -1,382 +1,382 @@
-code	label_sv	comment_sv	map_to_code
-9a	Åland	Librisdefinierad kod	
-9p	Palestina	Librisdefinierad kod	
-aa	Albanien		
-abc	Alberta 	"Se ""xxc"" (Kanada))"	
-ac	Ashmore and Cartier Islands	Obsolet	
-aca	Australian Capital Territory 	"Se ""at"" (Australien)"	
-ae	Algeriet		
-af	Afghanistan		
-ag	Argentina		
-ai	Armenien		
-air	Armeniska SSR	"Före juni 1992; använd ""ai"" (Armenien)"	ai
-aj	Azerbajdzjan		
-ajr	Azerbajdzjanska SSR	"Före juni 1992; använd ""aj"" (Azerbajdjan)"	aj
-aku	Alaska 	"Se ""xxu"" (Förenta staterna)"	
-alu	Alabama 	"Se ""xxu"" (Förenta staterna)"	
-am	Anguilla		
-an	Andorra		
-ao	Angola		
-aq	Antigua och Barbuda		
-aru	Arkansas 	"Se ""xxu"" (Förenta staterna)"	
-as	Amerikanska Samoa		
-at	Australien		
-au	Österrike		
-aw	Aruba		
-ay	Antarktis		
-azu	Arizona 	"Se ""xxu"" (Förenta staterna)"	
-ba	Bahrain		
-bb	Barbados		
-bcc	British Columbia 	"Se ""xxc"" (Se ""xxc"" (Kanada))"	
-bd	Burundi		
-be	Belgien		
-bf	Bahamas		
-bg	Bangladesh		
-bh	Belize		
-bi	Brittiska territorier i Indiska oceanen		
-bl	Brasilien		
-bm	Bermuda		
-bn	Bosnien-Hercegovina		
-bo	Bolivia		
-bp	Salomonöarna		
-br	Burma		
-bs	Botswana		
-bt	Bhutan		
-bu	Bulgarien		
-bv	Bouvetön		
-bw	Vitryssland		
-bwr	Vitryska SSR	"Före juni 1992; använd ""bw"" (Vitryssland)"	bw
-bx	Brunei		
-ca	Karibiska Nederländerna		
-cau	Kalifornien 	"Se ""xxu"" (Förenta staterna)"	
-cb	Kambodja		
-cc	Kina		
-cd	Tchad		
-ce	Sri Lanka		
-cf	Kongo-Brazzaville	Även Republiken Kongo	
-cg	Kongo-Kinshasa	"Även Demokratiska Republiken Kongo; f.d. Zaire"	
-ch	Taiwan 	"1949-; även Republiken Kina"	
-ci	Kroatien		
-cj	Caymanöarna		
-ck	Colombia		
-cl	Chile		
-cm	Kamerun		
-cn	Kanada	"Obsolet: använd ""xxc"" (Kanada)"	xxc
-co	Curaçao		
-cou	Colorado 	"Se ""xxu"" (Förenta staterna)"	
-cp	Canton and Elderbury Islands	Obsolet	
-cq	Comorerna		
-cr	Costa Rica		
-cs	Tjeckoslovakien 	"Före maj 1993; använd ""cx"" (Tjeckien) resp. ""xo"" (Slovakien)"	
-ctu	Connecticut 	"Se ""xxu"" (Förenta staterna)"	
-cu	Kuba		
-cv	Cap Verde		
-cw	Cooköarna		
-cx	Centralafrikanska republiken		
-cy	Cypern		
-cz	Canal Zone	"För jan. 1985; använd ""pn"" (Panama)"	pn
-dcu	District of Columbia 	"Se ""xxu"" (Förenta staterna)"	
-deu	Delaware 	"Se ""xxu"" (Förenta staterna)"	
-dk	Danmark		
-dm	Benin		
-dq	Dominica		
-dr	Dominikanska republiken		
-ea	Eritrea		
-ec	Ecuador		
-eg	Ekvatorialguinea		
-em	Östtimor		
-enk	England 	"Se ""xxk"" (Storbritannien)"	
-er	Estland		
-err	Estniska SSR	"Före okt. 1992; använd ""er"" (Estland)"	er
-es	El Salvador		
-et	Etiopien		
-fa	Färöarna		
-fg	Franska Guyana		
-fi	Finland		
-fj	Fiji		
-fk	Falklandsöarna		
-flu	Florida 	"Se ""xxu"" (Förenta staterna)"	
-fm	Mikronesiens federerade stater	Även Mikronesiska federationen	
-fp	Franska Polynesien		
-fr	Frankrike		
-fs	Terres australes et antarctiques françaises		
-ft	Djibouti		
-gau	Georgia 	"Se ""xxu"" (Förenta staterna)"	
-gb	Kiribati		
-gd	Grenada		
-ge	Tyska Demokratiska Republiken 	T.o.m. 1990	
-gh	Ghana		
-gi	Gibraltar		
-gl	Grönland		
-gm	Gambia		
-gn	Gilbert- och Elliceöarna	"Före okt. 1978; använd ""gb"" (Kiribati)"	
-go	Gabon		
-gp	Guadeloupe		
-gr	Grekland		
-gs	Georgien		
-gsr	Georgiska SSR	"Före juni 1992; använd ""gs"" (Georgien)"	
-gt	Guatemala		
-gu	Guam		
-gv	Guinea		
-gw	Tyskland		
-gy	Guyana		
-gz	Gazaremsan		
-hiu	Hawaii 	"Se ""xxu"" (Förenta staterna)"	
-hk	Hongkong 	"Före okt. 1997; använd ""cc"" (Kina)"	cc
-hm	Heard- och McDonaldöarna		
-ho	Honduras		
-ht	Haiti		
-hu	Ungern		
-iau	Iowa 	"Se ""xxu"" (Förenta staterna)"	
-ic	Island		
-idu	Idaho 	"Se ""xxu"" (Förenta staterna)"	
-ie	Irland		
-ii	Indien		
-ilu	Illinois 	"Se ""xxu"" (Förenta staterna)"	
-inu	Indiana 	"Se ""xxu"" (Förenta staterna)"	
-io	Indonesien		
-iq	Irak		
-ir	Iran		
-is	Israel		
-it	Italien		
-iu	Israel-Syrien Demilitariserade zoner	"Före jan. 1978; använd ""is"" (Israel)"	is
-iv	Elfenbenskusten		
-iw	Israel-Jordanine demilitariserade zoner	"Före jan. 1978; använd ""is"" (Israel)"	is
-iy	Irak - Saudiarabien neutral zon 		
-ja	Japan		
-ji	Johnstonatollen		
-jm	Jamaica		
-jn	Jan Mayen	"Före mars 1988; använd ""no"" (Norge)"	no
-jo	Jordanien		
-ke	Kenya		
-kg	Kirgizistan		
-kgr	Kirgiziska SSR	"Före juni 1992: använd ""kg"" (Kirgizistan)"	kg
-kn	Nordkorea	Även Demokratiska Folkrepubliken Korea	
-ko	Sydkorea	Även Republiken Korea	
-ksu	Kansas 	"Se ""xxu"" (Förenta staterna)"	
-ku	Kuwait		
-kv	Kosovo		
-kyu	Kentucky 	"Se ""xxu"" (Förenta staterna)"	
-kz	Kazakstan	Även Kazachstan	
-kzr	Kazakiska SSR	"Före juni 1992; använd ""kz"" (Kazakstan)"	kz
-lau	Louisiana 	"Se ""xxu"" (Förenta staterna)"	
-lb	Liberia		
-le	Libanon		
-lh	Liechtenstein		
-li	Litauen		
-lir	Litauiska SSR	"Före juni 1992; använd ""li"" (Litauen)"	li
-ln	Mellersta och södra Line Islands	"Före okt. 1978; använd ""gb"" (Kiribati)"	gb
-lo	Lesotho		
-ls	Laos		
-lu	Luxemburg		
-lv	Lettland		
-lvr	Lettiska SSR	"För juni 1992;  använd ""lv"" (Lettland)"	lv
-ly	Libyen		
-mau	Massachusetts 	"Se ""xxu"" (Förenta staterna)"	
-mbc	Manitoba 	"Se ""xxc"" (Kanada)"	
-mc	Monaco		
-mdu	Maryland 	"Se ""xxu"" (Förenta staterna)"	
-meu	Maine 	"Se ""xxu"" (Förenta staterna)"	
-mf	Mauritius		
-mg	Madagaskar		
-mh	Macao 	"Före maj 2000; använd ""cc"" (Kina)"	cc
-miu	Michigan 	"Se ""xxu"" (Förenta staterna)"	
-mj	Montserrat		
-mk	Oman		
-ml	Mali		
-mm	Malta		
-mnu	Minnesota 	"Se ""xxu"" (Förenta staterna)"	
-mo	Montenegro		
-mou	Missouri 	"Se ""xxu"" (Förenta staterna)"	
-mp	Mongoliet		
-mq	Martinique		
-mr	Marocko		
-msu	Mississippi 	"Se ""xxu"" (Förenta staterna)"	
-mtu	Montana 	"Se ""xxu"" (Förenta staterna)"	
-mu	Mauretanien		
-mv	Moldavien		
-mvr	Moldaviska SSR	"Före juni 1992; använd ""mv"" (Moldavien)"	mv
-mw	Malawi		
-mx	Mexiko		
-my	Malaysia		
-mz	Moçambique		
-na	Nederländska Antillerna	Före dec. 2011	
-nbu	Nebraska 	"Se ""xxu"" (Förenta staterna)"	
-ncu	North Carolina 	"Se ""xxu"" (Förenta staterna)"	
-ndu	North Dakota 	"Se ""xxu"" (Förenta staterna)"	
-ne	Nederländerna		
-nfc	Newfoundland och Labrador 	"Se ""xxc"" (Kanada)"	
-ng	Niger		
-nhu	New Hampshire 	"Se ""xxu"" (Förenta staterna)"	
-nik	Nordirland 	"Se ""xxk"" (Storbritannien)"	
-nju	New Jersey 	"Se ""xxu"" (Förenta staterna)"	
-nkc	New Brunswick 	"Se ""xxc"" (Kanada)"	
-nl	Nya Caledonien		
-nw	Norra Marianerna	Även Northen Mariana Islands	
-nmu	New Mexico 	"Se ""xxu"" (Förenta staterna)"	
-nn	Vanuatu		
-no	Norge		
-np	Nepal		
-nq	Nicaragua		
-nr	Nigeria		
-nsc	Nova Scotia 	"Se ""xxc"" (Kanada)"	
-ntc	North West Territories 	"Se ""xxc"" (Kanada)"	
-nu	Nauru		
-nuc	Nunavut 	"Se ""xxc"" (Kanada)"	
-nvu	Nevada 	"Se ""xxu"" (Förenta staterna)"	
-nw	Nordmarianerna		
-nx	Norfolkön		
-nyu	New York 	"Se ""xxu"" (Förenta staterna)"	
-nz	Nya Zeeland		
-ohu	Ohio 	"Se ""xxu"" (Förenta staterna)"	
-oku	Oklahoma 	"Se ""xxu"" (Förenta staterna)"	
-onc	Ontario 	"Se ""xxc"" (Kanada)"	
-oru	Oregon 	"Se ""xxu"" (Förenta staterna)"	
-ot	Mayotte		
-pau	Pennsylvania 	"Se ""xxu"" (Förenta staterna)"	
-pc	Pitcairnöarna		
-pe	Peru		
-pf	Paracelöarna		
-pg	Guinea-Bissau		
-ph	Filippinerna		
-pic	Prince Edward Island 	"Se ""xxc"" (Kanada)"	
-pk	Pakistan		
-pl	Polen		
-pn	Panama		
-po	Portugal		
-pp	Papua Nya Guinea		
-pr	Puerto Rico		
-pt	Portugisiska Timor	"Före jan. 1978; använd ""io"" (Indonesien)"	io
-pw	Palau		
-py	Paraguay		
-qa	Qatar		
-qea	Queensland 	"Se ""at"" (Australien)"	
-quc	Quebec 	"Se ""xxc"" (Kanada)"	
-rb	Serbien		
-re	Réunion		
-rh	Zimbabwe		
-riu	Rhode Island 	"Se ""xxu"" (Förenta staterna)"	
-rm	Rumänien		
-ru	Ryssland		
-rur	Ryska SFSR	"Före juni 1992; använd ""ru"" (Ryssland)"	ru
-rw	Rwanda		
-ry	Södra Ryukyuöarna	"Före jan. 1978; använd ""ja"" (Japan)"	
-sa	Sydafrika		
-sb	Svalbard	Obsolet	
-sc	Saint-Barthélemy		
-scu	South Carolina 	"Se ""xxu"" (Förenta staterna)"	
-sd	Sydsudan		
-sdu	South Dakota 	"Se ""xxu"" (Förenta staterna)"	
-se	Seychellerna		
-sf	São Tomé och Principe		
-sg	Senegal		
-sh	Spanska Nordafrika		
-si	Singapore		
-sj	Sudan		
-sk	Sikkim	Obsolet	
-sl	Sierra Leone		
-sm	San Marino		
-sn	Sint Maarten		
-snc	Saskatchewan 	"Se ""xxc"" (Kanada)"	
-so	Somalia		
-sp	Spanien		
-sq	Swaziland		
-sr	Surinam		
-ss	Västra Sahara		
-st	Saint-Martin		
-stk	Skottland 	"Se ""xxk"" (Storbritannien)"	
-su	Saudiarabien		
-sv	Swan Islands	Obsolet	
-sw	Sverige		
-sx	Namibia		
-sy	Syrien		
-sz	Schweiz		
-ta	Tadzjikistan		
-tar	Tadzjikistan	"Obsolet; använd ""ta"" (Tadzjikistan)"	ta
-tc	Turks and Caicos Islands		
-tg	Togo		
-th	Thailand		
-ti	Tunisien		
-tk	Turkmenistan		
-tkr	Turkmenistan	"Obsolet; använd ""tk"" (Turkmenistan)"	tk
-tl	Tokelau		
-tma	Tasmanien 	"Se ""at"" (Australien)"	
-tnu	Tennessee 	"Se ""xxu"" (Förenta staterna)"	
-to	Tonga		
-tr	Trinidad och Tobago		
-ts	Förenade Arabemiraten		
-tt	Trust Territory of the Pacific Islands	Obsolet	
-tu	Turkiet		
-tv	Tuvalu		
-txu	Texas 	"Se ""xxu"" (Förenta staterna)"	
-tz	Tanzania		
-ua	Egypten		
-uc	Amerikanska öar i Karibiska havet		
-ug	Uganda		
-ui	Diverse brittiska öar 	"Obsolet; använd ""xxk"" (Storbritannien) eller ""uik"" (Diverse brittiska öar)"	uik
-uik	Diverse brittiska öar 	"Se ""xxk"" (Storbritannien)"	
-uk	Storbritannien	"Obsolet; använd ""xxk"" (Storbritannien)"	xxk
-un	Ukraina		
-unr	Ukraina	"Obsolet; använd ""un"" (Ukraina)"	un
-up	Amerikanska öar i Stilla havet		
-ur	Sovjetunionen 	"Före mars 1988; använd ""xxr"" (Sovjetunionen)"	xxr
-us	Förenta staterna	"Obsolet; använd ""xxu"" (Förenta staterna)"	xxu
-utu	Utah 	"Se ""xxu"" (Förenta staterna)"	
-uv	Burkina Faso		
-uy	Uruguay		
-uz	Uzbekistan		
-uzr	Uzbekistan	"Obsolet; använd ""uz"" (Uzbekistan)"	uz
-vau	Virginia 	"Se ""xxu"" (Förenta staterna)"	
-vb	Brittiska Jungfuöarna		
-vc	Vatikanstaten		
-ve	Venezuela		
-vi	Amerikanska Jungfruöarna		
-vm	Vietnam		
-vn	Nordvietnam	"Före jan. 1978; använd ""vm"" (Vietnam)"	vm
-vp	Utgivningsland varierar		
-vra	Victoria 	"Se ""at"" (Australien)"	
-vs	Sydvietnam	"Före jan. 1978; använd ""vm"" (Vietnam)"	vm
-vtu	Vermont 	"Se ""xxu"" (Förenta staterna)"	
-wau	Washington 	"Se ""xxu"" (Förenta staterna)"	
-wb	Västberlin	"Före jan. 1990; använd ""gw"" (Tyskland)"	gw
-wea	Western Australia 	"Se ""at"" (Australien)"	
-wf	Wallis och Futuna		
-wiu	Wisconsin 	"Se ""xxu"" (Förenta staterna)"	
-wj	Västbanken		
-wk	Wake		
-wlk	Wales 	"Se ""xxk"" (Storbritannien)"	
-ws	Samoa		
-wvu	West Virginia 	"Se ""xxu"" (Förenta staterna)"	
-wyu	Wyoming 	"Se ""xxu"" (Förenta staterna)"	
-xa	Julön 	Indiska oceanen	
-xb	Kokosöarna		
-xc	Maldiverna		
-xd	Saint Kitts och Nevis	Även Saint Christopher och Nevis	
-xe	Marshallöarna		
-xf	Midwayöarna		
-xga	Coral Sea Islands Territory 	"Se ""at"" (Australien)"	
-xh	Niue		
-xi	Saintt Kitts-Nevis-Anguilla	"Före jan. 1985; använd ""xd"" (Saint Kitts och Nevis) resp. ""am"" (Anguilla)"	
-xj	Sankta Helena	Även Saint Helena	
-xk	Saint Lucia		
-xl	Saint-Pierre och Miquelon		
-xm	Saint Vincent och Grenadinerna		
-xn	Makedonien		
-xna	New South Wales 	"Se ""at"" (Australien)"	
-xo	Slovakien		
-xoa	Northern Territory	"Se ""at"" (Australien)"	
-xp	Spratlyöarna	Även Nansha-öarna	
-xr	Tjeckien		
-xra	South Australia 	"Se ""at"" (Australien)"	
-xs	Sydgeorgien och Sydsandwichöarna		
-xv	Slovenien		
-xx	Utgivningsland okänt / Ej specificerat		
-xxc	Kanada		
-xxk	Storbritannien		
-xxr	Sovjetunionen 	"April 1988 - juni 1992; jfr ""ur"" (Sovjetunionen)"	
-xxu	Förenta staterna		
-ye	Jemen		
-ykc	Yukon Territory 	"Se ""xxc"" (Kanada)"	
-ys	Demokratiska Folkrepubliken Jemen 	T.o.m. 1990	
-yu	Serbien och Montenegro 	T.o.m. april 2007	
-za	Zambia		
+code	label_sv	comment_sv	map_to_code	wiki_uri	
+9a	Åland	Librisdefinierad kod		
+9p	Palestina	Librisdefinierad kod		
+aa	Albanien			http://www.wikidata.org/entity/Q222
+abc	Alberta 	"Se ""xxc"" (Kanada))"		http://www.wikidata.org/entity/Q1951
+ac	Ashmore and Cartier Islands	Obsolet		http://www.wikidata.org/entity/Q133888
+aca	Australian Capital Territory 	"Se ""at"" (Australien)"		http://www.wikidata.org/entity/Q3258
+ae	Algeriet			http://www.wikidata.org/entity/Q262
+af	Afghanistan			http://www.wikidata.org/entity/Q889
+ag	Argentina			http://www.wikidata.org/entity/Q414
+ai	Armenien			http://www.wikidata.org/entity/Q399
+air	Armeniska SSR	"Före juni 1992; använd ""ai"" (Armenien)"	ai	http://www.wikidata.org/entity/Q132856
+aj	Azerbajdzjan			http://www.wikidata.org/entity/Q227
+ajr	Azerbajdzjanska SSR	"Före juni 1992; använd ""aj"" (Azerbajdjan)"	aj	http://www.wikidata.org/entity/Q131337
+aku	Alaska 	"Se ""xxu"" (Förenta staterna)"		http://www.wikidata.org/entity/Q797
+alu	Alabama 	"Se ""xxu"" (Förenta staterna)"		http://www.wikidata.org/entity/Q173
+am	Anguilla			http://www.wikidata.org/entity/Q25228
+an	Andorra			http://www.wikidata.org/entity/Q228
+ao	Angola			http://www.wikidata.org/entity/Q916
+aq	Antigua och Barbuda			http://www.wikidata.org/entity/Q781
+aru	Arkansas 	"Se ""xxu"" (Förenta staterna)"		http://www.wikidata.org/entity/Q1612
+as	Amerikanska Samoa			http://www.wikidata.org/entity/Q16641
+at	Australien			http://www.wikidata.org/entity/Q408
+au	Österrike			http://www.wikidata.org/entity/Q40
+aw	Aruba			http://www.wikidata.org/entity/Q21203
+ay	Antarktis			http://www.wikidata.org/entity/Q51
+azu	Arizona 	"Se ""xxu"" (Förenta staterna)"		http://www.wikidata.org/entity/Q816
+ba	Bahrain			http://www.wikidata.org/entity/Q398
+bb	Barbados			http://www.wikidata.org/entity/Q244
+bcc	British Columbia 	"Se ""xxc"" (Se ""xxc"" (Kanada))"		http://www.wikidata.org/entity/Q1973
+bd	Burundi			http://www.wikidata.org/entity/Q967
+be	Belgien			http://www.wikidata.org/entity/Q31
+bf	Bahamas			http://www.wikidata.org/entity/Q778
+bg	Bangladesh			http://www.wikidata.org/entity/Q902
+bh	Belize			http://www.wikidata.org/entity/Q242
+bi	Brittiska territorier i Indiska oceanen			http://www.wikidata.org/entity/Q43448
+bl	Brasilien			http://www.wikidata.org/entity/Q155
+bm	Bermuda			http://www.wikidata.org/entity/Q23635
+bn	Bosnien-Hercegovina			http://www.wikidata.org/entity/Q225
+bo	Bolivia			http://www.wikidata.org/entity/Q750
+bp	Salomonöarna			http://www.wikidata.org/entity/Q685
+br	Burma			http://www.wikidata.org/entity/Q836
+bs	Botswana			http://www.wikidata.org/entity/Q963
+bt	Bhutan			http://www.wikidata.org/entity/Q917
+bu	Bulgarien			http://www.wikidata.org/entity/Q219
+bv	Bouvetön			http://www.wikidata.org/entity/Q23408
+bw	Vitryssland			http://www.wikidata.org/entity/Q184
+bwr	Vitryska SSR	"Före juni 1992; använd ""bw"" (Vitryssland)"	bw	http://www.wikidata.org/entity/Q2895
+bx	Brunei			http://www.wikidata.org/entity/Q921
+ca	Karibiska Nederländerna			http://www.wikidata.org/entity/Q27561
+cau	Kalifornien 	"Se ""xxu"" (Förenta staterna)"		http://www.wikidata.org/entity/Q99
+cb	Kambodja			http://www.wikidata.org/entity/Q424
+cc	Kina			http://www.wikidata.org/entity/Q29520
+cd	Tchad			http://www.wikidata.org/entity/Q657
+ce	Sri Lanka			http://www.wikidata.org/entity/Q854
+cf	Kongo-Brazzaville	Även Republiken Kongo		http://www.wikidata.org/entity/Q971
+cg	Kongo-Kinshasa	"Även Demokratiska Republiken Kongo; f.d. Zaire"		http://www.wikidata.org/entity/Q974
+ch	Taiwan 	"1949-; även Republiken Kina"		http://www.wikidata.org/entity/Q148
+ci	Kroatien			http://www.wikidata.org/entity/Q224
+cj	Caymanöarna			http://www.wikidata.org/entity/Q5785
+ck	Colombia			http://www.wikidata.org/entity/Q739
+cl	Chile			http://www.wikidata.org/entity/Q298
+cm	Kamerun			http://www.wikidata.org/entity/Q1009
+cn	Kanada	"Obsolet: använd ""xxc"" (Kanada)"	xxc	
+co	Curaçao			http://www.wikidata.org/entity/Q25279
+cou	Colorado 	"Se ""xxu"" (Förenta staterna)"		http://www.wikidata.org/entity/Q1261
+cp	Canton and Elderbury Islands	Obsolet		http://www.wikidata.org/entity/Q2618621
+cq	Comorerna			http://www.wikidata.org/entity/Q970
+cr	Costa Rica			http://www.wikidata.org/entity/Q800
+cs	Tjeckoslovakien 	"Före maj 1993; använd ""cx"" (Tjeckien) resp. ""xo"" (Slovakien)"		http://www.wikidata.org/entity/Q33946
+ctu	Connecticut 	"Se ""xxu"" (Förenta staterna)"		http://www.wikidata.org/entity/Q779
+cu	Kuba			http://www.wikidata.org/entity/Q241
+cv	Cap Verde			http://www.wikidata.org/entity/Q1011
+cw	Cooköarna			http://www.wikidata.org/entity/Q26988
+cx	Centralafrikanska republiken			http://www.wikidata.org/entity/Q929
+cy	Cypern			http://www.wikidata.org/entity/Q229
+cz	Canal Zone	"För jan. 1985; använd ""pn"" (Panama)"	pn	http://www.wikidata.org/entity/Q498979
+dcu	District of Columbia 	"Se ""xxu"" (Förenta staterna)"		http://www.wikidata.org/entity/Q3551781
+deu	Delaware 	"Se ""xxu"" (Förenta staterna)"		http://www.wikidata.org/entity/Q1393
+dk	Danmark			http://www.wikidata.org/entity/Q35
+dm	Benin			http://www.wikidata.org/entity/Q962
+dq	Dominica			http://www.wikidata.org/entity/Q784
+dr	Dominikanska republiken			http://www.wikidata.org/entity/Q786
+ea	Eritrea			http://www.wikidata.org/entity/Q986
+ec	Ecuador			http://www.wikidata.org/entity/Q736
+eg	Ekvatorialguinea			http://www.wikidata.org/entity/Q983
+em	Östtimor			http://www.wikidata.org/entity/Q574
+enk	England 	"Se ""xxk"" (Storbritannien)"		http://www.wikidata.org/entity/Q21
+er	Estland			http://www.wikidata.org/entity/Q191
+err	Estniska SSR	"Före okt. 1992; använd ""er"" (Estland)"	er	
+es	El Salvador			http://www.wikidata.org/entity/Q792
+et	Etiopien			http://www.wikidata.org/entity/Q115
+fa	Färöarna			http://www.wikidata.org/entity/Q4628
+fg	Franska Guyana			http://www.wikidata.org/entity/Q3769
+fi	Finland			http://www.wikidata.org/entity/Q33
+fj	Fiji			http://www.wikidata.org/entity/Q712
+fk	Falklandsöarna			http://www.wikidata.org/entity/Q9648
+flu	Florida 	"Se ""xxu"" (Förenta staterna)"		http://www.wikidata.org/entity/Q812
+fm	Mikronesiens federerade stater	Även Mikronesiska federationen		http://www.wikidata.org/entity/Q702
+fp	Franska Polynesien			http://www.wikidata.org/entity/Q30971
+fr	Frankrike			http://www.wikidata.org/entity/Q142
+fs	Terres australes et antarctiques françaises			http://www.wikidata.org/entity/Q129003
+ft	Djibouti			http://www.wikidata.org/entity/Q977
+gau	Georgia 	"Se ""xxu"" (Förenta staterna)"		http://www.wikidata.org/entity/Q1428
+gb	Kiribati			http://www.wikidata.org/entity/Q710
+gd	Grenada			http://www.wikidata.org/entity/Q769
+ge	Tyska Demokratiska Republiken 	T.o.m. 1990		http://www.wikidata.org/entity/Q16957
+gh	Ghana			http://www.wikidata.org/entity/Q117
+gi	Gibraltar			http://www.wikidata.org/entity/Q1410
+gl	Grönland			http://www.wikidata.org/entity/Q223
+gm	Gambia			http://www.wikidata.org/entity/Q1005
+gn	Gilbert- och Elliceöarna	"Före okt. 1978; använd ""gb"" (Kiribati)"		http://www.wikidata.org/entity/Q1050859
+go	Gabon			http://www.wikidata.org/entity/Q1000
+gp	Guadeloupe			http://www.wikidata.org/entity/Q17012
+gr	Grekland			http://www.wikidata.org/entity/Q41
+gs	Georgien			http://www.wikidata.org/entity/Q230
+gsr	Georgiska SSR	"Före juni 1992; använd ""gs"" (Georgien)"		http://www.wikidata.org/entity/Q130229
+gt	Guatemala			http://www.wikidata.org/entity/Q774
+gu	Guam			http://www.wikidata.org/entity/Q16635
+gv	Guinea			http://www.wikidata.org/entity/Q1006
+gw	Tyskland			http://www.wikidata.org/entity/Q183
+gy	Guyana			http://www.wikidata.org/entity/Q734
+gz	Gazaremsan			http://www.wikidata.org/entity/Q39760
+hiu	Hawaii 	"Se ""xxu"" (Förenta staterna)"		http://www.wikidata.org/entity/Q782
+hk	Hongkong 	"Före okt. 1997; använd ""cc"" (Kina)"	cc	http://www.wikidata.org/entity/Q8646
+hm	Heard- och McDonaldöarna			http://www.wikidata.org/entity/Q131198
+ho	Honduras			http://www.wikidata.org/entity/Q783
+ht	Haiti			http://www.wikidata.org/entity/Q790
+hu	Ungern			http://www.wikidata.org/entity/Q28
+iau	Iowa 	"Se ""xxu"" (Förenta staterna)"		http://www.wikidata.org/entity/Q1546
+ic	Island			http://www.wikidata.org/entity/Q189
+idu	Idaho 	"Se ""xxu"" (Förenta staterna)"		http://www.wikidata.org/entity/Q1221
+ie	Irland			http://www.wikidata.org/entity/Q27
+ii	Indien			http://www.wikidata.org/entity/Q668
+ilu	Illinois 	"Se ""xxu"" (Förenta staterna)"		http://www.wikidata.org/entity/Q1204
+inu	Indiana 	"Se ""xxu"" (Förenta staterna)"		http://www.wikidata.org/entity/Q1415
+io	Indonesien			http://www.wikidata.org/entity/Q252
+iq	Irak			http://www.wikidata.org/entity/Q796
+ir	Iran			http://www.wikidata.org/entity/Q794
+is	Israel			http://www.wikidata.org/entity/Q801
+it	Italien			http://www.wikidata.org/entity/Q38
+iu	Israel-Syrien Demilitariserade zoner	"Före jan. 1978; använd ""is"" (Israel)"	is	http://www.wikidata.org/entity/Q21586797
+iv	Elfenbenskusten			http://www.wikidata.org/entity/Q1008
+iw	Israel-Jordanine demilitariserade zoner	"Före jan. 1978; använd ""is"" (Israel)"	is	http://www.wikidata.org/entity/Q62590159
+iy	Irak - Saudiarabien neutral zon 			http://www.wikidata.org/entity/Q15710
+ja	Japan			http://www.wikidata.org/entity/Q17
+ji	Johnstonatollen			http://www.wikidata.org/entity/Q131008
+jm	Jamaica			http://www.wikidata.org/entity/Q766
+jn	Jan Mayen	"Före mars 1988; använd ""no"" (Norge)"	no	http://www.wikidata.org/entity/Q14056
+jo	Jordanien			http://www.wikidata.org/entity/Q810
+ke	Kenya			http://www.wikidata.org/entity/Q114
+kg	Kirgizistan			http://www.wikidata.org/entity/Q813
+kgr	Kirgiziska SSR	"Före juni 1992: använd ""kg"" (Kirgizistan)"	kg	http://www.wikidata.org/entity/Q130276
+kn	Nordkorea	Även Demokratiska Folkrepubliken Korea		http://www.wikidata.org/entity/Q423
+ko	Sydkorea	Även Republiken Korea		http://www.wikidata.org/entity/Q884
+ksu	Kansas 	"Se ""xxu"" (Förenta staterna)"		http://www.wikidata.org/entity/Q1558
+ku	Kuwait			http://www.wikidata.org/entity/Q817
+kv	Kosovo			http://www.wikidata.org/entity/Q1246
+kyu	Kentucky 	"Se ""xxu"" (Förenta staterna)"		http://www.wikidata.org/entity/Q1603
+kz	Kazakstan	Även Kazachstan		http://www.wikidata.org/entity/Q232
+kzr	Kazakiska SSR	"Före juni 1992; använd ""kz"" (Kazakstan)"	kz	http://www.wikidata.org/entity/Q168811
+lau	Louisiana 	"Se ""xxu"" (Förenta staterna)"		http://www.wikidata.org/entity/Q1588
+lb	Liberia			http://www.wikidata.org/entity/Q1014
+le	Libanon			http://www.wikidata.org/entity/Q822
+lh	Liechtenstein			http://www.wikidata.org/entity/Q347
+li	Litauen			http://www.wikidata.org/entity/Q37
+lir	Litauiska SSR	"Före juni 1992; använd ""li"" (Litauen)"	li	
+ln	Mellersta och södra Line Islands	"Före okt. 1978; använd ""gb"" (Kiribati)"	gb	http://www.wikidata.org/entity/Q62590188
+lo	Lesotho			http://www.wikidata.org/entity/Q1013
+ls	Laos			http://www.wikidata.org/entity/Q819
+lu	Luxemburg			http://www.wikidata.org/entity/Q32
+lv	Lettland			http://www.wikidata.org/entity/Q211
+lvr	Lettiska SSR	"För juni 1992;  använd ""lv"" (Lettland)"	lv	
+ly	Libyen			http://www.wikidata.org/entity/Q1016
+mau	Massachusetts 	"Se ""xxu"" (Förenta staterna)"		http://www.wikidata.org/entity/Q771
+mbc	Manitoba 	"Se ""xxc"" (Kanada)"		http://www.wikidata.org/entity/Q1948
+mc	Monaco			http://www.wikidata.org/entity/Q235
+mdu	Maryland 	"Se ""xxu"" (Förenta staterna)"		http://www.wikidata.org/entity/Q1391
+meu	Maine 	"Se ""xxu"" (Förenta staterna)"		http://www.wikidata.org/entity/Q724
+mf	Mauritius			http://www.wikidata.org/entity/Q1027
+mg	Madagaskar			http://www.wikidata.org/entity/Q1019
+mh	Macao 	"Före maj 2000; använd ""cc"" (Kina)"	cc	http://www.wikidata.org/entity/Q14773
+miu	Michigan 	"Se ""xxu"" (Förenta staterna)"		http://www.wikidata.org/entity/Q1166
+mj	Montserrat			http://www.wikidata.org/entity/Q13353
+mk	Oman			http://www.wikidata.org/entity/Q842
+ml	Mali			http://www.wikidata.org/entity/Q912
+mm	Malta			http://www.wikidata.org/entity/Q233
+mnu	Minnesota 	"Se ""xxu"" (Förenta staterna)"		http://www.wikidata.org/entity/Q1527
+mo	Montenegro			http://www.wikidata.org/entity/Q236
+mou	Missouri 	"Se ""xxu"" (Förenta staterna)"		http://www.wikidata.org/entity/Q1581
+mp	Mongoliet			http://www.wikidata.org/entity/Q711
+mq	Martinique			http://www.wikidata.org/entity/Q17054
+mr	Marocko			http://www.wikidata.org/entity/Q1028
+msu	Mississippi 	"Se ""xxu"" (Förenta staterna)"		http://www.wikidata.org/entity/Q1494
+mtu	Montana 	"Se ""xxu"" (Förenta staterna)"		http://www.wikidata.org/entity/Q1212
+mu	Mauretanien			http://www.wikidata.org/entity/Q1025
+mv	Moldavien			http://www.wikidata.org/entity/Q217
+mvr	Moldaviska SSR	"Före juni 1992; använd ""mv"" (Moldavien)"	mv	http://www.wikidata.org/entity/Q170895
+mw	Malawi			http://www.wikidata.org/entity/Q1020
+mx	Mexiko			http://www.wikidata.org/entity/Q96
+my	Malaysia			http://www.wikidata.org/entity/Q833
+mz	Moçambique			http://www.wikidata.org/entity/Q1029
+na	Nederländska Antillerna	Före dec. 2011		http://www.wikidata.org/entity/Q25227
+nbu	Nebraska 	"Se ""xxu"" (Förenta staterna)"		http://www.wikidata.org/entity/Q1553
+ncu	North Carolina 	"Se ""xxu"" (Förenta staterna)"		http://www.wikidata.org/entity/Q1454
+ndu	North Dakota 	"Se ""xxu"" (Förenta staterna)"		http://www.wikidata.org/entity/Q1207
+ne	Nederländerna			http://www.wikidata.org/entity/Q55
+nfc	Newfoundland och Labrador 	"Se ""xxc"" (Kanada)"		http://www.wikidata.org/entity/Q2003
+ng	Niger			http://www.wikidata.org/entity/Q1032
+nhu	New Hampshire 	"Se ""xxu"" (Förenta staterna)"		http://www.wikidata.org/entity/Q759
+nik	Nordirland 	"Se ""xxk"" (Storbritannien)"		http://www.wikidata.org/entity/Q26
+nju	New Jersey 	"Se ""xxu"" (Förenta staterna)"		http://www.wikidata.org/entity/Q1408
+nkc	New Brunswick 	"Se ""xxc"" (Kanada)"		http://www.wikidata.org/entity/Q1965
+nl	Nya Caledonien			http://www.wikidata.org/entity/Q33788
+nw	Norra Marianerna	Även Northen Mariana Islands		http://www.wikidata.org/entity/Q16644
+nmu	New Mexico 	"Se ""xxu"" (Förenta staterna)"		http://www.wikidata.org/entity/Q1522
+nn	Vanuatu			http://www.wikidata.org/entity/Q686
+no	Norge			http://www.wikidata.org/entity/Q20
+np	Nepal			http://www.wikidata.org/entity/Q837
+nq	Nicaragua			http://www.wikidata.org/entity/Q811
+nr	Nigeria			http://www.wikidata.org/entity/Q1033
+nsc	Nova Scotia 	"Se ""xxc"" (Kanada)"		http://www.wikidata.org/entity/Q1952
+ntc	North West Territories 	"Se ""xxc"" (Kanada)"		http://www.wikidata.org/entity/Q2007
+nu	Nauru			http://www.wikidata.org/entity/Q697
+nuc	Nunavut 	"Se ""xxc"" (Kanada)"		http://www.wikidata.org/entity/Q2023
+nvu	Nevada 	"Se ""xxu"" (Förenta staterna)"		http://www.wikidata.org/entity/Q1227
+nw	Nordmarianerna			http://www.wikidata.org/entity/Q16644
+nx	Norfolkön			http://www.wikidata.org/entity/Q31057
+nyu	New York 	"Se ""xxu"" (Förenta staterna)"		http://www.wikidata.org/entity/Q1384
+nz	Nya Zeeland			http://www.wikidata.org/entity/Q664
+ohu	Ohio 	"Se ""xxu"" (Förenta staterna)"		http://www.wikidata.org/entity/Q1397
+oku	Oklahoma 	"Se ""xxu"" (Förenta staterna)"		http://www.wikidata.org/entity/Q1649
+onc	Ontario 	"Se ""xxc"" (Kanada)"		http://www.wikidata.org/entity/Q1904
+oru	Oregon 	"Se ""xxu"" (Förenta staterna)"		http://www.wikidata.org/entity/Q824
+ot	Mayotte			http://www.wikidata.org/entity/Q17063
+pau	Pennsylvania 	"Se ""xxu"" (Förenta staterna)"		http://www.wikidata.org/entity/Q1400
+pc	Pitcairnöarna			http://www.wikidata.org/entity/Q1779748
+pe	Peru			http://www.wikidata.org/entity/Q419
+pf	Paracelöarna			http://www.wikidata.org/entity/Q274388
+pg	Guinea-Bissau			http://www.wikidata.org/entity/Q1007
+ph	Filippinerna			http://www.wikidata.org/entity/Q928
+pic	Prince Edward Island 	"Se ""xxc"" (Kanada)"		http://www.wikidata.org/entity/Q1978
+pk	Pakistan			http://www.wikidata.org/entity/Q843
+pl	Polen			http://www.wikidata.org/entity/Q36
+pn	Panama			http://www.wikidata.org/entity/Q804
+po	Portugal			http://www.wikidata.org/entity/Q45
+pp	Papua Nya Guinea			http://www.wikidata.org/entity/Q691
+pr	Puerto Rico			http://www.wikidata.org/entity/Q1183
+pt	Portugisiska Timor	"Före jan. 1978; använd ""io"" (Indonesien)"	io	http://www.wikidata.org/entity/Q142965
+pw	Palau			http://www.wikidata.org/entity/Q695
+py	Paraguay			http://www.wikidata.org/entity/Q733
+qa	Qatar			http://www.wikidata.org/entity/Q846
+qea	Queensland 	"Se ""at"" (Australien)"		http://www.wikidata.org/entity/Q36074
+quc	Quebec 	"Se ""xxc"" (Kanada)"		http://www.wikidata.org/entity/Q176
+rb	Serbien			http://www.wikidata.org/entity/Q403
+re	Réunion			http://www.wikidata.org/entity/Q17070
+rh	Zimbabwe			http://www.wikidata.org/entity/Q954
+riu	Rhode Island 	"Se ""xxu"" (Förenta staterna)"		http://www.wikidata.org/entity/Q1387
+rm	Rumänien			http://www.wikidata.org/entity/Q218
+ru	Ryssland			http://www.wikidata.org/entity/Q159
+rur	Ryska SFSR	"Före juni 1992; använd ""ru"" (Ryssland)"	ru	http://www.wikidata.org/entity/Q2184
+rw	Rwanda			http://www.wikidata.org/entity/Q1037
+ry	Södra Ryukyuöarna	"Före jan. 1978; använd ""ja"" (Japan)"		http://www.wikidata.org/entity/Q62590870
+sa	Sydafrika			http://www.wikidata.org/entity/Q258
+sb	Svalbard	Obsolet		http://www.wikidata.org/entity/Q25231
+sc	Saint-Barthélemy			http://www.wikidata.org/entity/Q25362
+scu	South Carolina 	"Se ""xxu"" (Förenta staterna)"		http://www.wikidata.org/entity/Q1456
+sd	Sydsudan			http://www.wikidata.org/entity/Q958
+sdu	South Dakota 	"Se ""xxu"" (Förenta staterna)"		http://www.wikidata.org/entity/Q1211
+se	Seychellerna			http://www.wikidata.org/entity/Q1042
+sf	São Tomé och Principe			http://www.wikidata.org/entity/Q1039
+sg	Senegal			http://www.wikidata.org/entity/Q1041
+sh	Spanska Nordafrika			http://www.wikidata.org/entity/Q191011
+si	Singapore			http://www.wikidata.org/entity/Q334
+sj	Sudan			http://www.wikidata.org/entity/Q1049
+sk	Sikkim	Obsolet		http://www.wikidata.org/entity/Q3960459
+sl	Sierra Leone			http://www.wikidata.org/entity/Q1044
+sm	San Marino			http://www.wikidata.org/entity/Q238
+sn	Sint Maarten			http://www.wikidata.org/entity/Q26273
+snc	Saskatchewan 	"Se ""xxc"" (Kanada)"		http://www.wikidata.org/entity/Q1989
+so	Somalia			http://www.wikidata.org/entity/Q1045
+sp	Spanien			http://www.wikidata.org/entity/Q29
+sq	Swaziland			http://www.wikidata.org/entity/Q1050
+sr	Surinam			http://www.wikidata.org/entity/Q730
+ss	Västra Sahara			http://www.wikidata.org/entity/Q6250
+st	Saint-Martin			http://www.wikidata.org/entity/Q126125
+stk	Skottland 	"Se ""xxk"" (Storbritannien)"		http://www.wikidata.org/entity/Q22
+su	Saudiarabien			http://www.wikidata.org/entity/Q851
+sv	Swan Islands	Obsolet		http://www.wikidata.org/entity/Q1547671
+sw	Sverige			http://www.wikidata.org/entity/Q34
+sx	Namibia			http://www.wikidata.org/entity/Q1030
+sy	Syrien			http://www.wikidata.org/entity/Q858
+sz	Schweiz			http://www.wikidata.org/entity/Q39
+ta	Tadzjikistan			http://www.wikidata.org/entity/Q863
+tar	Tadzjikistan	"Obsolet; använd ""ta"" (Tadzjikistan)"	ta	http://www.wikidata.org/entity/Q199711
+tc	Turks and Caicos Islands			http://www.wikidata.org/entity/Q18221
+tg	Togo			http://www.wikidata.org/entity/Q945
+th	Thailand			http://www.wikidata.org/entity/Q869
+ti	Tunisien			http://www.wikidata.org/entity/Q948
+tk	Turkmenistan			http://www.wikidata.org/entity/Q874
+tkr	Turkmenistan	"Obsolet; använd ""tk"" (Turkmenistan)"	tk	http://www.wikidata.org/entity/Q199707
+tl	Tokelau			http://www.wikidata.org/entity/Q36823
+tma	Tasmanien 	"Se ""at"" (Australien)"		http://www.wikidata.org/entity/Q34366
+tnu	Tennessee 	"Se ""xxu"" (Förenta staterna)"		http://www.wikidata.org/entity/Q1509
+to	Tonga			http://www.wikidata.org/entity/Q678
+tr	Trinidad och Tobago			http://www.wikidata.org/entity/Q754
+ts	Förenade Arabemiraten			http://www.wikidata.org/entity/Q878
+tt	Trust Territory of the Pacific Islands	Obsolet		http://www.wikidata.org/entity/Q129237
+tu	Turkiet			http://www.wikidata.org/entity/Q43
+tv	Tuvalu			http://www.wikidata.org/entity/Q672
+txu	Texas 	"Se ""xxu"" (Förenta staterna)"		http://www.wikidata.org/entity/Q1439
+tz	Tanzania			http://www.wikidata.org/entity/Q924
+ua	Egypten			http://www.wikidata.org/entity/Q79
+uc	Amerikanska öar i Karibiska havet			http://www.wikidata.org/entity/Q7890763
+ug	Uganda			http://www.wikidata.org/entity/Q1036
+ui	Diverse brittiska öar 	"Obsolet; använd ""xxk"" (Storbritannien) eller ""uik"" (Diverse brittiska öar)"	uik	
+uik	Diverse brittiska öar 	"Se ""xxk"" (Storbritannien)"		
+uk	Storbritannien	"Obsolet; använd ""xxk"" (Storbritannien)"	xxk	
+un	Ukraina			http://www.wikidata.org/entity/Q212
+unr	Ukraina	"Obsolet; använd ""un"" (Ukraina)"	un	
+up	Amerikanska öar i Stilla havet			http://www.wikidata.org/entity/Q3378903
+ur	Sovjetunionen 	"Före mars 1988; använd ""xxr"" (Sovjetunionen)"	xxr	http://www.wikidata.org/entity/Q15180
+us	Förenta staterna	"Obsolet; använd ""xxu"" (Förenta staterna)"	xxu	
+utu	Utah 	"Se ""xxu"" (Förenta staterna)"		http://www.wikidata.org/entity/Q829
+uv	Burkina Faso			http://www.wikidata.org/entity/Q965
+uy	Uruguay			http://www.wikidata.org/entity/Q77
+uz	Uzbekistan			http://www.wikidata.org/entity/Q265
+uzr	Uzbekistan	"Obsolet; använd ""uz"" (Uzbekistan)"	uz	http://www.wikidata.org/entity/Q484578
+vau	Virginia 	"Se ""xxu"" (Förenta staterna)"		http://www.wikidata.org/entity/Q1370
+vb	Brittiska Jungfuöarna			http://www.wikidata.org/entity/Q25305
+vc	Vatikanstaten			http://www.wikidata.org/entity/Q237
+ve	Venezuela			http://www.wikidata.org/entity/Q717
+vi	Amerikanska Jungfruöarna			http://www.wikidata.org/entity/Q11703
+vm	Vietnam			http://www.wikidata.org/entity/Q881
+vn	Nordvietnam	"Före jan. 1978; använd ""vm"" (Vietnam)"	vm	http://www.wikidata.org/entity/Q172640
+vp	Utgivningsland varierar			
+vra	Victoria 	"Se ""at"" (Australien)"		http://www.wikidata.org/entity/Q36687
+vs	Sydvietnam	"Före jan. 1978; använd ""vm"" (Vietnam)"	vm	http://www.wikidata.org/entity/Q180573
+vtu	Vermont 	"Se ""xxu"" (Förenta staterna)"		http://www.wikidata.org/entity/Q16551
+wau	Washington 	"Se ""xxu"" (Förenta staterna)"		http://www.wikidata.org/entity/Q1223
+wb	Västberlin	"Före jan. 1990; använd ""gw"" (Tyskland)"	gw	http://www.wikidata.org/entity/Q56036
+wea	Western Australia 	"Se ""at"" (Australien)"		http://www.wikidata.org/entity/Q3206
+wf	Wallis och Futuna			http://www.wikidata.org/entity/Q35555
+wiu	Wisconsin 	"Se ""xxu"" (Förenta staterna)"		http://www.wikidata.org/entity/Q1537
+wj	Västbanken			http://www.wikidata.org/entity/Q62590853
+wk	Wake			http://www.wikidata.org/entity/Q43296
+wlk	Wales 	"Se ""xxk"" (Storbritannien)"		http://www.wikidata.org/entity/Q25
+ws	Samoa			http://www.wikidata.org/entity/Q683
+wvu	West Virginia 	"Se ""xxu"" (Förenta staterna)"		http://www.wikidata.org/entity/Q1371
+wyu	Wyoming 	"Se ""xxu"" (Förenta staterna)"		http://www.wikidata.org/entity/Q1214
+xa	Julön 	Indiska oceanen		http://www.wikidata.org/entity/Q31063
+xb	Kokosöarna			http://www.wikidata.org/entity/Q36004
+xc	Maldiverna			http://www.wikidata.org/entity/Q826
+xd	Saint Kitts och Nevis	Även Saint Christopher och Nevis		http://www.wikidata.org/entity/Q763
+xe	Marshallöarna			http://www.wikidata.org/entity/Q709
+xf	Midwayöarna			http://www.wikidata.org/entity/Q47863
+xga	Coral Sea Islands Territory 	"Se ""at"" (Australien)"		http://www.wikidata.org/entity/Q172216
+xh	Niue			http://www.wikidata.org/entity/Q34020
+xi	Saintt Kitts-Nevis-Anguilla	"Före jan. 1985; använd ""xd"" (Saint Kitts och Nevis) resp. ""am"" (Anguilla)"		http://www.wikidata.org/entity/Q1637975
+xj	Sankta Helena	Även Saint Helena		http://www.wikidata.org/entity/Q34497
+xk	Saint Lucia			http://www.wikidata.org/entity/Q760
+xl	Saint-Pierre och Miquelon			http://www.wikidata.org/entity/Q34617
+xm	Saint Vincent och Grenadinerna			http://www.wikidata.org/entity/Q757
+xn	Makedonien			http://www.wikidata.org/entity/Q221
+xna	New South Wales 	"Se ""at"" (Australien)"		http://www.wikidata.org/entity/Q3224
+xo	Slovakien			http://www.wikidata.org/entity/Q214
+xoa	Northern Territory	"Se ""at"" (Australien)"		http://www.wikidata.org/entity/Q3235
+xp	Spratlyöarna	Även Nansha-öarna		http://www.wikidata.org/entity/Q3273381
+xr	Tjeckien			http://www.wikidata.org/entity/Q213
+xra	South Australia 	"Se ""at"" (Australien)"		http://www.wikidata.org/entity/Q35715
+xs	Sydgeorgien och Sydsandwichöarna			http://www.wikidata.org/entity/Q35086
+xv	Slovenien			http://www.wikidata.org/entity/Q215
+xx	Utgivningsland okänt / Ej specificerat			
+xxc	Kanada			http://www.wikidata.org/entity/Q16
+xxk	Storbritannien			http://www.wikidata.org/entity/Q145
+xxr	Sovjetunionen 	"April 1988 - juni 1992; jfr ""ur"" (Sovjetunionen)"		http://www.wikidata.org/entity/Q15180
+xxu	Förenta staterna			http://www.wikidata.org/entity/Q30
+ye	Jemen			http://www.wikidata.org/entity/Q805
+ykc	Yukon Territory 	"Se ""xxc"" (Kanada)"		http://www.wikidata.org/entity/Q2009
+ys	Demokratiska Folkrepubliken Jemen 	T.o.m. 1990		http://www.wikidata.org/entity/Q199841
+yu	Serbien och Montenegro 	T.o.m. april 2007		http://www.wikidata.org/entity/Q37024
+za	Zambia			http://www.wikidata.org/entity/Q953


### PR DESCRIPTION
Unless we want to get them live in datasets.py?




Get MARC country code to URI
```
PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
PREFIX wdt: <http://www.wikidata.org/prop/direct/>
SELECT (replace(?code, "countries/", "") as ?countryCode) ?idd {
  ?idd wdt:P4801 ?code ;
  FILTER(strstarts(?code, "countries/"))
}

> wiki-countries.tsv
```

Add to landskoder.tsv
```
awk -F$'\t' -v OFS='\t' '
NR==FNR {
  cc[$1] = $2
  next
}

{
  print $1,$2,$3,$4,cc[$1]
}
' wiki-countries.tsv landskoder.tsv > landskoder2.tsv
```