### PR TITLE
display: Add inverseOf/instanceOf to Work

### DIFF
--- a/source/vocab/display.jsonld
+++ b/source/vocab/display.jsonld
@@ -496,8 +496,9 @@
             "contentType",
             "illustrativeContent",
             "cartographicAttributes",
-            "isPartOf"
-           ]
+            "isPartOf",
+            {"inverseOf": "instanceOf"}
+          ]
         },
         "DataCatalog": {
           "@id": "DataCatalog-cards",


### PR DESCRIPTION
It works now (since a couple of versions) that `lddb__dependencies` keeps track of the full property path