### PR TITLE
Make exactMatch a owl:SymmetricProperty

### DIFF
--- a/source/vocab/concepts.ttl
+++ b/source/vocab/concepts.ttl
@@ -117,7 +117,7 @@
     owl:equivalentProperty skos:definition ;
     owl:equivalentProperty madsrdf:definitionNote .
 
-:exactMatch a owl:ObjectProperty ;
+:exactMatch a owl:SymmetricProperty ;
     :category :integral ;
     rdfs:label "exact match"@en, "exakt match"@sv ;
     sdo:domainIncludes :Identity ;


### PR DESCRIPTION
So that `followReverseBroader` in XL can follow it it both directions.
It is a symmetric property and is defined as such in skos.