### PR TITLE
Feature/identifiers exact match

### DIFF
--- a/source/vocab/details.ttl
+++ b/source/vocab/details.ttl
@@ -649,34 +649,42 @@
 
 :LibrisNumber a owl:Class;
     :category :pending ;
-    rdfs:label "Libris-nummer"@sv;
+    rdfs:label "Libris number"@en, "Libris-nummer"@sv ;
     rdfs:subClassOf :Identifier .
 
 :ORCID a owl:Class;
-    rdfs:label "ORCID";
-    rdfs:comment "Open Researcher and Contributor ID";
+    rdfs:label "ORCID" ;
+    rdfs:comment "Open Researcher and Contributor ID" ;
+    skos:exactMatch <http://www.wikidata.org/entity/Q51044> ;
     rdfs:subClassOf :Identifier .
 
 :PatentNumber a owl:Class;
     :category :pending ;
-    rdfs:label "Patentnummer"@sv;
+    rdfs:label "Patent number"@en, "Patentnummer"@sv ;
     rdfs:subClassOf :Identifier .
 
 :PMID a owl:Class;
     :category :pending ;
     rdfs:label "PMID";
     rdfs:comment "PubMed ID";
+    skos:exactMatch <http://www.wikidata.org/entity/Q2082879> ;
     rdfs:subClassOf :Identifier .
 
 :Ringgold a owl:Class;
     :category :pending ;
     rdfs:label "RIN";
     rdfs:comment "Ringgold ID";
+    skos:exactMatch <http://www.wikidata.org/entity/Q17016896> ;
     rdfs:subClassOf :Identifier .
 
 :ScopusID a owl:Class;
     :category :pending ;
     rdfs:label "Scopus ID";
+    # TODO: Define relationship narrowMatch to different ScopusIDs
+    # <http://id.loc.gov/vocabulary/identifiers/scopus> author
+    # <http://www.wikidata.org/entity/P1153> Scopus author ID
+    # <http://www.wikidata.org/entity/P1156> Scopus source ID
+    # <http://www.wikidata.org/entity/P1155> Scopus affiliation ID
     rdfs:subClassOf :Identifier.
 
 :SweCRIS a owl:Class;
@@ -687,17 +695,26 @@
 :URI a owl:Class;
     :category :pending ;
     rdfs:label "URI";
+    skos:notation "uri";
     rdfs:comment "Universal Resource Identifier";
+    skos:exactMatch <http://id.loc.gov/vocabulary/identifiers/uri>, <http://www.wikidata.org/entity/Q61694> ;
     rdfs:subClassOf :Identifier .
 
 :VIAF a owl:Class;
-    rdfs:comment "The Virtual International Authority File";
+    rdfs:comment "Virtual International Authority File";
     rdfs:label "VIAF";
+    skos:exactMatch <http://id.loc.gov/vocabulary/identifiers/viaf>, <http://www.wikidata.org/entity/Q19832964>;
+    skos:notation "viaf" ;
+    # rdfs:seeAlso <https://www.viaf.org> ; NOTE: or define base-uri for VIAF slugs?
     rdfs:subClassOf :Identifier.
 
 :WorldCatNumber a owl:Class;
     :category :pending ;
     rdfs:subClassOf :Identifier .
+    # TODO:
+    # define relationship to <http://www.wikidata.org/entity/P243> OCLC number,
+    # <http://www.wikidata.org/entity/P5505> WorldCat registry ID,
+    # <http://www.wikidata.org/entity/Q76630151> WorldCat identities
 ## }}}
 
 ##

--- a/source/vocab/details.ttl
+++ b/source/vocab/details.ttl
@@ -279,13 +279,16 @@
 :AccessionNumber a owl:Class;
     rdfs:label "Accession number"@en, "Accessionsnummer"@sv;
     rdfs:subClassOf :Identifier;
-    owl:equivalentClass bf2:AccessionNumber .
+    owl:equivalentClass bf2:AccessionNumber ;
+    skos:exactMatch <http://www.wikidata.org/entity/Q1417099> .
 
 :Ansi a owl:Class; # rdfs:Datatype ?
     rdfs:label "ANSI number"@en, "ANSI-nummer"@sv;
     rdfs:subClassOf :Identifier;
     rdfs:comment "American National Standards Institute";
     skos:definition "Identifikator utfärdat av den amerikanska standardiseringsorganisationen American National Standards Institute."@sv;
+    skos:exactMatch <http://id.loc.gov/vocabulary/identifiers/ansi> ;
+    skos:notation "ansi" ;
     owl:equivalentClass bf2:Ansi .
 
 :AudioIssueNumber a owl:Class; # rdfs:Datatype ?
@@ -330,6 +333,8 @@
     owl:equivalentClass bf2:Doi;
     rdfs:comment "Digital Object Identifier.";
     skos:definition "Internationell standard för identifikation av digitala objekt."@sv;
+    skos:exactMatch <http://id.loc.gov/vocabulary/identifiers/doi>, <http://www.wikidata.org/entity/Q25670> ;
+    skos:notation "doi" ;
     rdfs:subClassOf :Identifier;
     rdfs:label "DOI" .
 
@@ -338,6 +343,7 @@
     rdfs:subClassOf :Identifier;
     rdfs:comment "International Article Identifier (European Article Number).";
     skos:definition "Internationellt artikelnummer."@sv;
+    skos:exactMatch <http://www.wikidata.org/entity/Q357404> ;
     rdfs:label "EAN" .
 
 :EIDR a owl:Class;
@@ -345,7 +351,10 @@
     rdfs:subClassOf :Identifier;
     rdfs:label "EIDR";
     rdfs:comment "Entertainment Identifier Registry" ;
-    skos:definition "Universellt unikt identifieringssystem inom film, tv och radio."@sv .
+    #skos:broader :DOI ; ?
+    skos:definition "Universellt unikt identifieringssystem inom film, tv och radio."@sv ;
+    skos:exactMatch <http://id.loc.gov/vocabulary/identifiers/eidr> ;
+    skos:notation "eidr" .
 
 :Fingerprint a owl:Class; # rdfs:Datatype ?
     owl:equivalentClass bf2:Fingerprint;
@@ -358,26 +367,34 @@
     rdfs:subClassOf :Identifier;
     rdfs:comment "Global Trade Item Number 14.";
     skos:definition "14-siffrigt nummer tilldelat för identifikation av handelsartiklar."@sv;
+    skos:exactMatch <http://id.loc.gov/vocabulary/identifiers/gtin-14> ;
+    skos:notation "gtin-14" ;
     rdfs:label "GTIN-14" .
 
 :Hdl a owl:Class; # rdfs:Datatype ?
     owl:equivalentClass bf2:Hdl;
     rdfs:subClassOf :Identifier;
     skos:definition "Unik och persistent identifikator för digitala objekt utvecklad av Corporation for National Research Initiatives."@sv;
+    skos:exactMatch <http://id.loc.gov/vocabulary/identifiers/hdl> ;
+    skos:notation "hdl" ;
     rdfs:label "Handle" .
 
 :ISAN a owl:Class; # rdfs:Datatype ?
     owl:equivalentClass bf2:Isan;
     rdfs:comment "International Standard Audiovisual Number.";
     rdfs:subClassOf :Identifier;
-    rdfs:label "ISAN" .
+    rdfs:label "ISAN" ;
+    skos:definition "Identifikator för audiovisuella verk och versioner."@sv;
+    skos:exactMatch <http://id.loc.gov/vocabulary/identifiers/isan>, <http://www.wikidata.org/entity/Q1654582> ;
+    skos:notation "isan" .
 
 :ISBN a owl:Class; # rdfs:Datatype ?
     owl:equivalentClass bf2:Isbn;
     rdfs:subClassOf :Identifier;
     rdfs:comment "International Standard Book Number.";
     skos:definition "Internationellt system för identifikation av monografiska publikationer, till exempel böcker och kartor utgivna för allmän spridning."@sv;
-    rdfs:label "ISBN" .
+    skos:exactMatch <http://www.wikidata.org/entity/Q33057>, <http://id.loc.gov/vocabulary/identifiers/isbn> ;
+    rdfs:label "ISBN"@sv .
 
 :ISBN13 a owl:Class; # rdfs:Datatype ?
     :category :pending ;
@@ -390,25 +407,30 @@
     rdfs:comment "International Standard Music Number.";
     rdfs:subClassOf :Identifier;
     skos:definition "Internationellt system för identifikation av noterad musik."@sv;
-    rdfs:label "ISMN" .
+    skos:exactMatch <http://id.loc.gov/vocabulary/identifiers/ismn>, <http://www.wikidata.org/entity/Q1666938> ;
+    rdfs:label "ISMN"@sv .
 
 :ISNI a owl:Class; # rdfs:Datatype ?
     owl:equivalentClass bf2:Isni;
     rdfs:comment "International Standard Name Identifier.";
     rdfs:subClassOf :Identifier;
     skos:definition "Internationellt system för identifikation av medverkande till medieinnehåll som böcker, tv-program och tidningsartiklar."@sv;
+    skos:exactMatch <http://id.loc.gov/vocabulary/identifiers/isni>, <http://www.wikidata.org/entity/Q423048> ;
     rdfs:label "ISNI" .
 
 :ISO a owl:Class; # rdfs:Datatype ?
     owl:equivalentClass bf2:Iso;
     rdfs:comment "International Organization for Standardization standard number.";
     rdfs:subClassOf :Identifier;
-    rdfs:label "ISO" .
+    rdfs:label "ISO" ;
+    skos:exactMatch <http://id.loc.gov/vocabulary/identifiers/iso> ;
+    skos:notation "iso" .
 
 :ISRC a owl:Class; # rdfs:Datatype ?
     owl:equivalentClass bf2:Isrc;
     rdfs:comment "International Standard Recording Code.";
     skos:definition "Internationellt system för identifikation av ljudinspelningar och musikvideor."@sv;
+    skos:exactMatch <http://id.loc.gov/vocabulary/identifiers/isrc>, <http://www.wikidata.org/entity/Q1148336> ;
     rdfs:subClassOf :Identifier;
     rdfs:label "ISRC" .
 
@@ -417,25 +439,31 @@
     rdfs:subClassOf :Identifier;
     rdfs:comment "International Standard Serial Number.";
     skos:definition "Internationellt system för identifikation av seriella resurser såsom tidskrifter och dagstidningar."@sv;
-    rdfs:label "ISSN" .
+    skos:exactMatch <http://id.loc.gov/vocabulary/identifiers/issn>, <http://www.wikidata.org/entity/Q131276> ;
+    rdfs:label "ISSN"@sv .
 
 :ISSNL a owl:Class; # rdfs:Datatype ?
     owl:equivalentClass bf2:IssnL;
     rdfs:subClassOf :Identifier;
     skos:definition "ISSN för identifikation av seriella resurser med samma innehåll i olika medieversioner."@sv;
+    skos:exactMatch <http://id.loc.gov/vocabulary/identifiers/issn-l>, <http://www.wikidata.org/entity/Q24748985> ;
     rdfs:label "ISSN-L" .
 
 :ISTC a owl:Class; # rdfs:Datatype ?
     owl:equivalentClass bf2:Istc;
     rdfs:comment "International Standard Text Code.";
     skos:definition "Internationellt system för identifikation av textbaserade verk."@sv;
+    skos:exactMatch <http://id.loc.gov/vocabulary/identifiers/istc>, <http://www.wikidata.org/entity/Q1666944> ;
+    skos:notation "istc" ;
     rdfs:subClassOf :Identifier;
     rdfs:label "ISTC" .
 
 :ISWC a owl:Class; # rdfs:Datatype ?
     owl:equivalentClass bf2:Iswc;
     rdfs:comment "International Standard Musical Work Code.";
-    skos:definition "Internationellt system för identifikation av musikaliska verk."@av;
+    skos:definition "Internationellt system för identifikation av musikaliska verk."@sv;
+    skos:exactMatch <http://id.loc.gov/vocabulary/identifiers/iswc>, <http://www.wikidata.org/entity/Q949026> ;
+    skos:notation "iswc" ;
     rdfs:subClassOf :Identifier;
     rdfs:label "ISWC" .
 
@@ -443,7 +471,8 @@
     owl:equivalentClass bf2:Lccn;
     rdfs:subClassOf :Identifier;
     rdfs:comment "Library of Congress Control Number.";
-    rdfs:label "LCCN" .
+    rdfs:label "LCCN" ;
+    skos:exactMatch <http://id.loc.gov/vocabulary/identifiers/lccn>, <http://id.loc.gov/vocabulary/identifiers/lccn> .
 
 :LcOverseasAcq a owl:Class; # rdfs:Datatype ?
     rdfs:label "LC acquisition program"@en, "LC:s förvärvsprogram"@sv;
@@ -486,7 +515,9 @@
 :NBN a owl:Class; # rdfs:Datatype ?
     owl:equivalentClass bf2:Nbn;
     rdfs:subClassOf :Identifier;
-    rdfs:comment "National Bibliography Number."@en, "Nationalbibliografiskt nummer. (Används normalt ej i Libris)."@sv;
+    rdfs:comment "National Bibliography Number."@en, "Nationalbibliografiskt nummer."@sv;
+    skos:exactMatch <http://www.wikidata.org/entity/Q3873059> ;
+    skos:scopeNote "Används normalt ej i Libris"@sv ;
     rdfs:label "NBN" .
 
 :PostalRegistration a owl:Class; # rdfs:Datatype ?
@@ -509,7 +540,8 @@
     owl:equivalentClass bf2:Sici;
     rdfs:subClassOf :Identifier;
     rdfs:comment "Serial Item and Contribution Identifier.";
-    rdfs:label "SICI" .
+    rdfs:label "SICI" ;
+    skos:exactMatch <http://id.loc.gov/vocabulary/identifiers/sici>, <http://www.wikidata.org/entity/Q3479782> .
 
 :SMDBNumber a owl:Class ; # rdfs:Datatype ?
     rdfs:subClassOf :SystemNumber ;
@@ -547,7 +579,9 @@
     owl:equivalentClass bf2:Urn;
     rdfs:subClassOf :Identifier;
     rdfs:comment "Uniform Resource Name.";
-    rdfs:label "URN" .
+    rdfs:label "URN" ;
+    skos:exactMatch <http://id.loc.gov/vocabulary/identifiers/urn>, <http://www.wikidata.org/entity/Q76497> ;
+    skos:notation "urn" .
 
 :VideoRecordingNumber a owl:Class; # rdfs:Datatype ?
     rdfs:label "Video recording number"@en, "Utgivningsnummer (videoinspelning)"@sv;

--- a/source/vocab/details.ttl
+++ b/source/vocab/details.ttl
@@ -590,10 +590,10 @@
 
 :WikidataID a owl:Class;
     rdfs:label "Wikidata ID";
-    :code "wikidata";
-    :exactMatch <http://id.loc.gov/vocabulary/identifiers/wikidata>;
+    skos:notation "wikidata";
+    skos:exactMatch <http://id.loc.gov/vocabulary/identifiers/wikidata>;
     rdfs:subClassOf :Identifier;
-    rdfs:comment "Wikidata item." .
+    rdfs:comment "Wikidata item."@en, "Wikidata objekt."@sv .
 
 :ISO639-1 a rdfs:Datatype ;
     rdfs:label "ISO 639-1" ;


### PR DESCRIPTION
* Add exactMatch to [LC Standard Identifier Schemes](https://id.loc.gov/vocabulary/identifiers.html) members and wikidata Items for Identifiers in KBV.
* Also added notation to Identifier codes (also available from id.loc.gov) defined in marcframe for possibly more vocabulary-driven matching down the road .
* Some small cleanups and notes on further establishing pending Identifiers.