### PR TITLE
Add matchesTransitive, used internally for search

### DIFF
--- a/source/vocab/concepts.ttl
+++ b/source/vocab/concepts.ttl
@@ -30,7 +30,7 @@
     rdfs:label "located in"@en, "ligger i"@sv;
     sdo:domainIncludes :Place ;
     rdfs:range :Place ;
-    rdfs:subPropertyOf :isPartOf ;
+    rdfs:subPropertyOf :isPartOf, :matchesTransitive ;
     skos:closeMatch sdo:location .
 
 :Event a owl:Class;
@@ -89,11 +89,32 @@
     :category :heuristicIdentifier ;
     owl:equivalentProperty skos:altLabel .
 
+:matchesTransitive a owl:TransitiveProperty ;
+    ptg:abstract true ;
+    rdfs:label "matches transitive"@en, "matchar transitivt"@sv ;
+    skos:scopeNote "Beräknad egenskap för sökningar och navigering. Används inte direkt."@sv, "Computed property for search and navigation. Not to be used directly."@en ;
+    skos:definition "Inferred generalized likeness of any valuable kind. Conceptually a superproperty of equivalence and even identity."@en .
+
+:broaderTransitive a owl:TransitiveProperty ;
+    ptg:abstract true ;
+    rdfs:label "broader transitive"@en, "transitivt bredare"@sv;
+    rdfs:subPropertyOf :matchesTransitive ;
+    #owl:inverseOf :narrowerTransitive;
+    owl:equivalentProperty skos:broaderTransitive .
+
+# NOTE: No need for this at the moment.
+#:narrowerTransitive a owl:TransitiveProperty ;
+#    ptg:abstract true ;
+#    rdfs:label "narrower transitive"@en, "transitivt smalare"@sv;
+#    owl:inverseOf :broaderTransitive;
+#    owl:equivalentProperty skos:narrowerTransitive .
+
 :broader a owl:ObjectProperty;
     rdfs:label "broader"@en, "bredare"@sv;
     sdo:domainIncludes :Concept ;
     owl:inverseOf :narrower;
     rdfs:range :Concept ;
+    rdfs:subPropertyOf :broaderTransitive ;
     owl:equivalentProperty skos:broader ;
     owl:equivalentProperty madsrdf:hasBroaderAuthority .
 
@@ -101,6 +122,7 @@
     rdfs:label "broader match"@en, "bredare match"@sv;
     sdo:domainIncludes :Identity ;
     rdfs:range :Concept ;
+    rdfs:subPropertyOf :broader ;
     owl:equivalentProperty skos:broadMatch ;
     owl:equivalentProperty madsrdf:hasBroaderExternalAuthority .
 
@@ -108,22 +130,24 @@
     rdfs:label "close match"@en, "nära match"@sv;
     sdo:domainIncludes :Identity ;
     rdfs:range :Concept ;
+    rdfs:subPropertyOf :matchesTransitive ;
     owl:equivalentProperty skos:closeMatch ;
     owl:equivalentProperty madsrdf:hasCloseExternalAuthority .
-
-:definition a owl:DatatypeProperty;
-    rdfs:label "definition"@en, "definition"@sv ;
-    sdo:domainIncludes :Concept ;
-    owl:equivalentProperty skos:definition ;
-    owl:equivalentProperty madsrdf:definitionNote .
 
 :exactMatch a owl:ObjectProperty ;
     :category :integral ;
     rdfs:label "exact match"@en, "exakt match"@sv ;
     sdo:domainIncludes :Identity ;
     sdo:rangeIncludes :Agent, :Concept ;
+    rdfs:subPropertyOf :closeMatch ;
     owl:equivalentProperty skos:exactMatch ;
     owl:equivalentProperty madsrdf:hasExactExternalAuthority .
+
+:definition a owl:DatatypeProperty;
+    rdfs:label "definition"@en, "definition"@sv ;
+    sdo:domainIncludes :Concept ;
+    owl:equivalentProperty skos:definition ;
+    owl:equivalentProperty madsrdf:definitionNote .
 
 :example a owl:DatatypeProperty;
     rdfs:label "example"@en, "exempel"@sv ;


### PR DESCRIPTION
The new `matchesTransitive` is to be used in search results to indicate the computed, indirect match.  It is based on the application pattern (and logical definition) of [`skos:broaderTransitive`](https://www.w3.org/TR/2009/NOTE-skos-primer-20090818/#sectransitivebroader).

## Illustration

This represents the deduction used by the search to find matching terms, which have a logical (inferred) `matchesTransitive` property linking to the searched for term.

Given the query:
```sparql
?s :instanceOf/:genreForm/:matchesTransitive* <Fiction> .
```

This would match:
```turtle
<x> :instanceOf [ :genreForm <Urban+Fantasy> ] .
```

Given that:
```turtle
<Urban+Fantasy> :broader <Fantasy> .
<Fantasy> :broader <Fiction> .

:broader :subPropertyOf :matchesTransitive .
```

Which implies:
```turtle
<Urban+Fantasy> :matchesTransitive <Fiction> .
```

Thus matching the query.