### PR TITLE
Regular fixes and alignments

### DIFF
--- a/source/vocab/base.ttl
+++ b/source/vocab/base.ttl
@@ -31,7 +31,11 @@
     owl:imports dc:, dctype:, skos:, prov:, foaf:, bibo:, sdo:, bf2:, bflc: ;
     skos:hasTopConcept :Instance, :Work, :Item, :Agent, :IndexTerm .
 
-# Various sources beyond the linked defintions themselves:
+
+##
+# Local Definitions Of Core Vocabulary Components
+##
+# TODO: just use context aliases, and add these labels in <external-labels.ttl>?
 
 rdf:type a owl:ObjectProperty;
     rdfs:label "type"@en, "typ"@sv .
@@ -65,6 +69,9 @@ rdf:type a owl:ObjectProperty;
 :Datatype a owl:Class;
     owl:equivalentClass rdfs:Datatype;
     rdfs:label "Data type"@en, "Datatyp"@sv .
+
+##
+# Extended Vocabulary Components
 
 :StructuredProperty a owl:Class;
     rdfs:subPropertyOf owl:ObjectProperty;
@@ -106,9 +113,7 @@ rdf:type a owl:ObjectProperty;
 
 
 ##
-# Common Properties
-
-# .. use rdfs:range rdf:langString where applicable?
+# Categorization Of Terms
 
 :category a owl:ObjectProperty;
     rdfs:label "category"@en, "kategori"@sv;
@@ -162,6 +167,11 @@ rdf:type a owl:ObjectProperty;
     skos:example "instanceOf, translationOf, locatedIn"@sv ;
     skos:scopeNote "Används i XL för att presentera relaterade resurser tillsammans med huvudsaklig resurs."@sv ;
     :code "integral" .
+
+
+##
+# Common Properties
+# .. use rdfs:range rdf:langString where applicable?
 
 :label a owl:DatatypeProperty;
     rdfs:label "label"@en, "benämning"@sv;

--- a/source/vocab/base.ttl
+++ b/source/vocab/base.ttl
@@ -45,8 +45,11 @@ rdf:type a owl:ObjectProperty;
     rdfs:label "Resurs"@sv, "Resource"@en;
     skos:altLabel "Entitet"@sv, "Entity"@en .
 
-##
-# Extended Vocabulary Components
+:Ontology a owl:Class ;
+    owl:equivalentClass owl:Ontology ;
+    rdfs:subClassOf :Resource;
+    rdfs:label "Ontologi"@sv, "Ontology"@en ;
+    skos:altLabel "Vokabulär"@sv, "Vocabulary"@en .
 
 :Class a owl:Class;
     owl:equivalentClass owl:Class;
@@ -55,6 +58,14 @@ rdf:type a owl:ObjectProperty;
 :ObjectProperty a owl:Class;
     owl:equivalentClass owl:ObjectProperty;
     rdfs:label "Object property"@en, "Relation"@sv .
+
+:FunctionalProperty a owl:Class;
+    owl:equivalentClass owl:FunctionalProperty;
+    rdfs:label "Functional property"@en, "Funktionell egenskap"@sv .
+
+:TransitiveProperty a owl:Class;
+    owl:equivalentClass owl:TransitiveProperty;
+    rdfs:label "Transitive property"@en, "Transitiv egenskap"@sv .
 
 :SymmetricProperty a owl:Class;
     owl:equivalentClass owl:SymmetricProperty;

--- a/source/vocab/relations.ttl
+++ b/source/vocab/relations.ttl
@@ -28,7 +28,9 @@ prefix relsubtype: <http://id.loc.gov/vocabulary/preservation/relationshipSubTyp
 :versionOf a owl:ObjectProperty;
     ptg:abstract true;
     rdfs:label "version av"@sv;
-    owl:equivalentProperty dc:isVersionOf .
+    owl:equivalentProperty dc:isVersionOf ;
+    owl:inverseOf :hasVersion;
+    rdfs:subPropertyOf :relatedTo .
 
 :hasVersion a owl:ObjectProperty;
     ptg:abstract true;
@@ -36,17 +38,18 @@ prefix relsubtype: <http://id.loc.gov/vocabulary/preservation/relationshipSubTyp
     rdfs:range :Endeavour;
     rdfs:label "har version"@sv;
     owl:equivalentProperty dc:hasVersion;
-    rdfs:subPropertyOf sdo:exampleOfWork .
+    owl:inverseOf :versionOf;
+    rdfs:subPropertyOf :relatedTo, sdo:exampleOfWork .
 
 :hasDerivative a owl:ObjectProperty;
     rdfs:label "har bearbetning"@sv;
-    rdfs:subPropertyOf :relatedTo;
+    rdfs:subPropertyOf :hasVersion;
     owl:inverseOf :derivativeOf;
     owl:equivalentProperty bf2:hasDerivative .
 
 :derivativeOf a owl:ObjectProperty;
     rdfs:label "är bearbetning av"@sv;
-    rdfs:subPropertyOf :relatedTo;
+    rdfs:subPropertyOf :versionOf;
     owl:inverseOf :hasDerivative;
     owl:equivalentProperty bf2:derivativeOf .
 

--- a/sys/context/base.jsonld
+++ b/sys/context/base.jsonld
@@ -64,12 +64,6 @@
     "CarrierType": "http://id.loc.gov/ontologies/bibframe/Carrier",
     "IssuanceType": "http://id.loc.gov/ontologies/bibframe/Issuance",
 
-    "langTag": {"@id": "code", "@type": "ISO639-1"},
-    "langCode": {"@id": "code", "@type": "ISO639-2"},
-    "langCodeBib": {"@id": "code", "@type": "ISO639-2-B"},
-    "langCodeTerm": {"@id": "code", "@type": "ISO639-2-T"},
-    "langCodeFull": {"@id": "code", "@type": "ISO639-3"},
-
     "isMemberOfRelation": {"@type": "@vocab"},
     "memberClass": {"@type": "@vocab", "@container": "@set"},
     "slugProperty": {"@type": "@vocab"},

--- a/sys/context/shared.jsonld
+++ b/sys/context/shared.jsonld
@@ -15,6 +15,7 @@
     "ObjectProperty": "owl:ObjectProperty",
     "DatatypeProperty": "owl:DatatypeProperty",
     "FunctionalProperty": "owl:FunctionalProperty",
+    "TransitiveProperty": "owl:TransitiveProperty",
     "Restriction": "owl:Restriction",
 
     "subClassOf": {"@id": "rdfs:subClassOf", "@container": "@set"},

--- a/sys/context/shared.jsonld
+++ b/sys/context/shared.jsonld
@@ -50,6 +50,12 @@
     "scopeNoteByLang": {"@id": "scopeNote", "@container": "@language"},
     "changeNoteByLang": {"@id": "changeNote", "@container": "@language"},
     "titleByLang": {"@id": "title", "@container": "@language"},
-    "descriptionByLang": {"@id": "description", "@container": "@language"}
+    "descriptionByLang": {"@id": "description", "@container": "@language"},
+
+    "langTag": {"@id": "code", "@type": "ISO639-1"},
+    "langCode": {"@id": "code", "@type": "ISO639-2"},
+    "langCodeBib": {"@id": "code", "@type": "ISO639-2-B"},
+    "langCodeTerm": {"@id": "code", "@type": "ISO639-2-T"},
+    "langCodeFull": {"@id": "code", "@type": "ISO639-3"}
   }
 }


### PR DESCRIPTION
Including:
* Moving language code shorthands from the base context to the shared context. (So these appear as just `:code` with a datatype  in e.g. Turtle.)
* Add some ontology terms (for the vocab view, to be tested)
* Ontology alignment of bf:versionOf and bf:derivativeOf (and their inverses)

See individual commits for details.
