### PR TITLE
Feature/caching sparql

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ data used by the National Library of Sweden.
 
 ## Dependencies
 
-Requires Python 3.6+. (Use PyPy for a general speed improvement.)
+Requires Python 3.7+. (Use PyPy for a general speed improvement.)
 
 Preferably set up a virtualenv:
 

--- a/datasets.py
+++ b/datasets.py
@@ -224,6 +224,10 @@ def materialterms():
         },
         {
             "source": "http://rdaregistry.info/termList/RDAMaterial.nt"
+        },
+        {
+            "source": "sparql/aat-materials",
+            "construct": "source/remote/construct-aat-materials.rq",
         }
     ],
         query="source/construct-material-terms.rq")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 pyparsing==2.4.2 # rdflib 4.2.2 pulls in a unspecified version which fails for pyparsing > 3.0.0
-rdflib==4.2.2
-rdflib-jsonld==0.5
+rdflib==6.1.1
 Markdown==3.1.1

--- a/source/construct-material-terms.rq
+++ b/source/construct-material-terms.rq
@@ -6,11 +6,18 @@ construct {
         skos:definition ?definition .
 } where {
     graph <https://id.kb.se/dataset/materialterms> {
-        ?s ?p ?o ; skos:exactMatch ?rda .
-        optional {
+        {
+            ?s ?p ?o .
+        } union {
+            ?s skos:exactMatch ?rda .
             graph <http://rdaregistry.info/termList/RDAMaterial.nt> {
                 ?rda skos:prefLabel ?prefLabel ;
                     skos:definition ?definition .
+            }
+        } union {
+            ?s skos:exactMatch ?aat .
+            graph <sparql/aat-materials> {
+                ?aat skos:prefLabel ?prefLabel .
             }
         }
     }

--- a/source/remote/construct-aat-materials.rq
+++ b/source/remote/construct-aat-materials.rq
@@ -1,0 +1,13 @@
+prefix aat: <http://vocab.getty.edu/aat/>
+prefix gvp: <http://vocab.getty.edu/ontology#>
+prefix skos: <http://www.w3.org/2004/02/skos/core#>
+
+construct {
+    ?material skos:prefLabel ?prefLabel
+} where {
+    service <http://vocab.getty.edu/sparql> {
+        values ?hierarchy { aat:300010357 aat:300168215 }
+        ?material gvp:broaderExtended ?hierarchy ;
+            skos:prefLabel ?prefLabel .
+    }
+}


### PR DESCRIPTION
The changes in `datacompiler.py` makes it possible to send a construct query to a sparql endpoint and cache the result as a Turtle document. I think we should have this functionality since ready-made, well defined RDF documents aren't always available for download. In some cases external definitions can instead be retrieved via a sparql endpoint, however we wouldn't want to do that live every time we build the definitions, hence the cache. 

The other changes are to show how this feature can be used; AAT prefLabels are retrieved via http://vocab.getty.edu/sparql, cached and then added to the material terms. The current solution is not optimal as `construct-material-terms.rq` now adds all prefLabels from _both_ RDA and AAT which creates duplicates for some languages. I think we rather just want to complement with prefLabels from AAT when there are none from RDA. This should achievable by rewriting the construct in some clever way (I've tried really hard already but gave up in the end :smile:)

Remote querying requires the latest rdflib version which in turn requires Python 3.7. Could this be a problem?
