### PR TITLE
Define alternate contexts

### DIFF
--- a/sys/context/kbv.jsonld
+++ b/sys/context/kbv.jsonld
@@ -9,7 +9,8 @@
     "recordStatus": {"@type": "@vocab"},
     "encodingLevel": {"@type": "@vocab"},
     "shelfMarkStatus": {"@type": "@vocab"},
-    "dimension": {"@type": "@vocab"},
+    "dimensionChain": {"@id": "dimension", "@type": "@vocab", "@container": "@list"},
+    "inverseOfTerm": {"@id": "owl:inverseOf", "@type": "@vocab"},
 
     "birthYear": {"@id": "birthDate", "@type": "Year"},
     "deathYear": {"@id": "deathDate", "@type": "Year"},


### PR DESCRIPTION
Includes setting the default context id as alias on KBV context.

It is necessary to merge this *after* https://github.com/libris/librisxl/pull/1100
