### PR TITLE
Add isIssueOf to instance cards

### DIFF
--- a/source/vocab/display.jsonld
+++ b/source/vocab/display.jsonld
@@ -486,6 +486,7 @@
             "associatedMedia",
             "usageAndAccessPolicy",
             "accessMode",
+            "isIssueOf",
             "relatedTo",
             {"inverseOf": "itemOf"},
             {"inverseOf": "reproductionOf"},


### PR DESCRIPTION
Note that we can merge this as is (it's technically as simple as it gets). But there is a caveat: we *might* still want to revise this property (as in even replacing it with a more general one) if we want close alignment to BF (pending a resolution to lcnetdev/bibframe-ontology#88). But only unless use of `kbv:isIssueOf` in the newspaper applications *isn't feature frozen*. If so we have to maintain it (including, in theory, infer if from more general ones if we'd ever want that application to be able to utilize descriptions from other, less specific sources than those we currently *remap* to use this specific property).