### PR TITLE
Display: Prefer KeyTitle and Title in Work/Instance hasTitle

### DIFF
--- a/source/vocab/display.jsonld
+++ b/source/vocab/display.jsonld
@@ -120,7 +120,14 @@
           "@type": "fresnel:Lens",
           "classLensDomain": "Instance",
           "showProperties": [
-            {"alternateProperties": [ "hasTitle", "identifiedBy" ]},
+            {
+              "alternateProperties": [
+                {"subPropertyOf": "hasTitle", "range": "KeyTitle"},
+                {"subPropertyOf": "hasTitle", "range": "Title"},
+                "hasTitle",
+                "identifiedBy"
+              ]
+            },
             "provisionActivity"
           ]
         },
@@ -128,7 +135,20 @@
           "@id": "Work-chips",
           "@type": "fresnel:Lens",
           "classLensDomain": "Work",
-          "showProperties": [ "hasTitle", "legalDate", "language", "marc:version", "version", "originDate" ]
+          "showProperties": [
+            {
+              "alternateProperties": [
+                {"subPropertyOf": "hasTitle", "range": "KeyTitle"},
+                {"subPropertyOf": "hasTitle", "range": "Title"},
+                "hasTitle"
+              ]
+            },
+            "legalDate",
+            "language",
+            "marc:version",
+            "version",
+            "originDate"
+          ]
         },
         "DataCatalog": {
           "@id": "DataCatalog-chips",
@@ -456,7 +476,13 @@
             "issuanceType",
             "mediaType",
             "carrierType",
-            "hasTitle",
+            {
+              "alternateProperties": [
+                {"subPropertyOf": "hasTitle", "range": "KeyTitle"},
+                {"subPropertyOf": "hasTitle", "range": "Title"},
+                "hasTitle"
+              ]
+            },
             "instanceOf",
             "responsibilityStatement",
             "editionStatement",
@@ -498,7 +524,13 @@
           "@id": "Work-cards",
           "classLensDomain": "Work",
           "showProperties": [
-            "hasTitle",
+            {
+              "alternateProperties": [
+                {"subPropertyOf": "hasTitle", "range": "KeyTitle"},
+                {"subPropertyOf": "hasTitle", "range": "Title"},
+                "hasTitle"
+              ]
+            },
             "marc:version",
             "version",
             "translationOf",

--- a/source/vocab/display.jsonld
+++ b/source/vocab/display.jsonld
@@ -56,6 +56,13 @@
           "showProperties": [
             "prefLabel"
           ]
+        },
+        "PrimaryContribution": {
+          "@type": "fresnel:Lens",
+          "classLensDomain": "PrimaryContribution",
+          "showProperties": [
+            "agent"
+          ]
         }
       }
     },
@@ -145,6 +152,11 @@
             },
             "legalDate",
             "language",
+            {
+              "alternateProperties": [
+                {"subPropertyOf": "contribution", "range": "PrimaryContribution"}
+              ]
+            },
             "marc:version",
             "version",
             "originDate"


### PR DESCRIPTION
* Pick `KeyTitle` over `Title` over any `hasTitle` in cards and chips for `Instance` and `Work`.
* Display PrimaryContribution in Work chips

Depends on support for smarter `alternateProperties` in [lxlviewer](https://github.com/libris/lxlviewer/pull/813) and [librisxl](https://github.com/libris/librisxl/pull/1145).

Note that the title rule doesn't actually work if `range` is implemented correctly since it would match all subclasses, for example `:VariantTitle rdfs:subClassOf :Title`. 
Update: We decided to stick with the "broken" implementation since it matches out use cases.

