### PR TITLE
Add more ByLang property variants

### DIFF
--- a/sys/context/shared.jsonld
+++ b/sys/context/shared.jsonld
@@ -60,6 +60,21 @@
     "titleByLang": {"@id": "title", "@container": "@language"},
     "descriptionByLang": {"@id": "description", "@container": "@language"},
 
+    "mainTitleByLang": {"@id": "mainTitle", "@container": "@language"},
+    "subtitleByLang": {"@id": "subtitle", "@container": "@language"},
+    "titleRemainderByLang": {"@id": "titleRemainder", "@container": "@language"},
+    "partNumberByLang": {"@id": "partNumber", "@container": "@language"},
+    "partNameByLang": {"@id": "partName", "@container": "@language"},
+    "responsibilityStatementByLang": {"@id": "responsibilityStatement", "@container": "@language"},
+    "editionStatementByLang": {"@id": "editionStatement", "@container": "@language"},
+    "seriesStatementByLang": {"@id": "seriesStatement", "@container": "@language"},
+    "seriesEnumerationByLang": {"@id": "seriesEnumeration", "@container": "@language"},
+
+    "familyNameByLang": {"@id": "familyName", "@container": "@language"},
+    "givenNameByLang": {"@id": "givenName", "@container": "@language"},
+    "nameByLang": {"@id": "name", "@container": "@language"},
+    "lifeSpanByLang": {"@id": "lifeSpan", "@container": "@language"},
+
     "langTag": {"@id": "code", "@type": "ISO639-1"},
     "langCode": {"@id": "code", "@type": "ISO639-2"},
     "langCodeBib": {"@id": "code", "@type": "ISO639-2-B"},


### PR DESCRIPTION
Chosen from the most common transliterated properties (see bib 880).

Note that these where based on statistics from 2020-05, so if you know of some big cleanup involving removal of any of these (making them superfluous) we can skip those.

Remaining common ones (more than 100) from those statistics are:
- 1015 issuanceTypeByLang - something's obviously wrong here...

Still in the running for making it to the final cut:
- 484 codeByLang
- 809 dateByLang
- 284 yearByLang

Legacy properties which we need to *remove or replace*, not *increase* dependence upon: 
- 487 marc:subordinateUnitByLang
- 377 marc:nonfilingCharsByLang
- 348 marc:seriesTracingPolicyByLang
- 313 marc:otherPhysicalDetailsByLang
- 164 marc:parallelTitleByLang
 