### PR TITLE
Remove pending from URI identifier class

### DIFF
--- a/source/vocab/details.ttl
+++ b/source/vocab/details.ttl
@@ -707,7 +707,6 @@
     rdfs:subClassOf :Identifier.
 
 :URI a owl:Class;
-    :category :pending ;
     rdfs:label "URI";
     skos:notation "uri";
     rdfs:comment "Universal Resource Identifier";


### PR DESCRIPTION
URI class is used and normalized to in all conversions for `024$2 uri` at this point.