### PR TITLE
Feature/include uri for resources

### DIFF
--- a/source/vocab/display.jsonld
+++ b/source/vocab/display.jsonld
@@ -12,6 +12,8 @@
       "alternateProperties": {"@id": "fresnel:alternateProperties", "@container": "@list", "@type": "@vocab"},
       "classLensDomain": {"@reverse": "displayLens", "@type": "@vocab"},
       "inverseOf": {"@id": "owl:inverseOf", "@type": "@vocab"},
+      "subPropertyOf": {"@id": "rdfs:subPropertyOf", "@type": "@vocab"},
+      "range": {"@id": "rdfs:range", "@type": "@vocab"},
       "labelByLang": {"@id": "label", "@container": "@language"},
       "commentByLang": {"@id": "comment", "@container": "@language"},
       "prefLabelByLang": {"@id": "prefLabel", "@container": "@language"},
@@ -1104,7 +1106,6 @@
           "fresnel:extends": {"@id": "ToCEntry-cards"},
           "showProperties": [ "fresnel:super" ]
         }
-
       }
     },
     "search-cards": {

--- a/source/vocab/display.jsonld
+++ b/source/vocab/display.jsonld
@@ -469,7 +469,8 @@
           "@id": "Resource-cards",
           "@type": "fresnel:Lens",
           "classLensDomain": "Resource",
-          "showProperties": [ "title", "prefLabel", "label", "name", "code", "exactMatch", "closeMatch", "broadMatch", "isPartOf", "isDefinedBy" ]
+          "fresnel:extends": {"@id": "Resource-chips"},
+          "showProperties": [ "fresnel:super", "exactMatch", "closeMatch", "broadMatch" ]
         },
         "Record": {
           "@type": "fresnel:Lens",


### PR DESCRIPTION
Let Resource-cards inherit from Resource-chips, which includes `uri` and fixes LXL-3961.

(This works locally. I _thought_ we used chips for these details in the index, but apparently not. And anyway it is generally good to inherit chips from cards unless special ordering is _required_. Both for making display consistent, and to ease maintenance.)