### PR TITLE
Adjust order in Person chip

### DIFF
--- a/source/vocab/display.jsonld
+++ b/source/vocab/display.jsonld
@@ -336,7 +336,7 @@
           "@id": "Person-chips",
           "@type": "fresnel:Lens",
           "classLensDomain": "Person",
-          "showProperties": [ "familyName", "givenName", "name", "marc:numeration", "marc:titlesAndOtherWordsAssociatedWithAName", "fullerFormOfName", "lifeSpan" ]
+          "showProperties": [ "familyName", "givenName", "name", "marc:numeration", "lifespan", "marc:titlesAndOtherWordsAssociatedWithAName", "fullerFormOfName" ]
         },
         "Family": {
           "@id": "Family-chips",


### PR DESCRIPTION
lifespan should come before title so that agents with the same
name and lifespan but different titles are next to each other when
sorting alphabetically:
Andersson, Lars, 1942-, pedagog
Andersson, Lars, 1942-, yrkesmilitär
    
(see LXL-3097)