### PR TITLE
Feature/extend romanization rules

### DIFF
--- a/source/i18n/rules.ttl
+++ b/source/i18n/rules.ttl
@@ -1,6 +1,14 @@
 prefix : <https://id.kb.se/vocab/>
 base <https://id.kb.se/>
 
+</i18n/rule/m0> a :TermCollection ;
+  :code "m0";
+  :label "Standardiserade språktransformationsregler enligt BCP47"@sv .
+
+</i18n/rule/x0> a :TermCollection ;
+  :code "x0";
+  :label "Libris-specifika språktransformationsregler"@sv .
+
 </i18n/rule/x0/lessing> a :LanguageTransformRules ;
   :label "Translitterering enligt Ferdinand Lessings schema"@sv ;
   :code "lessing" ;

--- a/source/i18n/rules.ttl
+++ b/source/i18n/rules.ttl
@@ -19,10 +19,25 @@ base <https://id.kb.se/>
   :code "skr-1980" ;
   :inCollection </i18n/rule/x0> .
 
-</i18n/rule/m0/iso-1995> a :LanguageTransformRules ;
-  :label "Translitterering enligt ISO 9:1995"@sv ;
-  :code "iso-1995" ;
+</i18n/rule/m0/iso> a :LanguageTransformRules ;
+  :code "iso" ;
+  :label "Translitterering enligt ISO-standard"@sv ;
   :inCollection </i18n/rule/m0> .
+
+</i18n/rule/m0/iso-1995> a :LanguageTransformRules ;
+  :code "iso-1995" ;
+  :label "Translitterering enligt ISO-standard från 1995"@sv ;
+  :broader </i18n/rule/m0/iso> ;
+  :inCollection </i18n/rule/m0> .
+
+</i18n/rule/iso-1995/Cyrl-t-Latn> a :LanguageTransformRules ;
+  :broader </i18n/rule/m0/iso-1995> ;
+  :label "Translitterering av kyrillisk till latinsk skrift enligt ISO 9:1995"@sv ;
+  :specifiesLanguageForm [ a :TransformedLanguageForm ;
+      :inLangScript </i18n/script/Latn> ;
+      :fromLangScript </i18n/script/Cyrl> ] ;
+  :seeAlso <https://sv.wikipedia.org/wiki/ISO_9> ,
+    <https://metadatabyran.kb.se/download/18.6945cdaa174b74a2c3615fe/1601917435290/Kyrilliska%20alfabetet.pdf> .
 
 </i18n/rule/x0/btj> a :LanguageTransformRules ;
   :label "Transkribering enligt Btj:s praxis för folkbiblioteken"@sv ;

--- a/source/i18n/tlangs.ttl
+++ b/source/i18n/tlangs.ttl
@@ -28,49 +28,49 @@ base <https://id.kb.se/>
   :inLanguage </language/bel> ;
   :inLangScript </i18n/script/Latn> ;
   :fromLangScript </i18n/script/Cyrl> ;
-  :langTransformAccordingTo </i18n/rule/m0/iso-1995> .
+  :langTransformAccordingTo </i18n/rule/iso-1995/Cyrl-t-Latn> .
 
 </i18n/lang/bg-Latn-t-bg-Cyrl-m0-iso-1995> a :TransformedLanguageForm ;
   :code "bg-Latn-t-bg-Cyrl-m0-iso-1995"^^:BCP47 ;
   :inLanguage </language/bul> ;
   :inLangScript </i18n/script/Latn> ;
   :fromLangScript </i18n/script/Cyrl> ;
-  :langTransformAccordingTo </i18n/rule/m0/iso-1995> .
+  :langTransformAccordingTo </i18n/rule/iso-1995/Cyrl-t-Latn> .
 
 </i18n/lang/kk-Latn-t-kk-Cyrl-m0-iso-1995> a :TransformedLanguageForm ;
   :code "kk-Latn-t-kk-Cyrl-m0-iso-1995"^^:BCP47 ;
   :inLanguage </language/kaz> ;
   :inLangScript </i18n/script/Latn> ;
   :fromLangScript </i18n/script/Cyrl> ;
-  :langTransformAccordingTo </i18n/rule/m0/iso-1995> .
+  :langTransformAccordingTo </i18n/rule/iso-1995/Cyrl-t-Latn> .
 
 </i18n/lang/mk-Latn-t-mk-Cyrl-m0-iso-1995> a :TransformedLanguageForm ;
   :code "mk-Latn-t-mk-Cyrl-m0-iso-1995"^^:BCP47 ;
   :inLanguage </language/mac> ;
   :inLangScript </i18n/script/Latn> ;
   :fromLangScript </i18n/script/Cyrl> ;
-  :langTransformAccordingTo </i18n/rule/m0/iso-1995> .
+  :langTransformAccordingTo </i18n/rule/iso-1995/Cyrl-t-Latn> .
 
 </i18n/lang/ru-Latn-t-ru-Cyrl-m0-iso-1995> a :TransformedLanguageForm ;
   :code "ru-Latn-t-ru-Cyrl-m0-iso-1995"^^:BCP47 ;
   :inLanguage </language/rus> ;
   :inLangScript </i18n/script/Latn> ;
   :fromLangScript </i18n/script/Cyrl> ;
-  :langTransformAccordingTo </i18n/rule/m0/iso-1995> .
+  :langTransformAccordingTo </i18n/rule/iso-1995/Cyrl-t-Latn> .
 
 </i18n/lang/sr-Latn-t-sr-Cyrl-m0-iso-1995> a :TransformedLanguageForm ;
   :code "sr-Latn-t-sr-Cyrl-m0-iso-1995"^^:BCP47 ;
   :inLanguage </language/srp> ;
   :inLangScript </i18n/script/Latn> ;
   :fromLangScript </i18n/script/Cyrl> ;
-  :langTransformAccordingTo </i18n/rule/m0/iso-1995> .
+  :langTransformAccordingTo </i18n/rule/iso-1995/Cyrl-t-Latn> .
 
 </i18n/lang/uk-Latn-t-uk-Cyrl-m0-iso-1995> a :TransformedLanguageForm ;
   :code "uk-Latn-t-uk-Cyrl-m0-iso-1995"^^:BCP47 ;
   :inLanguage </language/ukr> ;
   :inLangScript </i18n/script/Latn> ;
   :fromLangScript </i18n/script/Cyrl> ;
-  :langTransformAccordingTo </i18n/rule/m0/iso-1995> .
+  :langTransformAccordingTo </i18n/rule/iso-1995/Cyrl-t-Latn> .
 
 </i18n/lang/hi-Latn-t-hi-Deva-m0-alaloc> a :TransformedLanguageForm ;
   :code "hi-Latn-t-hi-Deva-m0-alaloc"^^:BCP47 ;

--- a/source/vocab/concepts.ttl
+++ b/source/vocab/concepts.ttl
@@ -77,6 +77,11 @@
     rdfs:label "Språktransformationsregler"@sv, "Language transform rules"@en;
     rdfs:subClassOf :ConceptScheme .
 
+:specifiesLanguageForm a owl:ObjectProperty ;
+    rdfs:label "specificerar språkform"@sv, "specifies language form"@en;
+    rdfs:domain :LanguageTransformRules ;
+    rdfs:range :TransformedLanguageForm .
+
 :Nationality a owl:Class ;
     rdfs:label "Nationality"@en, "Nationalitet"@sv .
 


### PR DESCRIPTION
This adds precision to the transformed language forms, to solve the conflation of `iso-1995` as the specific "ISO:9 from 1995, for Cyrillic to Latin script".

It is unclear if it is manageable and informative (or complicating) to do like this in general. At least in part, assessing this comes from how we use this data in the romanization feature.

If the rules are *just* informative support data, this is reasonably a good addition. But if we want to use these definitions in runtime algorithms (specifically to build BCP47 tags from `code` components), by this design, the algorithm would have to "climb up" via `broader` until if finds a code (though probably, as here, just one step). Might be OK, but it is more complex. For *maintaining predefined codes* I believe it is OK. But if we are to *generate* new `:TransformedLanguageForm`:s when the romanization API is called, we need to assess the complexity when using these definitions.