### PR TITLE
Add chip for TransformedLanguageForm

### DIFF
--- a/source/vocab/display.jsonld
+++ b/source/vocab/display.jsonld
@@ -274,7 +274,9 @@
           "@id": "Notation-chips",
           "@type": "fresnel:Lens",
           "classLensDomain": "Notation",
-          "showProperties": [ "label", "prefLabel"]
+          "showProperties": [
+            {"alternateProperties": ["prefLabel", "label"]}
+          ]
         },
         "ProvisionActivity": {
           "@id": "ProvisionActivity-chips",
@@ -325,6 +327,12 @@
           "showProperties": [
             {"alternateProperties": ["prefLabel", "label", "code"]}
           ]
+        },
+        "TransformedLanguageForm": {
+          "@id": "TransformedLanguageForm-chips",
+          "@type": "fresnel:Lens",
+          "classLensDomain": "TransformedLanguageForm",
+          "showProperties": [ "prefLabel", "inLanguage", "inLangScript"]
         },
         "marc:LanguageNote": {
           "@id": "LanguageNote-chips",


### PR DESCRIPTION
I guess we'd actually want prefLabel OR inLanguage + inLangScript here

something like 
```
          "showProperties": [ {"alternateProperties": ["prefLabel", ["inLanguage", "inLangScript"]] } ]
```
but that doesn't work