### PR TITLE
Add langTag to language cards

### DIFF
--- a/source/vocab/display.jsonld
+++ b/source/vocab/display.jsonld
@@ -701,7 +701,7 @@
           "@type": "fresnel:Lens",
           "classLensDomain": "Language",
           "fresnel:extends": {"@id": "Language-chips"},
-          "showProperties": [ "fresnel:super", "altLabel", "code", "isReplacedBy", "broader", {"inverseOf" : "broader"}, "comment" ]
+          "showProperties": [ "fresnel:super", "altLabel", "code", "langTag", "isReplacedBy", "broader", {"inverseOf" : "broader"}, "comment" ]
         },
         "Material": {
           "@id": "Material-cards",


### PR DESCRIPTION
This is needed when adding language tags to language containers in the client.

However, 'code' is now displayed twice in cards in the search results.  
E.g. for Ukrainian:
```
Kod ukr
Kod uk
```
