### PR TITLE
Add langTag to all non-local languages

### DIFF
--- a/common.py
+++ b/common.py
@@ -167,7 +167,7 @@ def languages():
             "dataset": "http://id.loc.gov/vocabulary/iso639-2"
         }
     ],
-        query="source/construct-languages-1.rq")
+        query="source/construct-languages-iso639-2.rq")
 
     graph = compiler.construct(sources=[
         {
@@ -179,7 +179,7 @@ def languages():
             "dataset": "http://id.loc.gov/vocabulary/iso639-1"
         }
     ],
-        query="source/construct-languages-2.rq")
+        query="source/construct-languages-iso639-1.rq")
 
     return "/language/", "2014-08-01T07:56:51.110Z", graph
 

--- a/common.py
+++ b/common.py
@@ -153,27 +153,33 @@ def relators():
 
 @compiler.dataset
 def languages():
-    loclanggraph = Graph()
-    loclanggraph.parse(
-            str(compiler.cache_url('http://id.loc.gov/vocabulary/iso639-1.nt')),
-            format='nt')
-    loclanggraph.parse(
-            str(compiler.cache_url('http://id.loc.gov/vocabulary/iso639-2.nt')),
-            format='nt')
-
     languages = Graph().parse(str(compiler.path('source/languages.ttl')), format='turtle')
+    iso639_1 = Graph().parse(str(compiler.cache_url('http://id.loc.gov/vocabulary/iso639-1.nt')), format='nt')
+    iso639_2 = Graph().parse(str(compiler.cache_url('http://id.loc.gov/vocabulary/iso639-2.nt')), format='nt')
 
     graph = compiler.construct(sources=[
-            {
-                "source": languages,
-                "dataset": BASE + "dataset/languages"
-            },
-            {
-                "source": loclanggraph,
-                "dataset": "http://id.loc.gov/vocabulary/languages"
-            }
-        ],
-        query="source/construct-languages.rq")
+        {
+            "source": languages,
+            "dataset": BASE + "dataset/languages"
+        },
+        {
+            "source": iso639_2,
+            "dataset": "http://id.loc.gov/vocabulary/iso639-2"
+        }
+    ],
+        query="source/construct-languages-1.rq")
+
+    graph = compiler.construct(sources=[
+        {
+            "source": graph,
+            "dataset": BASE + "dataset/languages"
+        },
+        {
+            "source": iso639_1,
+            "dataset": "http://id.loc.gov/vocabulary/iso639-1"
+        }
+    ],
+        query="source/construct-languages-2.rq")
 
     return "/language/", "2014-08-01T07:56:51.110Z", graph
 

--- a/source/construct-languages-iso639-1.rq
+++ b/source/construct-languages-iso639-1.rq
@@ -1,0 +1,40 @@
+prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+prefix xsd: <http://www.w3.org/2001/XMLSchema#>
+prefix skos: <http://www.w3.org/2004/02/skos/core#>
+prefix madsrdf: <http://www.loc.gov/mads/rdf/v1#>
+prefix dc: <http://purl.org/dc/terms/>
+prefix iso639_1: <http://id.loc.gov/vocabulary/iso639-1/>
+prefix kbv: <https://id.kb.se/vocab/>
+prefix langtag: <https://id.kb.se/i18n/lang/>
+
+construct {
+    ?s ?p ?o ;
+        owl:sameAs ?bcp47alias ;
+        skos:notation ?langCodeShort, ?langTag ;
+        skos:closeMatch ?locVariant .
+} where {
+    graph <https://id.kb.se/dataset/languages> {
+        {
+            ?s ?p ?o
+        } union {
+            ?s skos:prefLabel ?prefLabel ;
+                skos:notation ?locCode .
+            filter(
+                datatype(?locCode) = kbv:ISO639-2-T ||
+                datatype(?locCode) = xsd:string
+            )
+            filter(langMatches(lang(?prefLabel), 'en'))
+            graph <http://id.loc.gov/vocabulary/iso639-1> {
+                optional {
+                    ?locVariant madsrdf:authoritativeLabel|skos:prefLabel ?prefLabel
+                    bind(substr(str(?locVariant), strlen(str(iso639_1:)) + 1) as ?shortcode)
+                    bind(strdt(?shortcode, kbv:ISO639-1) as ?langCodeShort)
+                }
+            }
+            bind(str(coalesce(?langCodeShort, ?locCode)) as ?langTagStr)
+            bind(strdt(?langTagStr, kbv:BCP47) as ?langTag)
+            bind(IRI(concat(str(langtag:), ?langTagStr)) as ?bcp47alias)
+        }
+    }
+}
+

--- a/source/construct-languages-iso639-1.rq
+++ b/source/construct-languages-iso639-1.rq
@@ -14,27 +14,29 @@ construct {
         skos:closeMatch ?locVariant .
 } where {
     graph <https://id.kb.se/dataset/languages> {
-        {
-            ?s ?p ?o
-        } union {
-            ?s skos:prefLabel ?prefLabel ;
-                skos:notation ?locCode .
-            filter(
-                datatype(?locCode) = kbv:ISO639-2-T ||
-                datatype(?locCode) = xsd:string
-            )
-            filter(langMatches(lang(?prefLabel), 'en'))
+        ?s ?p ?o .
+        optional {
+            ?s skos:prefLabel ?prefLabel .
             graph <http://id.loc.gov/vocabulary/iso639-1> {
-                optional {
-                    ?locVariant madsrdf:authoritativeLabel|skos:prefLabel ?prefLabel
-                    bind(substr(str(?locVariant), strlen(str(iso639_1:)) + 1) as ?shortcode)
-                    bind(strdt(?shortcode, kbv:ISO639-1) as ?langCodeShort)
-                }
+                ?locVariant madsrdf:authoritativeLabel|skos:prefLabel ?prefLabel
+                bind(substr(str(?locVariant), strlen(str(iso639_1:)) + 1) as ?shortcode)
+                bind(strdt(?shortcode, kbv:ISO639-1) as ?langCodeShort)
             }
-            bind(str(coalesce(?langCodeShort, ?locCode)) as ?langTagStr)
-            bind(strdt(?langTagStr, kbv:BCP47) as ?langTag)
-            bind(IRI(concat(str(langtag:), ?langTagStr)) as ?bcp47alias)
         }
+        optional {
+            ?s skos:notation ?iso639_2 .
+            filter(datatype(?iso639_2) = kbv:ISO639-2)
+        }
+        optional {
+            ?s skos:notation ?iso639_3 .
+            filter(datatype(?iso639_3) = kbv:ISO639-3)
+        }
+        bind(str(
+            coalesce(?langCodeShort,
+                coalesce(?iso639_2, ?iso639_3))
+        ) as ?langTagStr)
+        bind(strdt(?langTagStr, kbv:BCP47) as ?langTag)
+        bind(IRI(concat(str(langtag:), ?langTagStr)) as ?bcp47alias)
     }
 }
 

--- a/source/construct-languages-iso639-2.rq
+++ b/source/construct-languages-iso639-2.rq
@@ -3,19 +3,14 @@ prefix xsd: <http://www.w3.org/2001/XMLSchema#>
 prefix skos: <http://www.w3.org/2004/02/skos/core#>
 prefix madsrdf: <http://www.loc.gov/mads/rdf/v1#>
 prefix dc: <http://purl.org/dc/terms/>
-prefix iso639_1: <http://id.loc.gov/vocabulary/iso639-1/>
 prefix iso639_2: <http://id.loc.gov/vocabulary/iso639-2/>
 prefix kbv: <https://id.kb.se/vocab/>
-prefix langtag: <https://id.kb.se/i18n/lang/>
 
 construct {
     ?s ?p ?o ;
-        owl:sameAs ?bcp47alias ;
         skos:prefLabel ?prefLabel ;
         skos:altLabel ?altLabel ;
-        skos:notation ?langCodeShort, ?langTag, ?marc ;
         skos:exactMatch ?locLang ;
-        skos:closeMatch ?locVariant .
 } where {
     graph <https://id.kb.se/dataset/languages> {
         {
@@ -27,7 +22,7 @@ construct {
                 datatype(?locCode) = xsd:string
             )
             bind(iri(concat(str(iso639_2:), str(?locCode))) as ?locLang)
-            graph <http://id.loc.gov/vocabulary/languages> {
+            graph <http://id.loc.gov/vocabulary/iso639-2> {
                 {
                     filter(!contains(?prefLabel, "|"))
                     ?locLang madsrdf:authoritativeLabel|skos:prefLabel ?prefLabel
@@ -40,17 +35,6 @@ construct {
                     bind(concat("^([^|]+\\|){", str(?n) ,"} *") as ?skipN)
                     bind(replace(replace(?altLabels, ?skipN, ""), " *\\|.*$", "") as ?altLabel)
                 }
-                optional {
-                    filter(langMatches(lang(?prefLabel), 'en'))
-                    ?locVariant madsrdf:authoritativeLabel|skos:prefLabel ?prefLabel .
-                    bind(str(iso639_1:) as ?iso639_1_base)
-                    filter(strstarts(str(?locVariant), ?iso639_1_base))
-                    bind(substr(str(?locVariant), strlen(?iso639_1_base) + 1) as ?shortcode)
-                    bind(strdt(?shortcode, kbv:ISO639-1) as ?langCodeShort)
-                }
-                bind(str(coalesce(?langCodeShort, ?locCode)) as ?langTagStr)
-                bind(strdt(?langTagStr, kbv:BCP47) as ?langTag)
-                bind(IRI(concat(str(langtag:), ?langTagStr)) as ?bcp47alias)
             }
         }
     }

--- a/source/languages.ttl
+++ b/source/languages.ttl
@@ -82,7 +82,7 @@
     skos:notation "9ke",
         "rmf"^^kbv:ISO639-3,
         "9ke"^^kbv:LibrisLocalLanguageCode ;
-    skos:prefLabel "Kale"@sv ;
+    skos:prefLabel "Kalé"@sv ;
     skos:broader <rom> .
     
 <9ki> a schema:Language ;

--- a/source/languages.ttl
+++ b/source/languages.ttl
@@ -13,6 +13,7 @@
 <9an> a schema:Language ;
     rdfs:comment "\"9an\" Librisdefinierad MARC-kod."@sv ;
     skos:notation "9an",
+        "rme"^^kbv:ISO639-3,
         "9an"^^kbv:LibrisLocalLanguageCode ;
     skos:prefLabel "Angloromani"@sv ;
     skos:broader <rom> .
@@ -34,6 +35,7 @@
 <9ca> a schema:Language ;
     rdfs:comment "\"9ca\" Librisdefinierad MARC-kod."@sv ;
     skos:notation "9ca",
+        "rmq"^^kbv:ISO639-3,
         "9ca"^^kbv:LibrisLocalLanguageCode ;
     skos:prefLabel "Caló"@sv ;
     skos:broader <rom> .
@@ -78,6 +80,7 @@
 <9ke> a schema:Language ;
     rdfs:comment "\"9ke\" Librisdefinierad MARC-kod."@sv ;
     skos:notation "9ke",
+        "rmf"^^kbv:ISO639-3,
         "9ke"^^kbv:LibrisLocalLanguageCode ;
     skos:prefLabel "Kale"@sv ;
     skos:broader <rom> .
@@ -126,6 +129,7 @@
 <9si> a schema:Language ;
     rdfs:comment "\"9si\" Librisdefinierad MARC-kod."@sv ;
     skos:notation "9si",
+        "rmo"^^kbv:ISO639-3,
         "9si"^^kbv:LibrisLocalLanguageCode ;
     skos:prefLabel "Sinte romani"@sv ;
     skos:broader <rom> .


### PR DESCRIPTION
Had to split `construct-languages.rq` in two to get desired result from `coalesce(?langCodeShort, ?locCode)`. Don't think it's necessarily a bad thing though as future modifications will probably be easier. Now there is one query that operates on the iso639-1 graph and the other on the iso639-2 graph.