### PR TITLE
Add ShelfMarkSequence to domain and range of replacedBy

### DIFF
--- a/source/vocab/relations.ttl
+++ b/source/vocab/relations.ttl
@@ -393,6 +393,8 @@ prefix relsubtype: <http://id.loc.gov/vocabulary/preservation/relationshipSubTyp
 
 :replacedBy a owl:ObjectProperty;
     rdfs:label "ersatt av"@sv;
+    sdo:domainIncludes :ShelfMarkSequence ;
+    sdo:rangeIncludes :ShelfMarkSequence ;
     owl:equivalentProperty bf2:replacedBy;
     rdfs:subPropertyOf :succeededBy, dc:isReplacedBy ;
     owl:inverseOf :replacementOf .


### PR DESCRIPTION
To make it possible to add via the cataloging interface. 
Already set by the shelfmark year-bump script.