### PR TITLE
Tag platforms terms with `:category :platform`

### DIFF
--- a/source/vocab/agents.ttl
+++ b/source/vocab/agents.ttl
@@ -307,3 +307,33 @@
     rdfs:subClassOf [ a owl:Restriction;
             owl:onProperty :hasPart; owl:someValuesFrom :Jurisdiction ] .
 
+
+##
+# Libris administrative "things"
+
+# Possible idea forward with a base "operator" Class for bibdb things, for now we inherit Library and Bibliography from Agent and Collection.
+# :OperatorProfile a owl:Class ;
+#     :category :abstract ;
+#     rdfs:label "Sigel"@sv ;
+#     rdfs:subClassOf :Agent .
+
+:Library a owl:Class ;
+    rdfs:label "Library"@en, "Bibliotek"@sv ;
+    rdfs:subClassOf :Collection, :Agent .
+    # rdfs 
+
+:Bibliography a owl:Class;
+    rdfs:label "Bibliography"@en, "Bibliografi"@sv;
+    rdfs:subClassOf :Collection, :Agent .
+
+:bibliography a owl:ObjectProperty ;
+    rdfs:comment "in bibliography"@en, "bibliografi som resursen ingår i"@sv ;
+    rdfs:domain :Record ;
+    sdo:rangeIncludes :Bibliography ;
+    rdfs:subPropertyOf dc:isPartOf ;
+    rdfs:label "bibliografi"@sv .
+
+:sigel a owl:DatatypeProperty;
+    rdfs:label "sigel code"@en, "sigel"@sv ;
+    rdfs:subPropertyOf :code;
+    rdfs:domain :Agent; .

--- a/source/vocab/base.ttl
+++ b/source/vocab/base.ttl
@@ -161,6 +161,16 @@ rdf:type a owl:ObjectProperty;
     rdfs:label "category"@en, "kategori"@sv;
     owl:equivalentProperty sdo:category .
 
+##
+# These terms may also be "bibliographic", but the platform cannot work without
+# them. If the "bibliographic" notions are 1:1 with the technical, the term is
+# the same, otherwise we need subclasses (which may also derive from other
+# subclasses).
+# See also: <https://github.com/libris/definitions/pull/413>
+:platform a skos:Collection ;
+    :code "platform" ;
+    rdfs:comment "Terms required by the XL platform."@en .
+
 :shorthand a skos:Collection ;
     rdfs:label "shorthand"@en, "kortform"@sv ;
     rdfs:comment "Anges som kategori på egenskaper som har en mer komplex bakomliggande struktur."@sv ;

--- a/source/vocab/platform.ttl
+++ b/source/vocab/platform.ttl
@@ -40,6 +40,7 @@
 
 
 :Document a owl:Class;
+    #:category :platform ;
     rdfs:label "Document"@en, "Dokument"@sv;
     owl:equivalentClass foaf:Document .
 
@@ -47,29 +48,35 @@
 # Records
 
 :Record a owl:Class;
+    :category :platform ;
     rdfs:label "Post"@sv, "Record"@en;
     rdfs:subClassOf :AdminMetadata .
 
 :SystemRecord a owl:Class;
+    :category :platform ;
     rdfs:label "System-post"@sv, "System record"@en;
     rdfs:comment "En post som innehåller systemkritisk eller -specifik information."@sv;
     rdfs:subClassOf :Record .
 
 :CacheRecord a owl:Class;
+    :category :platform ;
     rdfs:label "Cache-post"@sv, "Cache record"@en;
     rdfs:comment "En lokal kopia av en entitet från ett annat system. Transkriberad till det lokala vokabuläret."@sv;
     rdfs:subClassOf :Record .
 
 :PlaceholderRecord a owl:Class;
+    :category :platform ;
     rdfs:label "Platshållarpost"@sv, "Placeholder record"@en;
     rdfs:subClassOf :Record .
 
 :mainEntity a owl:ObjectProperty;
+    :category :platform ;
     rdfs:label "handlar om"@sv;
     rdfs:domain :Record;
     owl:equivalentProperty sdo:mainEntity, foaf:primaryTopic .
 
 :meta a owl:ObjectProperty;
+    :category :platform ;
     rdfs:label "Metadata"@en, "Metadata"@sv;
     owl:inverseOf :mainEntity;
     owl:equivalentProperty bf2:adminMetadata, foaf:isPrimaryTopicOf, sdo:mainEntityOfPage, xhv:meta ;
@@ -77,19 +84,21 @@
     rdfs:range :Record .
 
 :describedBy a owl:ObjectProperty;
+    :category :platform ;
     sdo:domainIncludes :Document;
     rdfs:range :Document;
     rdfs:label "Described by"@en, "Beskriven av"@sv;
     owl:equivalentProperty iana:describedby, wdrs:describedby .
 
+# NOTE: additional data about automapped BF2 terms {{{
+
 :recordStatus a owl:ObjectProperty;
+    #:category :platform ;
     rdfs:subPropertyOf :status;
     rdfs:label "Record status"@en, "Poststatus"@sv;
     rdfs:comment "Postens status, sätts automatiskt."@sv;
     rdfs:domain :Record;
     sdo:rangeIncludes marc:StatusType .
-
-# NOTE: additional data about automapped BF2 terms
 
 :AdminMetadata a owl:Class;
     rdfs:label "Administrative metadata"@en, "Administrativ metadata"@sv;
@@ -140,6 +149,7 @@
     rdfs:range :Agent .
 
 :created a owl:DatatypeProperty;
+    :category :platform ;
     rdfs:label "Skapad"@sv;
     rdfs:domain :AdminMetadata;
     owl:equivalentProperty bf2:creationDate ;
@@ -147,6 +157,7 @@
     rdfs:range xsd:dateTime .
 
 :modified a owl:DatatypeProperty;
+    :category :platform ;
     rdfs:label "Ändrad"@sv;
     rdfs:domain :AdminMetadata;
     owl:equivalentProperty bf2:changeDate ;
@@ -234,14 +245,18 @@
     rdfs:comment "Beteckning som anger den bibliografiska beskrivningens fullständighetsnivå"@sv;
     owl:equivalentProperty bflc:encodingLevel .
 
+# }}}
+
 :identifiedBy rdfs:subPropertyOf :describedBy; owl:equivalentProperty sdo:sameAs .
 
 :controlNumber a owl:DatatypeProperty;
+    #:category :platform ;
     rdfs:domain :Record;
     rdfs:label "control number"@en, "kontrollnummer"@sv;
     owl:equivalentProperty :identifier .
 
 :inDataset a owl:ObjectProperty;
+    :category :platform ;
     rdfs:label "in dataset"@en, "ingår i dataset"@sv;
     rdfs:domain :Record;
     rdfs:range :Dataset;
@@ -249,18 +264,21 @@
     rdfs:subPropertyOf dc:isPartOf .
 
 :uriSpace a owl:DatatypeProperty ;
+    :category :platform ;
     :category :pending ;
     rdfs:domain :Dataset ;
     rdfs:label "URI-rymd"@sv, "URI space"@en ;
     owl:equivalentProperty void:uriSpace .
 
 :uriRegexPattern a owl:DatatypeProperty ;
+    :category :platform ;
     :category :pending ;
     rdfs:domain :Dataset ;
     rdfs:label "URI-regex-uttryck"@sv, "URI regex pattern"@en ;
     owl:equivalentProperty void:uriRegexPattern .
 
 :datasetClass a owl:ObjectProperty ;
+    :category :platform ;
     :category :pending ;
     rdfs:domain :Dataset ;
     rdfs:range owl:Class ;
@@ -268,16 +286,19 @@
     owl:equivalentProperty void:class .
 
 :displayLens a owl:ObjectProperty ;
+    :category :platform ;
     :category :pending ;
     owl:inverseOf fresnel:classLensDomain .
 
 :DataCatalog a owl:Class;
+    :category :platform ;
     rdfs:label "Data catalog"@en, "Datakatalog"@sv;
     skos:definition "A collection of datasets or data services."@en, "En samling av dataset eller datatjänster."@sv;
     # NOTE: DCAT has Catalog as subClassOf Dataset, maybe something to consider.
     owl:equivalentClass sdo:DataCatalog, dcat:Catalog .
 
 :Dataset a owl:Class;
+    :category :platform ;
     rdfs:label "Dataset"@sv; # NOTE: English label provided through bf2 equivalence. Also minimally defined in things.ttl for "visibility".
     skos:altLabel "Datamängd"@sv;
     skos:definition "Data kodad i en definierad struktur. Inkluderar bland annat numeriska data, miljödata. Används av applikationsprogramvara för att beräkna medelvärden, korrelationer, eller för att producera modeller etc."@sv;
@@ -289,6 +310,7 @@
     owl:equivalentClass bf2:Dataset, sdo:Dataset, dcat:Dataset, void:Dataset, dctype:Dataset .
 
 :hasDataset a owl:ObjectProperty;
+    :category :platform ;
     rdfs:label "has dataset"@en, "har dataset"@sv;
     rdfs:domain :DataCatalog;
     rdfs:range :Dataset;
@@ -297,6 +319,7 @@
     rdfs:subPropertyOf dc:hasPart .
 
 :inDataCatalog a owl:ObjectProperty;
+    :category :platform ;
     rdfs:label "included in data catalog"@en, "ingår i datakatalog"@sv;
     skos:definition "A data catalog which contains this dataset."@en, "En datakatalog som datasetet ingår i."@sv;
     rdfs:domain :Dataset;
@@ -306,25 +329,30 @@
     rdfs:subPropertyOf dc:isPartOf .
 
 :QueryConstruct a owl:Class ;
+    :category :platform ;
     :category :pending .
 
 :dataQuery a owl:ObjectProperty ;
+    :category :platform ;
     :category :pending ;
     rdfs:label "data query"@en, "datafråga"@sv ;
     rdfs:domain :QueryConstruct ;
     rdfs:range :Representation .
 
 :sourceData a owl:ObjectProperty ;
+    :category :platform ;
     rdfs:label "data source"@en, "källdata"@sv ;
     rdfs:subPropertyOf dc:source .
 
 :dataDisplay a owl:ObjectProperty ;
+    :category :platform ;
     rdfs:label "data display"@en, "datavisning"@sv ;
-    rdfs:subPropertyOf :describedBy .
+    rdfs:subPropertyOf iana:stylesheet .
 
 # Pending:
 
 :datasetDistribution a owl:ObjectProperty;
+    :category :platform ;
     :category :pending;
     rdfs:label "dataset distribution"@en, "dataset distribution"@sv;
     rdfs:domain :Dataset;
@@ -332,11 +360,13 @@
     owl:equivalentProperty dcat:distribution, sdo:distribution .
 
 :DataDistribution a owl:Class; # NOTE: DatasetDistribution?
+    :category :platform ;
     :category :pending;
     rdfs:label "Data distribution"@en, "Datadistribution"@sv;
     owl:equivalentClass dcat:Distribution, sdo:DataDownload .
 
 :DataService a owl:Class;
+    :category :platform ;
     :category :pending;
     rdfs:label "Data service"@en, "Datatjänst"@sv;
     owl:equivalentClass dcat:DataService .
@@ -354,122 +384,110 @@
 #:ContactPoint owl:equivalentClass dcat:ContactPoint, sdo:ContactPoint . 
 
 
-#
-
-##
-# Libris administrative "things"
-
-# Possible idea forward with a base "operator" Class for bibdb things, for now we inherit Library and Bibliography from Agent and Collection.
-# :OperatorProfile a owl:Class ;
-#     :category :abstract ;
-#     rdfs:label "Sigel"@sv ;
-#     rdfs:subClassOf :Agent .
-
-:Library a owl:Class ;
-    rdfs:label "Library"@en, "Bibliotek"@sv ;
-    rdfs:subClassOf :Collection, :Agent .
-    # rdfs 
-
-:Bibliography a owl:Class;
-    rdfs:label "Bibliography"@en, "Bibliografi"@sv;
-    rdfs:subClassOf :Collection, :Agent .
-
-:bibliography a owl:ObjectProperty ;
-    rdfs:comment "in bibliography"@en, "bibliografi som resursen ingår i"@sv ;
-    rdfs:domain :Record ;
-    sdo:rangeIncludes :Bibliography ;
-    rdfs:subPropertyOf dc:isPartOf ;
-    rdfs:label "bibliografi"@sv .
-
-:sigel a owl:DatatypeProperty;
-    rdfs:label "sigel code"@en, "sigel"@sv ;
-    rdfs:subPropertyOf :code;
-    rdfs:domain :Agent; .
-
 ##
 # Paged Collections
 
 :ResourceView a owl:Class;
+    :category :platform ;
     owl:equivalentClass sdo:ItemPage .
 
 :PartialCollectionView a owl:Class;
+    :category :platform ;
     owl:equivalentClass hydra:PartialCollectionView, sdo:CollectionPage .
 
 :view a owl:ObjectProperty;
+    :category :platform ;
     rdfs:domain :Collection;
     rdfs:range :PartialCollectionView;
     owl:equivalentProperty hydra:view .
 
 :totalItems a owl:ObjectProperty;
+    :category :platform ;
     #rdfs:domain :Collection;
     sdo:domainIncludes :Collection, :PartialCollectionView;
     owl:equivalentProperty hydra:totalItems .
 
 :maxItems a owl:ObjectProperty;
+    :category :platform ;
     skos:definition "The maximum number of items that may be accessed through pagination. Might be smaller than totalItems"@en;
     rdfs:domain :PartialCollectionView .
 
 :first a owl:ObjectProperty;
+    :category :platform ;
     rdfs:domain :PartialCollectionView;
     owl:equivalentProperty hydra:first;
     rdfs:subPropertyOf iana:first .
 
 :previous a owl:ObjectProperty;
+    :category :platform ;
     rdfs:domain :PartialCollectionView;
     owl:equivalentProperty hydra:previous;
     rdfs:subPropertyOf iana:prev .
 
 :next a owl:ObjectProperty;
+    :category :platform ;
     rdfs:domain :PartialCollectionView;
     owl:equivalentProperty hydra:next;
     rdfs:subPropertyOf iana:next .
 
 :last a owl:ObjectProperty;
+    :category :platform ;
     rdfs:domain :PartialCollectionView;
     owl:equivalentProperty hydra:last;
     rdfs:subPropertyOf iana:last .
 
 :items a owl:ObjectProperty;
+    :category :platform ;
     rdfs:domain :PartialCollectionView;
     owl:equivalentProperty hydra:member .
 
 :itemsPerPage a owl:DatatypeProperty ;
+    :category :platform ;
     owl:equivalentProperty  opensearch:itemsPerPage, sindsearch:itemsPerPage .
 
 :itemOffset a owl:DatatypeProperty ;
+    :category :platform ;
     owl:equivalentProperty sindsearch:indexOffset .
 
 :search a owl:ObjectProperty;
+    :category :platform ;
     owl:equivalentProperty hydra:search;
     rdfs:domain :PartialCollectionView;
     rdfs:range :SearchTemplate .
 
 :SearchTemplate a owl:Class;
+    :category :platform ;
     rdfs:subClassOf hydra:IriTemplate .
 
 :mapping a owl:ObjectProperty;
+    :category :platform ;
     owl:equivalentProperty hydra:mapping;
     rdfs:domain :SearchTemplate;
     rdfs:range :SearchMapping .
 
 :SearchMapping a owl:Class;
+    :category :platform ;
     rdfs:subClassOf hydra:IriTemplateMapping .
 
 :variable a owl:DatatypeProperty;
+    :category :platform ;
     owl:equivalentProperty hydra:variable;
     rdfs:domain :SearchMapping;
     rdfs:range xsd:string .
 
 :property a owl:ObjectProperty ;
+    :category :platform ;
     owl:equivalentProperty hydra:property;
     rdfs:domain :SearchMapping;
     rdfs:range rdf:Property .
 
 :textQuery a owl:DatatypeProperty;
+    :category :platform ;
     owl:equivalentProperty hydra:freetextQuery;
     rdfs:label "freetext query"@en, "fritextsökning"@sv .
 
 :reverseLinks a owl:ObjectProperty;
+    :category :platform ;
     rdfs:range :PartialCollectionView;
     owl:inverseOf :items .
 
@@ -478,67 +496,82 @@
 # Containers (mainly used here for controlled URI:s)
 
 :Container a owl:Class ;
+    :category :platform ;
     owl:equivalentClass ldp:Container .
 
 :DirectContainer a owl:Class ;
+    :category :platform ;
     owl:equivalentClass ldp:DirectContainer ;
     rdfs:subClassOf :Container .
 
 :IndirectContainer a owl:Class ;
+    :category :platform ;
     owl:equivalentClass ldp:IndirectContainer ;
     rdfs:subClassOf :Container .
 
 :EntityContainer a owl:Class ;
+    :category :platform ;
     rdfs:subClassOf :IndirectContainer ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:onProperty :insertedContentRelation ;
             owl:hasValue :mainEntity ] .
 
 :administeredBy a owl:ObjectProperty ;
+    :category :platform ;
     sdo:domainIncludes :Container ;
     rdfs:range :Agent .
 
 :insertedContentRelation a owl:ObjectProperty, owl:FunctionalProperty ;
+    :category :platform ;
     owl:equivalentProperty ldp:insertedContentRelation .
 
 :membershipResource a owl:ObjectProperty, owl:FunctionalProperty ;
+    :category :platform ;
     owl:equivalentProperty ldp:membershipResource .
 
 :isMemberOfRelation a owl:ObjectProperty ;
+    :category :platform ;
     owl:equivalentProperty ldp:isMemberOfRelation .
 
-:memberClass a owl:ObjectProperty .
+:memberClass a owl:ObjectProperty ;
+    :category :platform .
 
-:slugProperty a owl:DatatypeProperty .
+:slugProperty a owl:DatatypeProperty ;
+    :category :platform .
 
 
 ##
 # Statistics for Facetted Browsing
 
-:statistics a owl:ObjectProperty .
+:statistics a owl:ObjectProperty ;
+    :category :platform .
 
-:Statistics a owl:Class;
+:Statistics a owl:Class ;
+    :category :platform ;
     rdfs:subPropertyOf qb:DataSet .
 
 :slice a owl:ObjectProperty;
+    :category :platform ;
     rdfs:domain :Statistics;
     rdfs:range :Slice;
     rdfs:subPropertyOf qb:slice .
 
 :Slice a owl:Class;
+    :category :platform ;
     rdfs:subPropertyOf qb:Slice .
 
 :dimension a owl:ObjectProperty;
+    :category :platform ;
     rdfs:domain :Slice;
     rdfs:range rdf:Property;
     rdfs:subPropertyOf qb:dimension .
 
 :observation a owl:ObjectProperty;
+    :category :platform ;
     rdfs:domain :Slice;
     rdfs:range :Observation;
     rdfs:subPropertyOf qb:observation .
 
 :Observation a owl:Class;
+    :category :platform ;
     rdfs:subClassOf qb:Observation .
-
-:object rdfs:subPropertyOf rdf:object .


### PR DESCRIPTION
and move library-things from platform to agents.

This is mainly house-keeping for clarity. We may eventually define these in a vocabulary of their own and alias them in the JSON-LD context. (But as we would like to make such a vocabulary more neutral (e.g. using `w3id.org`) and have some collaboration set up on that and the generic XL platform, let's defer those specifics until we know how that will pan out.)