### PR TITLE
Update arrangedStatementForMusic replacing version

### DIFF
--- a/source/marc/terms.ttl
+++ b/source/marc/terms.ttl
@@ -297,6 +297,12 @@ marc:NationalAgriculturalLibraryCallNumber a owl:Class;
 
 #TITLE
 
+marc:arrangedStatementForMusic a owl:DatatypeProperty ;
+    rdfs:label "Version (Music arr.)"@en, "Version (musik arr.)"@sv;
+    rdfs:comment "Används för fält $o i en MARC21 struktur för musikverk." ;
+    rdfs:domain kbv:Work .
+
+
 marc:mediaTerm a owl:DatatypeProperty;
     rdfs:label "Media term"@en, "Medieterm"@sv;
     rdfs:comment "Medieterm som är del av titel i en MARC21 struktur. används ej i RDA"@sv .

--- a/source/marc/terms.ttl
+++ b/source/marc/terms.ttl
@@ -299,7 +299,7 @@ marc:NationalAgriculturalLibraryCallNumber a owl:Class;
 
 marc:arrangedStatementForMusic a owl:DatatypeProperty ;
     rdfs:label "Version (Music arr.)"@en, "Version (musik arr.)"@sv;
-    rdfs:comment "Används för fält $o i en MARC21 struktur för musikverk." ;
+    rdfs:comment "Används för fält $o i en MARC21-struktur för musikverk." ;
     rdfs:domain kbv:Work .
 
 

--- a/source/marc/unlabelled.ttl
+++ b/source/marc/unlabelled.ttl
@@ -46,7 +46,6 @@ marc:actionIdentification a owl:DatatypeProperty .
 marc:additionalFormatCharacteristics a owl:DatatypeProperty .
 marc:agencyResponsibleForReproduction a owl:DatatypeProperty .
 marc:antecedent a owl:ObjectProperty .
-marc:arrangedStatementForMusic a owl:DatatypeProperty .
 marc:assignedByLC a owl:DatatypeProperty .
 marc:assignedByNlm a owl:DatatypeProperty .
 marc:associatedCountry a owl:DatatypeProperty .

--- a/source/marc/unlabelled.ttl
+++ b/source/marc/unlabelled.ttl
@@ -277,7 +277,6 @@ marc:undifferentiatedNumber a owl:DatatypeProperty .
 marc:uniformTitle a owl:DatatypeProperty .
 marc:useAndReproductionRights a owl:DatatypeProperty .
 marc:unparsedFingerprint a owl:DatatypeProperty .
-marc:version a owl:DatatypeProperty .
 marc:workUnitNumber a owl:DatatypeProperty .
 
 marc:nationalBibliographicAgency a owl:DatatypeProperty .

--- a/source/vocab/display.jsonld
+++ b/source/vocab/display.jsonld
@@ -159,8 +159,8 @@
                 {"subPropertyOf": "contribution", "range": "PrimaryContribution"}
               ]
             },
-            "marc:version",
             "version",
+            "marc:arrangementStatementForMusic",
             "originDate"
           ]
         },
@@ -599,8 +599,8 @@
                 "hasTitle"
               ]
             },
-            "marc:version",
             "version",
+            "marc:arrangementStatementForMusic",
             "translationOf",
             "contribution",
             "language",
@@ -650,7 +650,7 @@
             "hasTitle",
             "musicMedium",
             "musicKey",
-            "version",
+            "marc:arrangementStatementForMusic",
             "contribution",
             "composition",
             "language",


### PR DESCRIPTION


- [x] Upgrade `marc:arrangedStatementForMusic` from unlabeled.
- [x] Remove `marc:version` from unlabeled.
- [x] In display Remove `marc:version`, add `marc:arrangedStatementForMusic`.

Depends on https://github.com/libris/librisxl/pull/1208
