### PR TITLE
Move translationOf position in card

### DIFF
--- a/source/vocab/display.jsonld
+++ b/source/vocab/display.jsonld
@@ -601,7 +601,6 @@
             },
             "version",
             "marc:arrangementStatementForMusic",
-            "translationOf",
             "contribution",
             "language",
             "hasNotation",
@@ -615,7 +614,8 @@
             "illustrativeContent",
             "cartographicAttributes",
             "isPartOf",
-            {"inverseOf": "instanceOf"}
+            {"inverseOf": "instanceOf"},
+            "translationOf"
           ]
         },
         "DataCatalog": {

--- a/source/vocab/display.jsonld
+++ b/source/vocab/display.jsonld
@@ -614,8 +614,9 @@
             "illustrativeContent",
             "cartographicAttributes",
             "isPartOf",
-            {"inverseOf": "instanceOf"},
             "translationOf"
+            {"inverseOf": "instanceOf"},
+
           ]
         },
         "DataCatalog": {


### PR DESCRIPTION
Moving translationOf position in display cards to be more aligned with relations to other things (earlier placement because of it's relation to language and translated language).