### PR TITLE
Show romanization rule in language tag chips

### DIFF
--- a/source/i18n/rules.ttl
+++ b/source/i18n/rules.ttl
@@ -2,31 +2,43 @@ prefix : <https://id.kb.se/vocab/>
 base <https://id.kb.se/>
 
 </i18n/rule/x0/lessing> a :LanguageTransformRules ;
-  :label "Translitterering enligt Ferdinand Lessings schema"@sv ;
+  :label "Lessing"@sv ;
+  :description "Translitterering enligt Ferdinand Lessings schema"@sv ;
   :code "lessing" ;
+  :seeAlso <https://metadatabyran.kb.se/beskrivning/specialanvisningar/mangsprak/romaniseringsscheman#h-Mongoliska> ;
   :inCollection </i18n/rule/x0> .
 
 </i18n/rule/x0/skr-1980> a :LanguageTransformRules ;
-  :label "Translitterering enligt SKR 1980"@sv ;
+  :label "SKR 1980"@sv ;
+  :description "Translitterering enligt Svenska katalogiseringsregler 1980 (SKR)"@sv ;
   :code "skr-1980" ;
+  :seeAlso <https://metadatabyran.kb.se/download/18.6945cdaa174b74a2c361608/1601918851828/Grekiska%20alfabetet.pdf> ;
   :inCollection </i18n/rule/x0> .
 
 </i18n/rule/m0/iso-1995> a :LanguageTransformRules ;
-  :label "Translitterering enligt ISO 9:1995"@sv ;
+  :label "ISO 9:1995"@sv ;
+  :description "Translitterering enligt ISO 9:1995"@sv ;
   :code "iso-1995" ;
+  :seeAlso <https://metadatabyran.kb.se/beskrivning/specialanvisningar/mangsprak/romaniseringsscheman> ;
   :inCollection </i18n/rule/m0> .
 
 </i18n/rule/x0/btj> a :LanguageTransformRules ;
-  :label "Transkribering enligt Btj:s praxis för folkbiblioteken"@sv ;
+  :label "BTJ"@sv ;
+  :description "Transkribering enligt BTJ:s praxis för folkbiblioteken"@sv ;
   :code "btj" ;
+  :seeAlso <https://metadatabyran.kb.se/download/18.6945cdaa174b74a2c36160a/1601918887752/Transkriberingsschema%20f%C3%B6r%20nygrekisk%20skrift.pdf> ;
   :inCollection </i18n/rule/x0> .
 
 </i18n/rule/x0/yivo> a :LanguageTransformRules ;
-  :label "Translitterering enligt YIVO"@sv ;
+  :label "YIVO"@sv ;
+  :description "Romanisering enligt YIVO Institute for Jewish Research"@sv ;
   :code "yivo" ;
+  :seeAlso <https://yivo.org/yiddish-alphabet> ;
   :inCollection </i18n/rule/x0> .
 
 </i18n/rule/m0/alaloc> a :LanguageTransformRules ;
-  :label "Romanisering enligt ALA-LOC"@sv ;
+  :label "ALA-LC"@sv ;
+  :description "Romanisering enligt ALA-LC (American Library Association och Library of Congress)"@sv ;
   :code "alaloc" ;
+  :seeAlso <https://www.loc.gov/catdir/cpso/roman.html> ;
   :inCollection </i18n/rule/m0> .

--- a/source/vocab/display.jsonld
+++ b/source/vocab/display.jsonld
@@ -340,7 +340,7 @@
           "@id": "TransformedLanguageForm-chips",
           "@type": "fresnel:Lens",
           "classLensDomain": "TransformedLanguageForm",
-          "showProperties": [ "prefLabel", "inLanguage", "inLangScript"]
+          "showProperties": [ "prefLabel", "inLanguage", "langTransformAccordingTo"]
         },
         "marc:LanguageNote": {
           "@id": "LanguageNote-chips",


### PR DESCRIPTION
Display rule in language tag chips for transformed strings.
e.g. "Armenian · ALA-LC" instead of "Armenian · latin alphabet"