### PR TITLE
Update swedish label for instanceOf

### DIFF
--- a/source/vocab/things.ttl
+++ b/source/vocab/things.ttl
@@ -80,7 +80,7 @@
 
 :instanceOf a owl:ObjectProperty ;
     :category :integral ;
-    rdfs:label "instans av Verk"@sv;
+    rdfs:label "instans av"@sv;
     owl:inverseOf :hasInstance ;
     owl:equivalentProperty bf2:instanceOf;
     rdfs:subPropertyOf sdo:exampleOfWork, dc:isFormatOf, rdfa:copy;


### PR DESCRIPTION
Simplify Swedish label for instanceOf -> "instans av" instead of "instans av Verk".

Not needed for qualification when we get more titles in works.