### PR TITLE
Add image, thumbnail, ImageObject, contributor to vocab

### DIFF
--- a/source/vocab/relations.ttl
+++ b/source/vocab/relations.ttl
@@ -195,7 +195,15 @@
     rdfs:domain :Resource;
     rdfs:range :ImageObject;
     rdfs:subPropertyOf :isPrimaryTopicOf;
-    owl:equivalentProperty sdo:image .
+    owl:equivalentProperty sdo:image, foaf:depicts .
+
+ :imageOf a owl:ObjectProperty;
+    rdfs:label "image of"@en, "bild på"@sv;
+    rdfs:comment "Det som finns på bilden."@sv;
+    rdfs:domain :ImageObject;
+    rdfs:range :Resource;
+    rdfs:subPropertyOf sdo:about ;
+    owl:equivalentProperty foaf:depicts .    
 
 :thumbnail a owl:ObjectProperty;
     rdfs:label "thumbnail"@en, "miniatyrbild"@sv;

--- a/source/vocab/relations.ttl
+++ b/source/vocab/relations.ttl
@@ -191,15 +191,15 @@
 
 :image a owl:ObjectProperty;
     rdfs:label "image"@en, "bild"@sv;
-    rdfs:comment "En bild på resursen"@sv;
+    rdfs:comment "En bild på resursen."@sv;
     rdfs:domain :Resource;
     rdfs:range :ImageObject;
     rdfs:subPropertyOf :isPrimaryTopicOf;
     owl:equivalentProperty sdo:image, foaf:depicts .
 
- :imageOf a owl:ObjectProperty;
+:imageOf a owl:ObjectProperty;
     rdfs:label "image of"@en, "bild på"@sv;
-    rdfs:comment "Det som finns på bilden."@sv;
+    rdfs:comment "Resurs som förekommer på bilden."@sv;
     rdfs:domain :ImageObject;
     rdfs:range :Resource;
     rdfs:subPropertyOf sdo:about ;

--- a/source/vocab/relations.ttl
+++ b/source/vocab/relations.ttl
@@ -195,7 +195,7 @@
     rdfs:domain :Resource;
     rdfs:range :ImageObject;
     rdfs:subPropertyOf :isPrimaryTopicOf;
-    owl:equivalentProperty sdo:image, foaf:depicts .
+    owl:equivalentProperty sdo:image, foaf:depiction .
 
 :imageOf a owl:ObjectProperty;
     rdfs:label "image of"@en, "bild på"@sv;

--- a/source/vocab/relations.ttl
+++ b/source/vocab/relations.ttl
@@ -619,7 +619,7 @@
 :contributor a owl:DatatypeProperty;
     :category :shorthand;
     rdfs:label "Contributor"@en, "Medverkande"@sv;
-    rdfs:domain :Document; # TODO?
+    sdo:domainIncludes :Endeavour, :MediaObject ;
     owl:equivalentProperty dc:contributor;
     rdfs:subPropertyOf prov:wasAttributedTo;
     owl:propertyChainAxiom ( :contribution :agent ) .

--- a/source/vocab/relations.ttl
+++ b/source/vocab/relations.ttl
@@ -194,7 +194,7 @@
     rdfs:comment "En bild på resursen"@sv;
     rdfs:domain :Resource;
     rdfs:range :ImageObject;
-    rdfs:subPropertyOf :associatedMedia;
+    rdfs:subPropertyOf :isPrimaryTopicOf;
     owl:equivalentProperty sdo:image .
 
 :thumbnail a owl:ObjectProperty;

--- a/source/vocab/relations.ttl
+++ b/source/vocab/relations.ttl
@@ -189,6 +189,28 @@
     rdfs:subClassOf :Document;
     owl:equivalentClass sdo:MediaObject .
 
+:image a owl:ObjectProperty;
+    rdfs:label "image"@en, "bild"@sv;
+    rdfs:comment "En bild på resursen"@sv;
+    rdfs:domain :Resource;
+    rdfs:range :ImageObject;
+    rdfs:subPropertyOf :associatedMedia;
+    owl:equivalentProperty sdo:image .
+
+:thumbnail a owl:ObjectProperty;
+    rdfs:label "thumbnail"@en, "miniatyrbild"@sv;
+    skos:altLabel "tumnagel"@sv, "indexbild"@sv;
+    rdfs:comment "En förminskad bild"@sv;
+    sdo:domainIncludes :ImageObject;
+    sdo:rangeIncludes :ImageObject;
+    rdfs:subPropertyOf :image;
+    owl:equivalentProperty sdo:thumbnail .
+
+:ImageObject a owl:Class;
+    rdfs:label "Image object"@en, "Bildobjekt"@sv;
+    rdfs:subclassOf :MediaObject;
+    owl:equivalentClass sdo:ImageObject .
+
 :electronicLocator a owl:ObjectProperty;
     rdfs:label "Electronic location"@en, "Elektronisk adress"@sv;
     sdo:domainIncludes :Item, :Instance;
@@ -593,6 +615,14 @@
 :contributionOf a owl:ObjectProperty ;
     ptg:abstract true;
     owl:equivalentProperty bf2:contributionOf .
+
+:contributor a owl:DatatypeProperty;
+    :category :shorthand;
+    rdfs:label "Contributor"@en, "Medverkande"@sv;
+    rdfs:domain :Document; # TODO?
+    owl:equivalentProperty dc:contributor;
+    rdfs:subPropertyOf prov:wasAttributedTo;
+    owl:propertyChainAxiom ( :contribution :agent ) .
 
 :Contribution a owl:Class ;
     rdfs:label "Medverkan"@sv ;


### PR DESCRIPTION
Add properties and classes for representing images of any kind of resource (e.g. instances/works/persons/concepts), and thumbnails thereof.

These are *specific* relationships, to overcome the vagueness and possibly contradictory interpretations of `associatedMedia` (and e.g. the *very* specific `hasRepresentation` (see also PREMIS disjointedness)).