### PR TITLE
Add definitions for detailed change notes 

### DIFF
--- a/source/apps.jsonld
+++ b/source/apps.jsonld
@@ -22,7 +22,7 @@
     {
       "@id": "https://libris.kb.se/find",
       "@type": "DataService",
-      "titleByLang":  {"sv": "Sök-tjänst", "en": "Search Service"},
+      "titleByLang":  {"sv": "Libris sök", "en": "Libris Search"},
       "statistics": {
         "sliceList": [
           { "dimensionChain": [{"inverseOfTerm": "itemOf"}, "heldBy"], "itemLimit": 1000 },

--- a/source/changenotes.ttl
+++ b/source/changenotes.ttl
@@ -1,0 +1,25 @@
+prefix skos: <http://www.w3.org/2004/02/skos/core#>
+prefix : <https://id.kb.se/vocab/>
+
+base <https://id.kb.se/>
+
+</changenote/primarycontribution> a :ChangeCategory ;
+  skos:prefLabel "Change of primary contribution"@en, "Ändring av primärt upphov"@sv .
+
+</changenote/worktitle> a :ChangeCategory ;
+  skos:prefLabel "Change of work title"@en, "Ändring av verkets titel"@sv .
+
+</changenote/primarytitle> a :ChangeCategory ;
+  skos:prefLabel "Change of primary title"@en, "Ändring av huvudtitel"@sv .
+
+</changenote/primatrypublication> a :ChangeCategory ;
+  skos:prefLabel "Change of primary publication"@en, "Ändring av primär utgivning"@sv .
+
+</changenote/targetaudience> a :ChangeCategory ;
+  skos:prefLabel "Change of target audience"@en, "Ändring av målgrupp"@sv .
+
+</changenote/classification> a :ChangeCategory ;
+  skos:prefLabel "Change of classification"@en, "Ändring av klassifikation"@sv .
+
+</changenote/serialrelation> a :ChangeCategory ;
+  skos:prefLabel "Change of serial relationships"@en, "Ändring av serierelation"@sv .

--- a/source/changenotes.ttl
+++ b/source/changenotes.ttl
@@ -18,8 +18,11 @@ base <https://id.kb.se/>
 </changenote/targetaudience> a :ChangeCategory ;
   skos:prefLabel "Change of target audience"@en, "Ändring av målgrupp"@sv .
 
-</changenote/classification> a :ChangeCategory ;
-  skos:prefLabel "Change of classification"@en, "Ändring av klassifikation"@sv .
+</changenote/ddcclassification> a :ChangeCategory ;
+  skos:prefLabel "Change of DDC classification"@en, "Ändring av DDK-klassifikation"@sv .
+  
+</changenote/sabclassification> a :ChangeCategory ;
+  skos:prefLabel "Change of SAB classification"@en, "Ändring av SAB-klassifikation"@sv .
 
 </changenote/serialrelation> a :ChangeCategory ;
   skos:prefLabel "Change of serial relationships"@en, "Ändring av serierelation"@sv .

--- a/source/changenotes.ttl
+++ b/source/changenotes.ttl
@@ -12,7 +12,7 @@ base <https://id.kb.se/>
 </changenote/primarytitle> a :ChangeCategory ;
   skos:prefLabel "Change of primary title"@en, "Ändring av huvudtitel"@sv .
 
-</changenote/primatrypublication> a :ChangeCategory ;
+</changenote/primarypublication> a :ChangeCategory ;
   skos:prefLabel "Change of primary publication"@en, "Ändring av primär utgivning"@sv .
 
 </changenote/targetaudience> a :ChangeCategory ;

--- a/source/changenotes.ttl
+++ b/source/changenotes.ttl
@@ -4,7 +4,7 @@ prefix : <https://id.kb.se/vocab/>
 base <https://id.kb.se/>
 
 </changenote/primarycontribution> a :ChangeCategory ;
-  skos:prefLabel "Change of primary contribution"@en, "Ändring av primärt upphov"@sv .
+  skos:prefLabel "Change of primary contribution"@en, "Ändring av primär medverkan"@sv .
 
 </changenote/worktitle> a :ChangeCategory ;
   skos:prefLabel "Change of work title"@en, "Ändring av verkets titel"@sv .

--- a/source/datasets/idkbse.ttl
+++ b/source/datasets/idkbse.ttl
@@ -180,6 +180,13 @@ base <https://id.kb.se/dataset/>
     :uriSpace "/generator/" ;
     :created "2018-04-25T18:55:14.723Z"^^xsd:dateTime .
 
+<changenotes> a :Dataset ;
+    :isPartOf <common> ;
+    :sourceData [ :uri 'build/changenotes.json.lines' ;
+        :sourceData [ :uri 'source/changenotes.ttl' ] ] ;
+    :uriSpace "/changenote/" ;
+    :created "2023-06-14T15:03:47Z"^^xsd:dateTime .
+
 <schemes> a :Dataset ;
     :isPartOf <common> ;
     :sourceData [ :uri 'build/schemes.json.lines' ;

--- a/source/generators.ttl
+++ b/source/generators.ttl
@@ -8,7 +8,7 @@
     rdfs:label "The MarcFrame Conversion Process of Libris XL"@en .
 
 <https://id.kb.se/generator/globalchanges> a bf2:GenerationProcess ;
-    rdfs:label "The Global Changes Process of Libris XL"@en, "LibrisXL:s globala ändringar" .
+    rdfs:label "The Global Changes Process of Libris XL"@en, "LibrisXL:s globala ändringar"@sv .
 
 <https://id.kb.se/generator/swepub-classifier> a bf2:GenerationProcess ;
     rdfs:label "Swepub Autoclassifier"@en, "Swepubs autoklassificering"@sv .

--- a/source/generators.ttl
+++ b/source/generators.ttl
@@ -8,25 +8,25 @@
     rdfs:label "The MarcFrame Conversion Process of Libris XL"@en .
 
 <https://id.kb.se/generator/globalchanges> a bf2:GenerationProcess ;
-    rdfs:label "The Global Changes Process of Libris XL"@en, "LibrisXL:s globala ändringar"@sv .
+    rdfs:label "The Global Changes Process of Libris XL"@en, "Libris XL:s globala ändringar"@sv .
 
 <https://id.kb.se/generator/swepub-classifier> a bf2:GenerationProcess ;
     rdfs:label "Swepub Autoclassifier"@en, "Swepubs autoklassificering"@sv .
 
 <https://id.kb.se/generator/apix> a bf2:GenerationProcess ;
-    rdfs:label "The APIX subsystem of LibrisXL"@en, "APIX"@sv .
+    rdfs:label "The APIX subsystem of Libris XL"@en, "APIX"@sv .
 
 <https://id.kb.se/generator/batchimport> a bf2:GenerationProcess ;
-    rdfs:label "The batch import subsystem of LibrisXL"@en .
+    rdfs:label "The batch import subsystem of Libris XL"@en .
 
 <https://id.kb.se/generator/voyager> a bf2:GenerationProcess ;
     rdfs:label "The pre-2018 implementation of Libris"@en .
 
 <https://id.kb.se/generator/whelkcopier> a bf2:GenerationProcess ;
-    rdfs:label "The WhelkCopier subsystem of LibrisXL, used to copy data between Libris XL instances"@en .
+    rdfs:label "The WhelkCopier subsystem of Libris XL, used to copy data between Libris XL instances"@en .
 
 <https://id.kb.se/generator/crud> a bf2:GenerationProcess ;
-    rdfs:label "The REST API of Libris XL"@en, "LibrisXL:s REST-API"@sv .
+    rdfs:label "The REST API of Libris XL"@en, "Libris XL:s REST-API"@sv .
 
 <https://id.kb.se/generator/cataloguing> a bf2:GenerationProcess ;
     rdfs:label "The Libris XL Cataloguing Tool"@en, "Libris katalogisering"@sv .

--- a/source/generators.ttl
+++ b/source/generators.ttl
@@ -2,28 +2,34 @@
 @prefix bf2: <http://id.loc.gov/ontologies/bibframe/> .
 
 <https://id.kb.se/generator/definitions> a bf2:GenerationProcess ;
-    rdfs:label "The Definitions Dataset Generator of Libris XL" .
+    rdfs:label "The Definitions Dataset Generator of Libris XL"@en .
 
 <https://id.kb.se/generator/marcframe> a bf2:GenerationProcess ;
-    rdfs:label "The MarcFrame Conversion Process of Libris XL" .
+    rdfs:label "The MarcFrame Conversion Process of Libris XL"@en .
 
 <https://id.kb.se/generator/globalchanges> a bf2:GenerationProcess ;
-    rdfs:label "The Global Changes Process of Libris XL" .
+    rdfs:label "The Global Changes Process of Libris XL"@en, "LibrisXL:s globala ändringar" .
 
 <https://id.kb.se/generator/swepub-classifier> a bf2:GenerationProcess ;
-    rdfs:label "Swepub Autoclassifier" .
+    rdfs:label "Swepub Autoclassifier"@en, "Swepubs autoklassificering"@sv .
 
 <https://id.kb.se/generator/apix> a bf2:GenerationProcess ;
-    rdfs:label "The APIX subsystem of LibrisXL" .
+    rdfs:label "The APIX subsystem of LibrisXL"@en, "APIX"@sv .
 
 <https://id.kb.se/generator/batchimport> a bf2:GenerationProcess ;
-    rdfs:label "The batch import subsystem of LibrisXL" .
+    rdfs:label "The batch import subsystem of LibrisXL"@en .
 
 <https://id.kb.se/generator/voyager> a bf2:GenerationProcess ;
-    rdfs:label "The pre-2018 implementation of Libris" .
+    rdfs:label "The pre-2018 implementation of Libris"@en .
 
 <https://id.kb.se/generator/whelkcopier> a bf2:GenerationProcess ;
-    rdfs:label "The WhelkCopier subsystem of LibrisXL, used to copy data between Libris XL instances" .
+    rdfs:label "The WhelkCopier subsystem of LibrisXL, used to copy data between Libris XL instances"@en .
 
 <https://id.kb.se/generator/crud> a bf2:GenerationProcess ;
-    rdfs:label "The REST API of Libris XL" .
+    rdfs:label "The REST API of Libris XL"@en, "LibrisXL:s REST-API"@sv .
+
+<https://id.kb.se/generator/cataloguing> a bf2:GenerationProcess ;
+    rdfs:label "The Libris XL Cataloguing Tool"@en, "Libris katalogisering"@sv .
+
+<https://id.kb.se/generator/mergeworks> a bf2:GenerationProcess ;
+    rdfs:label "The Work Merger Tool"@en, "Automatisk Verkssammanslagning"@sv .

--- a/source/vocab/base.ttl
+++ b/source/vocab/base.ttl
@@ -159,6 +159,7 @@ rdf:type a owl:ObjectProperty;
 
 :category a owl:ObjectProperty;
     rdfs:label "category"@en, "kategori"@sv;
+    sdo:domainIncludes :ChangeNote ;
     owl:equivalentProperty sdo:category .
 
 ##
@@ -233,7 +234,7 @@ rdf:type a owl:ObjectProperty;
 
 :comment a owl:DatatypeProperty;
     rdfs:label "comment"@en, "kommentar"@sv;
-    sdo:domainIncludes :Agent, :Title, :ToCEntry, :EAN, :UPC, :Language, :Script ;
+    sdo:domainIncludes :Agent, :Title, :ToCEntry, :EAN, :UPC, :Language, :Script , :ChangeNote ;
     owl:equivalentProperty rdfs:comment .
 
 :code a owl:DatatypeProperty;

--- a/source/vocab/concepts.ttl
+++ b/source/vocab/concepts.ttl
@@ -285,7 +285,8 @@
 :changeNote a owl:DatatypeProperty;
     rdfs:label "Change note"@en, "Anmärkning om ändring"@sv;
     rdfs:domain :Concept;
-    owl:equivalentProperty skos:changeNote .
+    owl:equivalentProperty skos:changeNote ;
+    owl:propertyChainAxiom (:hasChangeNote :label) .
 
 :editorialNote a owl:DatatypeProperty;
     rdfs:label "editorial note"@en, "redaktionell anmärkning"@sv;

--- a/source/vocab/details.ttl
+++ b/source/vocab/details.ttl
@@ -1320,6 +1320,13 @@
     rdfs:comment "Oformaterad uppgift om datum/årtal/tidsperiod."@sv;
     owl:equivalentProperty bf2:date, dc:date .
 
+:atTime a owl:DatatypeProperty ;
+  owl:equivalentProperty prov:atTime ;
+  sdo:domainIncludes :Event , :ChangeNote ;
+  rdfs:label "at time"@en, "tidpunkt"@sv ;
+  rdfs:comment "Tidpunkt angiven med exakt tidsstämpel."@sv ;
+  rdfs:range xsd:dateTime .
+
 :year a owl:DatatypeProperty;
     sdo:domainIncludes :PrimaryProvisionActivity;
     rdfs:subPropertyOf :date;

--- a/source/vocab/display.jsonld
+++ b/source/vocab/display.jsonld
@@ -72,6 +72,19 @@
           "showProperties": [
             "agent"
           ]
+        },
+        "GenerationProcess": {
+          "@type": "fresnel:Lens",
+          "classLensDomain": "GenerationProcess",
+          "showProperties": [
+            {"alternateProperties": ["code", "label"]}
+          ]
+        },
+        "ChangeNote": {
+          "@id": "ChangeNote-tokens",
+          "@type": "fresnel:Lens",
+          "classLensDomain": "ChangeNote",
+          "showProperties": [ "category" ]
         }
       }
     },
@@ -519,6 +532,13 @@
           "@type": "fresnel:Lens",
           "classLensDomain": "PoliticalTendencyPeriod",
           "showProperties": [ "politicalTendency", "firstIssueDate", "lastIssueDate" ]
+        },
+        "ChangeNote": {
+          "@id": "ChangeNote-chips",
+          "@type": "fresnel:Lens",
+          "classLensDomain": "ChangeNote",
+          "fresnel:extends": {"@id": "ChangeNote-tokens"},
+          "showProperties": [ "fresnel:super", "label", "tool" ]
         }
       }
     },
@@ -537,7 +557,7 @@
           "@type": "fresnel:Lens",
           "@id": "Record-cards",
           "classLensDomain": "Record",
-          "showProperties": [ "controlNumber", "inDataset", "created", "modified", "identifiedBy", "bibliography", "encodingLevel", "technicalNote", "recordStatus", "descriptionCreator", "descriptionUpgrader", "descriptionLastModifier", "descriptionConventions", "cataloguersNote",  "generationDate", "generationProcess", "sourceConsulted" ]
+          "showProperties": [ "controlNumber", "inDataset", "created", "modified", "identifiedBy", "bibliography", "encodingLevel", "hasChangeNote", "technicalNote", "recordStatus", "descriptionCreator", "descriptionUpgrader", "descriptionLastModifier", "descriptionConventions", "cataloguersNote",  "generationDate", "generationProcess", "sourceConsulted" ]
         },
         "Instance": {
           "@type": "fresnel:Lens",
@@ -1018,6 +1038,13 @@
           "@id": "TransformedLanguageForm-cards",
           "fresnel:extends": {"@id": "Resource-chips"},
           "showProperties": [ "fresnel:super", "inLanguage", "inLangScript", "fromLangScript", "langTransformAccordingTo" ]
+        },
+        "ChangeNote": {
+          "@id": "ChangeNote-cards",
+          "@type": "fresnel:Lens",
+          "classLensDomain": "ChangeNote",
+          "fresnel:extends": {"@id": "ChangeNote-chips"},
+          "showProperties": [ "category", "label", "comment", "atTime", "tool" ]
         }
       }
     },
@@ -1231,6 +1258,13 @@
         },
         "TransformedLanguageForm": {
           "fresnel:extends": {"@id": "TransformedLanguageForm-cards"},
+          "showProperties": [ "fresnel:super" ]
+        },
+        "ChangeNote": {
+          "@id": "ChangeNote-full",
+          "@type": "fresnel:Lens",
+          "classLensDomain": "ChangeNote",
+          "fresnel:extends": {"@id": "ChangeNote-cards"},
           "showProperties": [ "fresnel:super" ]
         }
       }

--- a/source/vocab/platform.ttl
+++ b/source/vocab/platform.ttl
@@ -186,6 +186,7 @@
     rdfs:subPropertyOf bf2:descriptionConventions, :conformsTo .
 
 :derivedFrom a owl:ObjectProperty;
+    :category :platform ;
     rdfs:label "Source metadata"@en, "Metadatakälla"@sv;
     rdfs:comment "Länk till metadata som var källan för resursen"@sv;
     rdfs:domain :AdminMetadata;
@@ -267,22 +268,26 @@
 # Technical  details and change descriptions {{{
 
 :technicalNote a owl:ObjectProperty;
+    :category :platform ;
     rdfs:subPropertyOf :hasNote;
     rdfs:domain :Record;
     rdfs:range :TechnicalNote;
     rdfs:label "technical note"@en, "systemteknisk anmärkning"@sv .
 
 :TechnicalNote a owl:Class;
+    :category :platform ;
     rdfs:subClassOf :StructuredValue;
     rdfs:label "Technical note"@en, "Systemteknisk anmärkning"@sv .
 
 :hasChangeNote a owl:ObjectProperty ;
+    :category :platform ;
     rdfs:subPropertyOf :technicalNote ;
     sdo:domainIncludes :Record ;
     rdfs:range :ChangeNote ;
     rdfs:label "Change note"@en, "Ändringsanmärkning"@sv .
 
 :ChangeNote a owl:Class ;
+    :category :platform ;
     rdfs:subClassOf :TechnicalNote ;
     rdfs:subClassOf [ a owl:Restriction ;
           owl:onProperty :category ;
@@ -291,14 +296,17 @@
     rdfs:label "Change note"@en, "Ändringsanmärkning"@sv .
 
 :ChangeCategory a owl:Class ;
+    :category :platform ;
     rdfs:subClassOf :Concept ;
     rdfs:label "Change Category"@en, "Ändringskategori"@sv .
 
 :CreateNote a owl:Class ;
+    :category :platform ;
     rdfs:subClassOf :ChangeNote ;
     rdfs:label "Create note"@en, "Uppkomstanmärkning"@sv .
 
 :tool a owl:ObjectProperty ;
+    :category :platform ;
     sdo:domainIncludes :ChangeNote ;
     sdo:rangeIncludes :GenerationProcess ;
     rdfs:label "Tool"@en, "Verktyg"@sv .

--- a/source/vocab/platform.ttl
+++ b/source/vocab/platform.ttl
@@ -3,6 +3,7 @@
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix sdo: <http://schema.org/> .
 @prefix ptg: <http://protege.stanford.edu/plugins/owl/protege#> .
 @prefix fresnel: <http://www.w3.org/2004/09/fresnel#> .
 
@@ -262,6 +263,47 @@
     rdfs:range :Dataset;
     owl:equivalentProperty void:inDataset;
     rdfs:subPropertyOf dc:isPartOf .
+
+# Technical  details and change descriptions {{{
+
+:technicalNote a owl:ObjectProperty;
+    rdfs:subPropertyOf :hasNote;
+    rdfs:domain :Record;
+    rdfs:range :TechnicalNote;
+    rdfs:label "technical note"@en, "systemteknisk anmärkning"@sv .
+
+:TechnicalNote a owl:Class;
+    rdfs:subClassOf :StructuredValue;
+    rdfs:label "Technical note"@en, "Systemteknisk anmärkning"@sv .
+
+:hasChangeNote a owl:ObjectProperty ;
+  rdfs:subPropertyOf :technicalNote ;
+  sdo:domainIncludes :Record ;
+  rdfs:range :ChangeNote ;
+  rdfs:label "Change note"@en, "Ändringsanmärkning"@sv .
+
+:ChangeNote a owl:Class ;
+  rdfs:subClassOf :TechnicalNote ;
+  rdfs:subClassOf [ a owl:Restriction ;
+      owl:onProperty :category ;
+      owl:allValuesFrom :ChangeCategory
+    ] ;
+  rdfs:label "Change note"@en, "Ändringsanmärkning"@sv .
+
+:ChangeCategory a owl:Class ;
+  rdfs:subClassOf :Concept ;
+  rdfs:label "Change Category"@en, "Ändringskategori"@sv .
+
+:CreateNote a owl:Class ;
+  rdfs:subClassOf :ChangeNote ;
+  rdfs:label "Create note"@en, "Uppkomstanmärkning"@sv .
+
+:tool a owl:ObjectProperty ;
+  sdo:domainIncludes :ChangeNote ;
+  sdo:rangeIncludes :GenerationProcess ;
+  rdfs:label "Tool"@en, "Verktyg"@sv .
+
+# }}}
 
 :uriSpace a owl:DatatypeProperty ;
     :category :platform ;

--- a/source/vocab/platform.ttl
+++ b/source/vocab/platform.ttl
@@ -277,31 +277,31 @@
     rdfs:label "Technical note"@en, "Systemteknisk anmärkning"@sv .
 
 :hasChangeNote a owl:ObjectProperty ;
-  rdfs:subPropertyOf :technicalNote ;
-  sdo:domainIncludes :Record ;
-  rdfs:range :ChangeNote ;
-  rdfs:label "Change note"@en, "Ändringsanmärkning"@sv .
+    rdfs:subPropertyOf :technicalNote ;
+    sdo:domainIncludes :Record ;
+    rdfs:range :ChangeNote ;
+    rdfs:label "Change note"@en, "Ändringsanmärkning"@sv .
 
 :ChangeNote a owl:Class ;
-  rdfs:subClassOf :TechnicalNote ;
-  rdfs:subClassOf [ a owl:Restriction ;
-      owl:onProperty :category ;
-      owl:allValuesFrom :ChangeCategory
-    ] ;
-  rdfs:label "Change note"@en, "Ändringsanmärkning"@sv .
+    rdfs:subClassOf :TechnicalNote ;
+    rdfs:subClassOf [ a owl:Restriction ;
+          owl:onProperty :category ;
+          owl:allValuesFrom :ChangeCategory
+      ] ;
+    rdfs:label "Change note"@en, "Ändringsanmärkning"@sv .
 
 :ChangeCategory a owl:Class ;
-  rdfs:subClassOf :Concept ;
-  rdfs:label "Change Category"@en, "Ändringskategori"@sv .
+    rdfs:subClassOf :Concept ;
+    rdfs:label "Change Category"@en, "Ändringskategori"@sv .
 
 :CreateNote a owl:Class ;
-  rdfs:subClassOf :ChangeNote ;
-  rdfs:label "Create note"@en, "Uppkomstanmärkning"@sv .
+    rdfs:subClassOf :ChangeNote ;
+    rdfs:label "Create note"@en, "Uppkomstanmärkning"@sv .
 
 :tool a owl:ObjectProperty ;
-  sdo:domainIncludes :ChangeNote ;
-  sdo:rangeIncludes :GenerationProcess ;
-  rdfs:label "Tool"@en, "Verktyg"@sv .
+    sdo:domainIncludes :ChangeNote ;
+    sdo:rangeIncludes :GenerationProcess ;
+    rdfs:label "Tool"@en, "Verktyg"@sv .
 
 # }}}
 

--- a/source/vocab/unstable.ttl
+++ b/source/vocab/unstable.ttl
@@ -23,16 +23,6 @@
 
 # NOTE
 
-:technicalNote a owl:ObjectProperty;
-    rdfs:subPropertyOf :hasNote;
-    rdfs:domain :Record;
-    rdfs:range :TechnicalNote;
-    rdfs:label "technical note"@en, "systemteknisk anmärkning"@sv .
-
-:TechnicalNote a owl:Class;
-    rdfs:subClassOf :StructuredValue;
-    rdfs:label "Technical note"@en, "Systemteknisk anmärkning"@sv .
-
 :ToCEntry a owl:Class;
     rdfs:label "Table of contents entry"@en, "Utökad innehållsförteckning"@sv .
 

--- a/sys/context/kbv.jsonld
+++ b/sys/context/kbv.jsonld
@@ -14,6 +14,7 @@
 
     "created": {"@type": "xsd:dateTime"},
     "modified": {"@type": "xsd:dateTime"},
+    "atTime": {"@type": "xsd:dateTime"},
 
     "birthYear": {"@id": "birthDate", "@type": "Year"},
     "deathYear": {"@id": "deathDate", "@type": "Year"},


### PR DESCRIPTION
These are for detailed record provenance data, including creation and relevant change events.

Includes:
- Add `ChangeNote` and `CreateNote` classes (based on `TechnicalNote`) and add/update related properties.
- Add `tool` property for linking to defined tools/processes. (Possibly to be used on the record itself as well.)
- Add change categories, more generators and edit some labels
- Update display accrordingly.

Details are modelled as "notes" rather than "events", mainly since notes are more "OK" to conflate details within, whereas an event design could lead into "unattainable perfection" territory ("crude" vs. "too abstract"). Also, an event-oriented design may be at odds with a record design for data management. This may merit some discussion of course...