### PR TITLE
Update translationOf in work card order

### DIFF
--- a/source/vocab/display.jsonld
+++ b/source/vocab/display.jsonld
@@ -618,6 +618,7 @@
             "originDate",
             "contribution",
             "language",
+            "translationOf",
             "hasNotation",
             "hasVariant",
             "inCollection",
@@ -630,7 +631,6 @@
             "dissertation",
             "cartographicAttributes",
             "isPartOf",
-            "translationOf",
             {"inverseOf": "instanceOf"}
 
           ]


### PR DESCRIPTION
Move translationOf higher in order of cards (not full view because of workflow differences) to ease spotting the correct work.

See LXL-4193