### PR TITLE
Add labels for Endeavour, Creation and Embodiment

### DIFF
--- a/source/vocab/things.ttl
+++ b/source/vocab/things.ttl
@@ -42,11 +42,13 @@
 :Endeavour a owl:Class ;
     ptg:abstract true;
     #TOOD? skos:relatedMatch <http://purl.org/vocab/frbr/core#Endeavour>
+    rdfs:label "Verk, instans eller exemplar"@sv, "Endeavour"@en ;
     rdfs:comment "Abstrakt basklass för :Work, :Instance och :Item."@sv;    
     rdfs:subClassOf :Document .
 
 :Creation a owl:Class ;
     ptg:abstract true;
+    rdfs:label "Verk eller instans"@sv, "Creation"@en ;
     rdfs:comment "Abstrakt basklass för :Work och :Instance."@sv;
     rdfs:subClassOf :Endeavour ;
     rdfs:subClassOf sdo:CreativeWork, dc:BibliographicResource .
@@ -54,6 +56,7 @@
 # Inspiration taken from relation http://purl.org/vocab/frbr/core#embodiment
 :Embodiment a owl:Class ;
     ptg:abstract true;
+    rdfs:label "Instans eller exemplar"@sv, "Embodiment"@en ;
     rdfs:comment "Abstrakt basklass för :Instance och :Item."@sv;
     rdfs:subClassOf :Endeavour .
 


### PR DESCRIPTION
The English labels are just the formal name, the Swedish ones are in the "X or Y" form suggested. Use these for the English ones too?

(Note: `Embodiment` is also the baseclass of `Representation` (which is from PREMIS and has an "interesting" relationship to `bf:Item`)...)