### PR TITLE
Add standalone Work-full lens

### DIFF
--- a/source/vocab/display.jsonld
+++ b/source/vocab/display.jsonld
@@ -1123,11 +1123,36 @@
         "Work": {
           "fresnel:extends": {"@id": "Work-cards"},
           "showProperties": [
-            "fresnel:super",
+            {
+              "alternateProperties": [
+                {"subPropertyOf": "hasTitle", "range": "KeyTitle"},
+                {"subPropertyOf": "hasTitle", "range": "Title"},
+                "hasTitle"
+              ]
+            },
+            "legalDate",
+            "version",
+            "marc:arrangedStatementForMusic",
+            "originDate",
+            "contribution",
+            "language",
+            "hasNotation",
+            "hasVariant",
+            "inCollection",
+            "genreForm",
+            "classification",
+            "subject",
+            "intendedAudience",
+            "contentType",
+            "dissertation",
+            "cartographicAttributes",
+            "isPartOf",
+            "translationOf",
             "continues",
             {"inverseOf": "continuedBy"},
             "continuedBy",
-            {"inverseOf": "continues"}
+            {"inverseOf": "continues"},
+            {"inverseOf": "instanceOf"}
           ]
         },
         "NotatedMusic": {


### PR DESCRIPTION
Removing Work full lens-extension from Card. To not chase our tails so we can both have a relation to translationOf as a distinct related entity last in the fullview and having an original title and language readily available in the card view through `translationOf/hasTitle|language` .