### PR TITLE
Swepub: add PublicationStatus Retracted

### DIFF
--- a/source/swepub/terms.ttl
+++ b/source/swepub/terms.ttl
@@ -29,11 +29,6 @@ swepub:InPress a swepub:PublicationStatus ;
     rdfs:comment "Artiklar som har färdigställs för formell publicering."@sv ;
     rdfs:comment "Articles that have been completed for formal publication."@en .
 
-swepub:Redacted a swepub:PublicationStatus ;
-    skos:prefLabel "Redacted"@en ;
-    rdfs:comment "Publicerat material som har blivit tillbakadraget."@sv ;
-    rdfs:comment "Publication that has been retracted."@en .
-
 swepub:Retracted a swepub:PublicationStatus ;
     skos:prefLabel "Retracted"@en ;
     rdfs:comment "Publikation som har blivit återtagen."@sv ;

--- a/source/swepub/terms.ttl
+++ b/source/swepub/terms.ttl
@@ -34,6 +34,11 @@ swepub:Redacted a swepub:PublicationStatus ;
     rdfs:comment "Publicerat material som har blivit tillbakadraget."@sv ;
     rdfs:comment "Publication that has been retracted."@en .
 
+swepub:Retracted a swepub:PublicationStatus ;
+    skos:prefLabel "Retracted"@en ;
+    rdfs:comment "Publikation som har blivit återtagen."@sv ;
+    rdfs:comment "Output which has been withdrawn."@en .
+
 
 swepub:EpubAheadOfPrintOnlineFirst a swepub:PublicationStatus ;
     skos:prefLabel "Epub ahead of print/Online first"@en ;


### PR DESCRIPTION
https://jira.kb.se/browse/SWEPUB2-1112

Should we perhaps at the same time remove the seemingly unused `swepub:Redacted`?