### PR TITLE
Add hasComponent to Item search-chip

### DIFF
--- a/source/vocab/display.jsonld
+++ b/source/vocab/display.jsonld
@@ -1372,7 +1372,7 @@
       "lenses": {
         "Item": {
           "fresnel:extends": {"@id": "Item-chips"},
-          "showProperties": [ "fresnel:super", "subject", "summary" ]
+          "showProperties": [ "fresnel:super", "subject", "summary", "hasComponent" ]
         },
         "Person": {
           "fresnel:extends": {"@id": "Person-chips"},


### PR DESCRIPTION
So that the Items in hasComponent can be searched in the same way as the top-level Item.

Example: shelfMark in @reverse.itemOf
`/find?%40type=Instance&@reverse.itemOf.hasComponent.shelfMark.label=KoB*` 
should work in the same way as
`/find?%40type=Instance&@reverse.itemOf.shelfMark.label=KoB*`