### PR TITLE
Add availability to Item search-chips

### DIFF
--- a/source/vocab/display.jsonld
+++ b/source/vocab/display.jsonld
@@ -753,7 +753,8 @@
             "classification",
             "subject",
             "summary",
-            "immediateAcquisition"
+            "immediateAcquisition",
+            "availability"
           ]
         },
         "StructuredValue": {
@@ -1372,7 +1373,7 @@
       "lenses": {
         "Item": {
           "fresnel:extends": {"@id": "Item-chips"},
-          "showProperties": [ "fresnel:super", "subject", "summary", "hasComponent" ]
+          "showProperties": [ "fresnel:super", "subject", "summary", "hasComponent", "availability" ]
         },
         "Person": {
           "fresnel:extends": {"@id": "Person-chips"},


### PR DESCRIPTION
So that Instances can be filtered on `@reverse.itemOf.availability.@id` (or `@reverse.itemOf.hasComponent.availability.@id`)

Also need to add availability to Item-cards. Since search-chips are made from shrunk cards. (We might need to adjust this mechanism going forward)