### PR TITLE
Remove archival terms

### DIFF
--- a/source/marc/construct-enums.rq
+++ b/source/marc/construct-enums.rq
@@ -1622,7 +1622,7 @@ construct {
         #(marc:HoldingCharacterCodingType	marc:MARC-8-VRLIN	marc:HoldingCharacterCodingType-_	"_"	UNDEF	UNDEF	"MARC-8/VRLIN"@sv)
         # (marc:AuthorityCharacterCodingType	marc:MARC-8-VRLIN	marc:AuthorityCharacterCodingType-_)
 
-        (marc:TypeOfControlType	marc:ArchivalControl	marc:TypeOfControlType-a	"a"	UNDEF	UNDEF	"Resursen beskrivs enligt arkivalisk princip"@sv	"Archival control"@en)
+        #(marc:TypeOfControlType	marc:ArchivalControl	marc:TypeOfControlType-a	"a"	UNDEF	UNDEF	"Resursen beskrivs enligt arkivalisk princip"@sv	"Archival control"@en)
 
         (marc:RomanizationType	marc:InternationalStandard	marc:RomanizationType-a	"a"	UNDEF	UNDEF	"Internationell standard"@sv	"International standard"@en)
         (marc:RomanizationType	marc:ConventionalRomanizationOrConventionalFormOfNameInLanguageOfCatalogingAgency	marc:RomanizationType-g	"g"	UNDEF	UNDEF	"Transkription eller vedertagen form"@sv	"Conventional romanization or conventional form of name in language of cataloging agency"@en)

--- a/source/marc/enums.ttl
+++ b/source/marc/enums.ttl
@@ -1539,11 +1539,11 @@
 #    skos:prefLabel "Subject Subdivision"@en,
 #        "Typ av underindelning"@sv .
 
-:TypeOfControlType a :CollectionClass ;
-    rdfs:subClassOf :EnumeratedTerm ;
-    skos:notation "TypeOfControlType" ;
-    skos:prefLabel "Type of Control"@en,
-        "Kontrollkod för arkivmaterial"@sv .
+# :TypeOfControlType a :CollectionClass ;
+#     rdfs:subClassOf :EnumeratedTerm ;
+#     skos:notation "TypeOfControlType" ;
+#     skos:prefLabel "Type of Control"@en,
+#         "Kontrollkod för arkivmaterial"@sv .
 
 #:TypeOfRecordType a :CollectionClass ;
 #    rdfs:subClassOf :EnumeratedTerm ;

--- a/source/marc/enums.ttl
+++ b/source/marc/enums.ttl
@@ -2071,10 +2071,10 @@
 #    skos:prefLabel "Literary Text for Sound Recording"@en,
 #        "Typ av genre för text till ljudupptagning (ej musik)"@sv .
 
-:typeOfControl a owl:ObjectProperty ;
-    sdo:rangeIncludes :TypeOfControlType ;
-    skos:prefLabel "Type of Control"@en,
-        "Kontrollkod för arkivmaterial"@sv .
+# :typeOfControl a owl:ObjectProperty ;
+#     sdo:rangeIncludes :TypeOfControlType ;
+#     skos:prefLabel "Type of Control"@en,
+#         "Kontrollkod för arkivmaterial"@sv .
 
 :typeOfEntry a owl:ObjectProperty ;
     sdo:domainIncludes kbv:Serial ;

--- a/source/vocab/things.ttl
+++ b/source/vocab/things.ttl
@@ -319,10 +319,11 @@
 
 # Additional Work/Coordination Types
 
-:ArchivalUnit a owl:Class;
-    :category :pending ;
-    rdfs:label "Archival unit"@en, "Arkivenhet"@sv;
-    rdfs:subClassOf :Work .
+# :ArchivalUnit a owl:Class;
+#     owl:deprecated true ;
+#     :category :pending ;
+#     rdfs:label "Archival unit"@en, "Arkivenhet"@sv;
+#     rdfs:subClassOf :Work .
 
 :Kit a owl:Class;
     rdfs:label "Kit"@en, "Paket"@sv;


### PR DESCRIPTION
Removal of archival terms from BIB 000/06[b] (0 uses and obsolete since 1995) and 000/08 (noisy info on description purpose).

- [x] [librisxl PR](https://github.com/libris/librisxl/pull/1388) with Marcframe changes and Cleanupscript for marc:typeOfControl.

FMT-229