### PR TITLE
Feature/lws 35 terms for search mappings

### DIFF
--- a/source/vocab/platform.ttl
+++ b/source/vocab/platform.ttl
@@ -607,14 +607,14 @@
     rdfs:label "and"@en, "och"@sv ;
     skos:altLabel "&&" ;
     rdfs:domain :SearchMapping ;
-    rdfs:range rdf:List .
+    rdfs:range :SearchMapping .
 
 :or a owl:ObjectProperty ;
     :category :platform, :pending ;
     rdfs:label "or"@en, "eller"@sv ;
     skos:altLabel "||" ;
     rdfs:domain :SearchMapping ;
-    rdfs:range rdf:List .
+    rdfs:range :SearchMapping .
 
 :not a owl:ObjectProperty ;
     :category :platform, :pending ;

--- a/source/vocab/platform.ttl
+++ b/source/vocab/platform.ttl
@@ -602,6 +602,66 @@
     rdfs:range :PartialCollectionView;
     owl:inverseOf :items .
 
+:and a owl:ObjectProperty ;
+    :category :platform, :pending ;
+    rdfs:label "and"@en, "och"@sv ;
+    skos:altLabel "&&" ;
+    rdfs:domain :SearchMapping ;
+    rdfs:range rdf:List .
+
+:or a owl:ObjectProperty ;
+    :category :platform, :pending ;
+    rdfs:label "or"@en, "eller"@sv ;
+    skos:altLabel "||" ;
+    rdfs:domain :SearchMapping ;
+    rdfs:range rdf:List .
+
+:not a owl:ObjectProperty ;
+    :category :platform, :pending ;
+    rdfs:label "not"@en, "ej"@sv ;
+    skos:altLabel "!" ;
+    rdfs:domain :SearchMapping ;
+    rdfs:range :SearchMapping .
+
+:equals a rdf:Property ;
+    :category :platform, :pending ;
+    rdfs:label "equals"@en, "likamed"@sv ;
+    skos:altLabel "=" ;
+    rdfs:domain :SearchMapping .
+
+:notEquals a rdf:Property ;
+    :category :platform, :pending ;
+    rdfs:label "not equals"@en, "ej likamed"@sv ;
+    skos:altLabel "!=" ;
+    rdfs:domain :SearchMapping .
+
+:greaterThan a rdf:Property ;
+    :category :platform, :pending ;
+    rdfs:label "greater than"@en, "större än"@sv ;
+    skos:altLabel ">" ;
+    rdfs:domain :SearchMapping
+    rdfs:range rdf:Literal .
+
+:greaterThanOrEquals a rdf:Property ;
+    :category :platform, :pending ;
+    rdfs:label "greater than or equals"@en, "större än eller likamed"@sv ;
+    skos:altLabel ">=" ;
+    rdfs:domain :SearchMapping
+    rdfs:range rdf:Literal .
+
+:lessThan a rdf:Property ;
+    :category :platform, :pending ;
+    rdfs:label "less than"@en, "mindre än"@sv ;
+    skos:altLabel "<" ;
+    rdfs:domain :SearchMapping
+    rdfs:range rdf:Literal .
+
+:lessThanOrEquals a rdf:Property ;
+    :category :platform, :pending ;
+    rdfs:label "less than or equals"@en, "mindre än eller likamed"@sv ;
+    skos:altLabel "<=" ;
+    rdfs:domain :SearchMapping
+    rdfs:range rdf:Literal .
 
 ##
 # Containers (mainly used here for controlled URI:s)

--- a/sys/context/kbv.jsonld
+++ b/sys/context/kbv.jsonld
@@ -19,6 +19,8 @@
     "birthYear": {"@id": "birthDate", "@type": "Year"},
     "deathYear": {"@id": "deathDate", "@type": "Year"},
 
+    "and": {"@container": "@list" },
+    "or": {"@container": "@list" },
     "termComponentList": {"@container": "@list"},
     "sliceByDimension": {"@id": "slice", "@container": "@index"},
     "sliceList": {"@id": "slice", "@container": "@list"},


### PR DESCRIPTION
For representing boolean queries. See https://jira.kb.se/browse/LWS-35.

The immediate use of these terms is for search mappings, hence the strict domains/ranges. Can of course be less strict should we need the terms for other stuff.