### PR TITLE
Get property type right for contributor

### DIFF
--- a/source/vocab/relations.ttl
+++ b/source/vocab/relations.ttl
@@ -624,7 +624,7 @@
     ptg:abstract true;
     owl:equivalentProperty bf2:contributionOf .
 
-:contributor a owl:DatatypeProperty;
+:contributor a owl:ObjectProperty;
     :category :shorthand;
     rdfs:label "Contributor"@en, "Medverkande"@sv;
     sdo:domainIncludes :Endeavour, :MediaObject ;


### PR DESCRIPTION
Since `:contributor owl:propertyChainAxiom ( :contribution :agent ) .` and `:agent :range :Agent`