### PR TITLE
Add filter on concerning.issuanceType

### DIFF
--- a/source/apps.jsonld
+++ b/source/apps.jsonld
@@ -46,6 +46,7 @@
           { "dimensionChain": ["intendedAudience"], "itemLimit": 100 },
           { "dimensionChain": ["meta", "bibliography"], "itemLimit": 100 },
           { "dimensionChain": ["concerning", {"inverseOfTerm": "itemOf"}, "heldBy"], "itemLimit": 100, "connective": "OR", "_matchMissing": "concerning" },
+          { "dimensionChain": ["concerning", "issuanceType"], "itemLimit": 100 },
           { "dimensionChain": ["category"], "itemLimit": 100, "connective": "OR", "_matchMissing": "category"}
         ]
       }


### PR DESCRIPTION
Depends on https://github.com/libris/librisxl/commit/2e7a15a3d4957193251013fdb4163feda43cf681

Maybe we should add a mechanism to the search API that checks which keyword mappings are available before enabling a filter.
Otherwise the upgrade procedure is more involved. The index needs to be recreated before the filter can be added to apps.jsonld.