### PR TITLE
More precise KBV Item/Holding model

### DIFF
--- a/source/vocab/items.ttl
+++ b/source/vocab/items.ttl
@@ -1,6 +1,8 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix ptg: <http://protege.stanford.edu/plugins/owl/protege#> .
+
 @prefix sdo: <http://schema.org/> .
 @prefix bf2: <http://id.loc.gov/ontologies/bibframe/> .
 @prefix rdaent: <http://rdvocab.info/uri/schema/FRBRentitiesRDA/> .
@@ -26,17 +28,27 @@
 # BF2 ITEM/HOLDING LOCATION
 
 :Item a owl:Class ;
-    rdfs:label "Item"@en, "Bestånd"@sv ;
+    rdfs:label "Item"@en, "Exemplar"@sv ;
+    ptg:abstract true ;
     :category marc:hold;
     rdfs:subClassOf :Embodiment;
     skos:closeMatch rdaent:Item;
     owl:equivalentClass bf2:Item, sdo:Product, holding:Item .
     #TODO?: owl:equivalentClass [ owl:unionOf (sdo:Product sdo:Offer) ] ;
 
-:SingleItem a owl:Class ;
-    rdfs:subClassOf :Item ;
+:ItemHolding a owl:Class ;
+    rdfs:label "Item holding"@en, "Bestånd"@sv ;
+    rdfs:subClassOf :Item , sdo:SomeProducts  .
+
+:SomeItem a owl:Class ;
+    #ptg:abstract true ;
     :category marc:none ;
-    owl:equivalentClass sdo:IndividualProduct ;
+    rdfs:label "Some item"@en, "Något exemplar"@sv ;
+    rdfs:subClassOf :Item .
+
+:SingleItem a owl:Class ;
+    rdfs:subClassOf :SomeItem , sdo:IndividualProduct ;
+    :category marc:none ;
     rdfs:label "Single item"@en, "Exemplar"@sv .
 
 :itemOf a owl:ObjectProperty ;
@@ -256,10 +268,9 @@
     rdfs:label "has component"@en, "har komponent"@sv ;
     :category :compositional, :integral;
     rdfs:subPropertyOf bf2:hasPart ;
-    rdfs:domain :Item ;
     owl:inverseOf :componentOf ;
-    # TODO: rdfs:domain :SomeItems ;
-    rdfs:range :Item ;
+    rdfs:domain :ItemHolding ;
+    rdfs:range :SomeItem ;
     skos:note "Retained from BF1 to enable an Item entity to describe several Items within the same holding. (Historically due to local variations in Libris MARC21-spec.)"@en .
 
 :componentOf a owl:ObjectProperty ;

--- a/source/vocab/items.ttl
+++ b/source/vocab/items.ttl
@@ -2,7 +2,6 @@
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix ptg: <http://protege.stanford.edu/plugins/owl/protege#> .
-
 @prefix sdo: <http://schema.org/> .
 @prefix bf2: <http://id.loc.gov/ontologies/bibframe/> .
 @prefix rdaent: <http://rdvocab.info/uri/schema/FRBRentitiesRDA/> .
@@ -22,23 +21,20 @@
 # OTHER ITEM PROPERTIES AND CLASSES
 # RETAINED SCHEMA/BF1 MAPPINGS
 # EARLY LOCAL LIBRIS HOLDING TERMS
-# MODEL SUGGESTIONS
 
 ##
 # BF2 ITEM/HOLDING LOCATION
 
 :Item a owl:Class ;
-    rdfs:label "Item"@en, "Exemplar"@sv ;
-    ptg:abstract true ;
+    rdfs:label "Item"@en, "Bestånd"@sv ;
     :category marc:hold;
-    rdfs:subClassOf :Embodiment;
+    rdfs:subClassOf :Embodiment, sdo:Product;
     skos:closeMatch rdaent:Item;
-    owl:equivalentClass bf2:Item, sdo:Product, holding:Item .
-    #TODO?: owl:equivalentClass [ owl:unionOf (sdo:Product sdo:Offer) ] ;
+    owl:equivalentClass bf2:Item, holding:Item .
 
 :ItemHolding a owl:Class ;
-    rdfs:label "Item holding"@en, "Bestånd"@sv ;
-    rdfs:subClassOf :Item , sdo:SomeProducts  .
+    rdfs:label "Item holding"@en, "Beståndsinnehav"@sv ;
+    rdfs:subClassOf :Item , sdo:Offer  .
 
 :SomeItem a owl:Class ;
     #ptg:abstract true ;
@@ -46,10 +42,15 @@
     rdfs:label "Some item"@en, "Något exemplar"@sv ;
     rdfs:subClassOf :Item .
 
+:MultipleItems a owl:Class ;
+    rdfs:subClassOf :Item ;
+    rdfs:subClassOf sdo:SomeProducts ;
+    rdfs:label "Multiple items"@en, "Flera exemplar"@sv .
+
 :SingleItem a owl:Class ;
     rdfs:subClassOf :SomeItem , sdo:IndividualProduct ;
     :category marc:none ;
-    rdfs:label "Single item"@en, "Exemplar"@sv .
+    rdfs:label "Single item"@en, "Enskilt exemplar"@sv .
 
 :itemOf a owl:ObjectProperty ;
     rdfs:label "Holding for"@en, "bestånd på"@sv ;
@@ -267,9 +268,9 @@
 :hasComponent a owl:ObjectProperty ;
     rdfs:label "has component"@en, "har komponent"@sv ;
     :category :compositional, :integral;
-    rdfs:subPropertyOf bf2:hasPart ;
-    owl:inverseOf :componentOf ;
+    rdfs:subPropertyOf bf2:hasPart, sdo:itemOffered ;
     rdfs:domain :ItemHolding ;
+    owl:inverseOf :componentOf ;
     rdfs:range :SomeItem ;
     skos:note "Retained from BF1 to enable an Item entity to describe several Items within the same holding. (Historically due to local variations in Libris MARC21-spec.)"@en .
 
@@ -323,16 +324,3 @@
     rdfs:range rdfs:Literal ;
     rdfs:comment "Om materialet ställs upp efter titel, författare, ämne eller annat beskrivande uppställningsord. Kan kombineras med kompletterande placeringsuppgifter, t.ex. klassifikation eller uppställningsord."@sv;
     skos:example "Deckare", "Lagerlöf" .
-
-
-# MODEL SUGGESTIONS
-#
-# :MultipleItems a owl:Class ;
-#     rdfs:subClassOf :Item ;
-#     owl:equivalentClass sdo:SomeProducts ;
-#     rdfs:label "Multiple items"@en, "Flera exemplar"@sv .
-
-# :IndividualItem a owl:Class ;
-#     rdfs:subClassOf :Item ;
-#     owl:equivalentClass sdo:IndividualProduct ;
-#     rdfs:label "Individual item"@en, "Enskilt exemplar"@sv .

--- a/source/vocab/items.ttl
+++ b/source/vocab/items.ttl
@@ -26,6 +26,7 @@
 # BF2 ITEM/HOLDING LOCATION
 
 :Item a owl:Class ;
+    #ptg:abstract true ;
     rdfs:label "Item"@en, "Bestånd"@sv ;
     :category marc:hold;
     rdfs:subClassOf :Embodiment, sdo:Product;
@@ -37,7 +38,6 @@
     rdfs:subClassOf :Item , sdo:Offer  .
 
 :HeldComponent a owl:Class ;
-    #ptg:abstract true ;
     :category marc:none ;
     rdfs:label "Held component"@en, "Beståndskomponent"@sv ;
     rdfs:subClassOf :Item .

--- a/source/vocab/items.ttl
+++ b/source/vocab/items.ttl
@@ -42,11 +42,6 @@
     rdfs:label "Held component"@en, "Beståndskomponent"@sv ;
     rdfs:subClassOf :Item .
 
-:MultipleItems a owl:Class ;
-    rdfs:subClassOf :Item ;
-    rdfs:subClassOf sdo:SomeProducts ;
-    rdfs:label "Multiple items"@en, "Flera exemplar"@sv .
-
 :SingleItem a owl:Class ;
     rdfs:subClassOf :HeldComponent , sdo:IndividualProduct ;
     :category marc:none ;

--- a/source/vocab/items.ttl
+++ b/source/vocab/items.ttl
@@ -36,10 +36,10 @@
     rdfs:label "Item holding"@en, "Beståndsinnehav"@sv ;
     rdfs:subClassOf :Item , sdo:Offer  .
 
-:SomeItem a owl:Class ;
+:HeldComponent a owl:Class ;
     #ptg:abstract true ;
     :category marc:none ;
-    rdfs:label "Some item"@en, "Något exemplar"@sv ;
+    rdfs:label "Held component"@en, "Beståndskomponent"@sv ;
     rdfs:subClassOf :Item .
 
 :MultipleItems a owl:Class ;
@@ -48,7 +48,7 @@
     rdfs:label "Multiple items"@en, "Flera exemplar"@sv .
 
 :SingleItem a owl:Class ;
-    rdfs:subClassOf :SomeItem , sdo:IndividualProduct ;
+    rdfs:subClassOf :HeldComponent , sdo:IndividualProduct ;
     :category marc:none ;
     rdfs:label "Single item"@en, "Enskilt exemplar"@sv .
 
@@ -271,7 +271,7 @@
     rdfs:subPropertyOf bf2:hasPart, sdo:itemOffered ;
     rdfs:domain :ItemHolding ;
     owl:inverseOf :componentOf ;
-    rdfs:range :SomeItem ;
+    rdfs:range :HeldComponent ;
     skos:note "Retained from BF1 to enable an Item entity to describe several Items within the same holding. (Historically due to local variations in Libris MARC21-spec.)"@en .
 
 :componentOf a owl:ObjectProperty ;


### PR DESCRIPTION
Justera beståndsmodellen för att skilja mellan innehav och dess komponenter. Beståndskomponenter kan vara logiska innehav (hylla, status, etc.), eller faktiska enskilda exemplar.

- `kbv:ItemHolding` blir en normaliserad nod (som principiellt "reifierar" `kbv:heldBy`).
- `kbv:hasComponent` får domän `kbv:ItemHolding` och range `kbv:HeldComponent`. Den kan då inte i sig vara ett bestånd (så vi tar bort den nuvarande (förvirrande men&mdash;som tur är&mdash;oanvända) möjligheten att ange rekursiva bestånd).
- `kbv:HeldComponent` är en konkret typ för  komponenter av innehavet. Sådana kan, men måste inte, preciseras som faktiska exemplar (detta blir basklassen för `kbv:SingleItem`).

Några frågor:
- [ ] Vill vi att `kbv:heldBy` ska ha domain `kbv:ItemHolding`? (Möjligen inte, om vi vill härleda den från kedjan `(kbv:heldBy kbv:hasComponent)`; för att ha en kompatibel, flexibel form i relation till BF & RDA. Men vi kan också göra en sådan härledning enbart för `bf:heldBy`, för att tydligt specialisera vår relation.)
- [ ] `kbv:Item` _kan_ göras `ptg:abstract`; den är basklass för bestånd respektive exemplar. Men om vi vill göra en mjukare övergång kan vi avvakta med det (den är därför f.n. utkommenterad).