### PR TITLE
Change linked description to linked articleList in apps.jsonld

### DIFF
--- a/source/apps.jsonld
+++ b/source/apps.jsonld
@@ -97,7 +97,7 @@
       "@id": "https://id.kb.se/",
       "@type": "DataCatalog",
       "title": "ID.KB.SE",
-      "description": {"@id": "https://id.kb.se/doc/summary"},
+      "article": {"@id": "https://id.kb.se/doc/summary"},
       "articleList": [
         {"@id": "https://id.kb.se/"},
         {"@id": "https://id.kb.se/marcframe/"},


### PR DESCRIPTION
Addresses indexing problem. We should also define `article` and `articleList` for these.