### PR TITLE
Add support for manual transliteration of Iranian languages (other)

### DIFF
--- a/source/i18n/tlangs.ttl
+++ b/source/i18n/tlangs.ttl
@@ -701,11 +701,24 @@ base <https://id.kb.se/>
   :fromLangScript </i18n/script/Cyrl> ;
   :langTransformAccordingTo </i18n/rule/m0/alaloc> .
 
+</i18n/lang/ira-Latn-t-ira-Arab-m0-alaloc> a :TransformedLanguageForm ;
+  :code "ira-Latn-t-ira-Arab-m0-alaloc"^^:BCP47 ;
+  :inLanguage </language/ira> ;
+  :inLangScript </i18n/script/Latn> ;
+  :fromLangScript </i18n/script/Arab> ;
+  :langTransformAccordingTo </i18n/rule/m0/alaloc> .
+
 </i18n/lang/ira-Latn-t-ira-Arab> a :TransformedLanguageForm ;
   :code "ira-Latn-t-ira-Arab"^^:BCP47 ;
   :inLanguage </language/ira> ;
   :inLangScript </i18n/script/Latn> ;
-  :fromLangScript </i18n/script/Arab> ;
+  :fromLangScript </i18n/script/Arab> .
+
+</i18n/lang/ira-Latn-t-ira-Cyrl-m0-alaloc> a :TransformedLanguageForm ;
+  :code "ira-Latn-t-ira-Cyrl-m0-alaloc"^^:BCP47 ;
+  :inLanguage </language/ira> ;
+  :inLangScript </i18n/script/Latn> ;
+  :fromLangScript </i18n/script/Cyrl> ;
   :langTransformAccordingTo </i18n/rule/m0/alaloc> .
 
 </i18n/lang/ira-Latn-t-ira-Cyrl> a :TransformedLanguageForm ;

--- a/source/i18n/tlangs.ttl
+++ b/source/i18n/tlangs.ttl
@@ -701,6 +701,19 @@ base <https://id.kb.se/>
   :fromLangScript </i18n/script/Cyrl> ;
   :langTransformAccordingTo </i18n/rule/m0/alaloc> .
 
+</i18n/lang/ira-Latn-t-ira-Arab> a :TransformedLanguageForm ;
+  :code "ira-Latn-t-ira-Arab"^^:BCP47 ;
+  :inLanguage </language/ira> ;
+  :inLangScript </i18n/script/Latn> ;
+  :fromLangScript </i18n/script/Arab> ;
+  :langTransformAccordingTo </i18n/rule/m0/alaloc> .
+
+</i18n/lang/ira-Latn-t-ira-Cyrl> a :TransformedLanguageForm ;
+  :code "ira-Latn-t-ira-Cyrl"^^:BCP47 ;
+  :inLanguage </language/ira> ;
+  :inLangScript </i18n/script/Latn> ;
+  :fromLangScript </i18n/script/Cyrl> .
+
 </i18n/lang/kaa-Latn-t-kaa-Cyrl-m0-alaloc> a :TransformedLanguageForm ;
   :code "kaa-Latn-t-kaa-Cyrl-m0-alaloc"^^:BCP47 ;
   :inLanguage </language/kaa> ;


### PR DESCRIPTION
They mostly use ALA-LC romanization schemes. For other cases we leave the transliteration scheme unspecified.
(This results in two input fields in the cataloging interface. The one not used can be left empty.)