### PR TITLE
Add type coercion for label with type rdf:HTML

### DIFF
--- a/sys/context/shared.jsonld
+++ b/sys/context/shared.jsonld
@@ -75,6 +75,8 @@
     "nameByLang": {"@id": "name", "@container": "@language"},
     "lifeSpanByLang": {"@id": "lifeSpan", "@container": "@language"},
 
+    "labelHTML": {"@id": "label", "@type": "rdf:HTML"},
+
     "langTag": {"@id": "code", "@type": "BCP47"},
     "langCodeShort": {"@id": "code", "@type": "ISO639-1"},
     "langCode": {"@id": "code", "@type": "ISO639-2"},


### PR DESCRIPTION
Following the same naming as `descriptionHTML` defined in [source/app/help.jsonld](https://github.com/libris/definitions/blob/a320ff90c87a96e143826812a50afb0635c8cccd/source/app/help.jsonld#L12)

Used for [spelling suggestions in search API](https://github.com/libris/librisxl/blob/cf9ce06fde7ea749c754e85ad7d1d9706249d19e/rest/src/main/groovy/whelk/rest/api/SearchUtils.groovy#L237). 