### PR TITLE
Add platform vocab terms for bulk changes

### DIFF
--- a/source/vocab/base.ttl
+++ b/source/vocab/base.ttl
@@ -240,7 +240,7 @@ rdf:type a owl:ObjectProperty;
 
 :comment a owl:DatatypeProperty;
     rdfs:label "comment"@en, "kommentar"@sv;
-    sdo:domainIncludes :Agent, :Title, :ToCEntry, :EAN, :UPC, :Language, :Script , :ChangeNote, :AdministrativeAction;
+    sdo:domainIncludes :Agent, :Title, :ToCEntry, :EAN, :UPC, :Language, :Script , :ChangeNote, :AdministrativeAction, :BulkChange;
     owl:equivalentProperty rdfs:comment .
 
 :code a owl:DatatypeProperty;

--- a/source/vocab/display.jsonld
+++ b/source/vocab/display.jsonld
@@ -1471,6 +1471,10 @@
         "AdministrativeAction": {
           "fresnel:extends": {"@id": "AdministrativeAction-cards"},
           "showProperties": [ "fresnel:super", {"inverseOf": "concerning"} ]
+        },
+        "BulkChange": {
+          "fresnel:extends": {"@id": "Resource-cards"},
+          "showProperties": [ "fresnel:super", "bulkChangeStatus" ]
         }
       }
     },

--- a/source/vocab/platform.ttl
+++ b/source/vocab/platform.ttl
@@ -729,7 +729,6 @@
 
 :BulkChangeStatusType a owl:Class ;
     :category :platform ;
-    ptg:abstract true ;
     rdfs:subClassOf :Status ;
     skos:notation "BulkChangeStatusType" ;
     skos:prefLabel "Bulk change status"@en, "Massändringsstatus"@sv .

--- a/source/vocab/platform.ttl
+++ b/source/vocab/platform.ttl
@@ -686,3 +686,89 @@
 :Observation a owl:Class;
     :category :platform ;
     rdfs:subClassOf qb:Observation .
+
+##
+# Record history
+:changeSets a owl:ObjectProperty;
+    :category :platform ;
+    sdo:domainIncludes :BulkChangePreview ;
+    rdfs:range :ChangeSet .
+
+:ChangeSet a owl:Class;
+    :category :platform .
+
+##
+# Bulk changes
+:BulkChange a owl:Class ;
+    :category :platform ;
+    rdfs:label "Bulk change"@en, "Massändring"@sv ;
+    rdfs:subClassOf :GenerationProcess .
+
+:BulkChangeSpecification a owl:Class ;
+    :category :platform ;
+    ptg:abstract true;
+    rdfs:label "Change specification"@en, "Ändringsspecifikation"@sv .
+
+:BulkChangePreview a owl:Class ;
+    :category :platform ;
+    rdfs:label "Bulk change preview"@en, "Massändringsförhandsgranskning"@sv ;
+    rdfs:subClassOf :PartialCollectionView .
+
+:bulkChangeSpecification a owl:ObjectProperty;
+    :category :platform ;
+    rdfs:label "change specification"@en, "ändringsspecifikation"@sv ;
+    rdfs:domain :BulkChange ;
+    rdfs:range :BulkChangeSpecification .
+
+:bulkChangeStatus a owl:ObjectProperty;
+    :category :platform ;
+    rdfs:subPropertyOf :status;
+    rdfs:label "bulk change status"@en, "massändringsstatus"@sv ;
+    rdfs:domain :BulkChange ;
+    rdfs:range :BulkChangeStatusType .
+
+:BulkChangeStatusType a owl:Class ;
+    :category :platform ;
+    ptg:abstract true ;
+    rdfs:subClassOf :Status ;
+    skos:notation "BulkChangeStatusType" ;
+    skos:prefLabel "Bulk change status"@en, "Massändringsstatus"@sv .
+
+:DraftBulkChange a :BulkChangeStatusType ;
+    :category :platform ;
+    skos:prefLabel "A draft bulk change that is not ready to be run"@en, "Ett utkast till massändring som inte är redo att köras"@sv .
+
+:ReadyBulkChange a :BulkChangeStatusType ;
+    :category :platform ;
+    skos:prefLabel "A bulk change that is ready to be run"@en, "En massändring som är redo att köras"@sv .
+
+:RunningBulkChange a :BulkChangeStatusType ;
+    :category :platform ;
+    skos:prefLabel "A bulk change that is running"@en, "En massändring som körs"@sv .
+
+:CompletedBulkChange a :BulkChangeStatusType ;
+    :category :platform ;
+    skos:prefLabel "A bulk change that has already taken place"@en, "En massändring som redan kört klart"@sv .
+
+:FailedBulkChange a :BulkChangeStatusType ;
+    :category :platform ;
+    skos:prefLabel "A bulk change that failed to complete"@en, "En massändring som misslyckats att köra klart"@sv .
+
+:FormSpecification a owl:Class ;
+    :category :platform ;
+    rdfs:subClassOf :BulkChangeSpecification ;
+    rdfs:comment "En deklarativ beskrivning av en ändring som ska utföras. Består av en form på data som ska matchas och en målform för ändringar."@sv ;
+    rdfs:label "Specification of bulk change form"@en, "Specifikation av form för massändring"@sv .
+
+:changeForm a owl:ObjectProperty;
+    :category :platform ;
+    rdfs:domain :FormSpecification ;
+    rdfs:range :Resource .
+
+:matchForm a owl:ObjectProperty;
+    :category :platform ;
+    rdfs:subPropertyOf :changeForm .
+
+:targetForm a owl:ObjectProperty;
+    :category :platform ;
+    rdfs:subPropertyOf :changeForm .

--- a/source/vocab/platform.ttl
+++ b/source/vocab/platform.ttl
@@ -735,23 +735,28 @@
 
 :DraftBulkChange a :BulkChangeStatusType ;
     :category :platform ;
-    skos:prefLabel "A draft bulk change that is not ready to be run"@en, "Ett utkast till massändring som inte är redo att köras"@sv .
+    rdfs:comment "A draft bulk change that is not ready to be run"@en, "Ett utkast till massändring som inte är redo att köras"@sv ;
+    skos:prefLabel "Draft"@en, "Utkast"@sv .
 
 :ReadyBulkChange a :BulkChangeStatusType ;
     :category :platform ;
-    skos:prefLabel "A bulk change that is ready to be run"@en, "En massändring som är redo att köras"@sv .
+    rdfs:comment "A bulk change that is ready to be run"@en, "En massändring som är redo att köras"@sv ;
+    skos:prefLabel "Ready"@en, "Redo"@sv .
 
 :RunningBulkChange a :BulkChangeStatusType ;
     :category :platform ;
-    skos:prefLabel "A bulk change that is running"@en, "En massändring som körs"@sv .
+    rdfs:comment "A bulk change that is running"@en, "En massändring som körs"@sv ;
+    skos:prefLabel "Running"@en, "Kör"@sv .
 
 :CompletedBulkChange a :BulkChangeStatusType ;
     :category :platform ;
-    skos:prefLabel "A bulk change that has already taken place"@en, "En massändring som redan kört klart"@sv .
+    rdfs:comment "A bulk change that has already taken place"@en, "En massändring som redan kört klart"@sv ;
+    skos:prefLabel "Completed"@en, "Avslutad"@sv .
 
 :FailedBulkChange a :BulkChangeStatusType ;
     :category :platform ;
-    skos:prefLabel "A bulk change that failed to complete"@en, "En massändring som misslyckats att köra klart"@sv .
+    rdfs:comment "A bulk change that failed to complete"@en, "En massändring som misslyckats att köra klart"@sv ;
+    skos:prefLabel "Failed"@en, "Misslyckad"@sv .
 
 :FormSpecification a owl:Class ;
     :category :platform ;

--- a/source/vocab/platform.ttl
+++ b/source/vocab/platform.ttl
@@ -766,6 +766,7 @@
 
 :changeForm a owl:ObjectProperty;
     :category :platform ;
+    ptg:abstract true;
     rdfs:domain :FormSpecification ;
     rdfs:range :Resource .
 

--- a/source/vocab/platform.ttl
+++ b/source/vocab/platform.ttl
@@ -720,6 +720,30 @@
     rdfs:domain :BulkChange ;
     rdfs:range :BulkChangeSpecification .
 
+#TODO
+:bulkChangeMetaChanges a owl:ObjectProperty;
+    :category :platform ;
+    rdfs:subPropertyOf :status;
+    rdfs:label "bulk change record changes"@en, "poständringar vid massändring"@sv ;
+    rdfs:domain :BulkChange ;
+    rdfs:range :BulkChangeMetaChangesType .
+
+:BulkChangeMetaChangesType a owl:Class ;
+    :category :platform ;
+    rdfs:subClassOf :Status ;
+    skos:notation "BulkChangeStatusType" ;
+    skos:prefLabel "Bulk change record changes"@en, "Poständringar vid massändring"@sv .
+
+#TODO
+:LoudBulkChange a :BulkChangeMetaChangesType ;
+    :category :platform ;
+    skos:prefLabel "Loud"@en, "Högljudd"@sv .
+
+#TODO
+:SilentBulkChange a :BulkChangeMetaChangesType ;
+    :category :platform ;
+    skos:prefLabel "Silent"@en, "Tyst"@sv .
+
 :bulkChangeStatus a owl:ObjectProperty;
     :category :platform ;
     rdfs:subPropertyOf :status;

--- a/sys/context/kbv.jsonld
+++ b/sys/context/kbv.jsonld
@@ -9,6 +9,7 @@
     "recordStatus": {"@type": "@vocab"},
     "encodingLevel": {"@type": "@vocab"},
     "shelfMarkStatus": {"@type": "@vocab"},
+    "bulkChangeStatus": {"@type": "@vocab"},
     "dimensionChain": {"@id": "dimension", "@type": "@vocab", "@container": "@list"},
     "inverseOfTerm": {"@id": "owl:inverseOf", "@type": "@vocab"},
 

--- a/sys/context/kbv.jsonld
+++ b/sys/context/kbv.jsonld
@@ -10,6 +10,7 @@
     "encodingLevel": {"@type": "@vocab"},
     "shelfMarkStatus": {"@type": "@vocab"},
     "bulkChangeStatus": {"@type": "@vocab"},
+    "bulkChangeMetaChanges": {"@type": "@vocab"},
     "dimensionChain": {"@id": "dimension", "@type": "@vocab", "@container": "@list"},
     "inverseOfTerm": {"@id": "owl:inverseOf", "@type": "@vocab"},
 


### PR DESCRIPTION
Bulk changes are managed as regular entitys/records. Type `BulkChange`.
Descriptive metadata is placed in `:label` and `:comment`.

`:bulkChangeSpecification` holds the specification of the actual changes to perform.
For now "`:FormSpecification`" (naming???). Can be extended to whelktool scripts etc.

`BulkChangePreview` is used for previewing the result of a (draft) `BulkChange` 
* `totalItems` Number of affected records 
* `changeSets` A description of the "abstract" change that will be performed on all records
* `items` A list of previews of updated records. 
    * Each in the change history format: data before, data after, change sets
    
e.g libris.kb.se/api/_bulk-change/preview?@id=<bulk change record>&_limit=5

Most properties / classes are "namespaced" with a "BulkChange..." prefix.

Add `changeSets` / `ChangeSet` that is already used by the `/_changeSets` API.

TODO?
* Description of execution occasion?
* Description of results?
* Form for live updates of progress?
    * number of processed records etc 