### PR TITLE
Update definition of :maxItems

### DIFF
--- a/source/vocab/platform.ttl
+++ b/source/vocab/platform.ttl
@@ -520,8 +520,8 @@
 
 :maxItems a owl:ObjectProperty;
     :category :platform ;
-    skos:definition "The maximum number of items that may be accessed through pagination. Might be smaller than totalItems"@en;
-    rdfs:domain :PartialCollectionView .
+    skos:definition "The maximum number of items in the collection/view/result. For paginated collections: the maximum number of items that may be accessed through pagination. Might be smaller than totalItems."@en;
+    sdo:domainIncludes :PartialCollectionView, :Slice .
 
 :first a owl:ObjectProperty;
     :category :platform ;


### PR DESCRIPTION
It is now also used to signal the max number of items in a Slice (facet group). 
Corresponding to `itemLimit` in apps.jsonld. Which is not defined and could be replaced with `:maxItems`?