### PR TITLE
Add EXIF properties for media objects

### DIFF
--- a/source/vocab/files-packages-representations.ttl
+++ b/source/vocab/files-packages-representations.ttl
@@ -3,6 +3,7 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix exif: <http://www.w3.org/2003/12/exif#> .
 @prefix sdo: <http://schema.org/> .
 @prefix dc: <http://purl.org/dc/terms/> .
 @prefix bf2: <http://id.loc.gov/ontologies/bibframe/> .
@@ -141,3 +142,19 @@
     rdfs:label "height"@en, "höjd"@sv ;
     sdo:domainIncludes :MediaObject ; # TODO: broaden domain later to also apply on Manifest and physical objects
     owl:equivalentProperty sdo:height .
+
+:bitsPerSample a owl:DatatypeProperty ;
+    rdfs:label "bits per sample"@en "bits per sample"@sv;
+    sdo:domainIncludes :MediaObject ;
+    owl:equivalentProperty exif:bitsPerSample .
+
+:colorSpace a owl:DatatypeProperty ;
+    rdfs:label "color space"@en, "färgrymd"@sv ;
+    sdo:domainIncludes :MediaObject ;
+    owl:equivalentProperty exif:colorSpace .
+
+:dateTimeDigitized a owl:DatatypeProperty ;
+    rdfs:label "datetime digitized"@en, "digitiseringsdatum"@sv ;
+    sdo:domainIncludes :MediaObject ;
+    owl:equivalentProperty exif:dateTimeDigitized ;
+    rdfs:range xsd:dateTime .


### PR DESCRIPTION
Adding terms extracted from the EXIF tags of image files and added to (image) file descriptions.

Added terms are:

bitsPerSample - The number of bits per image component. 
colorSpace - The color space information tag.
dateTimeDigitized - The date and time when the image was stored as digital data.


Terms taken from https://www.w3.org/2003/12/exif/