### PR TITLE
Add :Identity to domain of :meta

### DIFF
--- a/source/vocab/platform.ttl
+++ b/source/vocab/platform.ttl
@@ -83,6 +83,7 @@
     owl:inverseOf :mainEntity;
     owl:equivalentProperty bf2:adminMetadata, foaf:isPrimaryTopicOf, sdo:mainEntityOfPage, xhv:meta ;
     rdfs:subPropertyOf :describedBy ;
+    sdo:domainIncludes :Identity ;
     rdfs:range :Record .
 
 :describedBy a owl:ObjectProperty;


### PR DESCRIPTION
Enables adding `:meta` property to `:Agent` and `:Concept` resources (needed in the bulk change tool).

Should make sense since `:Identity` resources often appear as `:mainEntity` and we have `:meta owl:inverseOf :mainEntity`.