### PR TITLE
Feature/updated rdaregistry urls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 # Local App Config
 /.venv
 /venv
+.python-version
 
 # Common OS, Tool and Editor Files
 .*.sw*

--- a/source/construct-materials.rq
+++ b/source/construct-materials.rq
@@ -15,7 +15,7 @@ construct {
         }
         optional {
             ?s skos:exactMatch ?rda .
-            graph <http://rdaregistry.info/termList/RDAMaterial.nt> {
+            graph <https://www.rdaregistry.info/nt/termList/RDAMaterial.nt> {
                 ?rda skos:prefLabel ?rdaLabel ;
                     skos:definition ?definition .
             }

--- a/source/construct-musnotationsterms.rq
+++ b/source/construct-musnotationsterms.rq
@@ -8,7 +8,7 @@ construct {
     graph <https://id.kb.se/dataset/musnotationterms> {
         ?s ?p ?o ; skos:exactMatch ?rda .
         optional {
-            graph <http://rdaregistry.info/termList/MusNotation.nt> {
+            graph <https://www.rdaregistry.info/nt/termList/MusNotation.nt> {
                 ?rda skos:prefLabel ?prefLabel ;
                     skos:definition ?definition .
                 filter(lang(?prefLabel) != 'sv')

--- a/source/construct-tacnotationterms.rq
+++ b/source/construct-tacnotationterms.rq
@@ -8,7 +8,7 @@ construct {
     graph <https://id.kb.se/dataset/tacnotationterms> {
         ?s ?p ?o ; skos:exactMatch ?rda .
         optional {
-            graph <http://rdaregistry.info/termList/TacNotation.nt> {
+            graph <https://www.rdaregistry.info/nt/termList/TacNotation.nt> {
                 ?rda skos:prefLabel ?prefLabel ;
                     skos:definition ?definition .
                 filter(lang(?prefLabel) != 'sv')

--- a/source/datasets/idkbse.ttl
+++ b/source/datasets/idkbse.ttl
@@ -20,13 +20,13 @@ base <https://id.kb.se/dataset/>
                 :dataQuery [ :uri "source/construct-rda-terms.rq" ] ;
                 :sourceData [ :uri 'source/rda-terms.ttl' ;
                               :representationOf <rdaterms> ] ,
-                    <http://rdaregistry.info/termList/RDAContentType.nt> ,
+                    <https://www.rdaregistry.info/nt/termList/RDAContentType.nt> ,
                     <http://id.loc.gov/vocabulary/contentTypes> ,
 
-                    <http://rdaregistry.info/termList/RDAMediaType.nt> ,
+                    <https://www.rdaregistry.info/nt/termList/RDAMediaType.nt> ,
                     <http://id.loc.gov/vocabulary/mediaTypes> ,
 
-                    <http://rdaregistry.info/termList/RDACarrierType.nt> ,
+                    <https://www.rdaregistry.info/nt/termList/RDACarrierType.nt> ,
                     <http://id.loc.gov/vocabulary/carriers> ,
 
                     #<http://rdaregistry.info/termList/ModeIssue> ,
@@ -42,7 +42,7 @@ base <https://id.kb.se/dataset/>
     :sourceData [ :uri "build/materials.json.lines" ; :sourceData [ a :QueryConstruct ;
             :dataQuery [ :uri "source/construct-materials.rq" ] ;
             :sourceData [ :uri 'source/materials.ttl'; :representationOf <materials> ],
-                <http://rdaregistry.info/termList/RDAMaterial.nt> ,
+                <https://www.rdaregistry.info/nt/termList/RDAMaterial.nt> ,
                 [ a :QueryConstruct ;
                     :dataQuery [ :uri "source/remote/construct-aat-materials.rq" ] ;
                     :representationOf <urn:x-cache:sparql:aat-materials> ]
@@ -55,7 +55,7 @@ base <https://id.kb.se/dataset/>
     :sourceData [ :uri "build/musnotationterms.json.lines" ; :sourceData [ a :QueryConstruct ;
             :dataQuery [ :uri "source/construct-musnotationsterms.rq" ] ;
             :sourceData [ :uri 'source/musicnotation.ttl' ; :representationOf <musnotationterms> ] ,
-                    <http://rdaregistry.info/termList/MusNotation.nt>
+                    <https://www.rdaregistry.info/nt/termList/MusNotation.nt>
         ] ] ;
     :uriSpace "/term/rda/musnotation/" ;
     :created "2021-05-21T23:59:01.337Z"^^xsd:dateTime .
@@ -65,7 +65,7 @@ base <https://id.kb.se/dataset/>
     :sourceData [ :uri "build/tacnotationterms.json.lines" ; :sourceData [ a :QueryConstruct ;
             :dataQuery [ :uri "source/construct-tacnotationterms.rq" ] ;
             :sourceData [ :uri 'source/tactilenotation.ttl' ; :representationOf <tacnotationterms> ],
-                <http://rdaregistry.info/termList/TacNotation.nt>
+                <https://www.rdaregistry.info/nt/termList/TacNotation.nt>
         ] ] ;
     :uriSpace "/term/rda/tacnotation/" ;
     :created "2021-05-21T23:59:10.456Z"^^xsd:dateTime .


### PR DESCRIPTION
Det visade sig att http://rdaregistry.info/termList/[namn].nt inte längre fungerar. Jag bytte ut alla sådana länkar mot https://www.rdaregistry.info/nt/termList/[namn].nt och kunde därefter köra datasets.py utan problem.
