### PR TITLE
Ensure lens index key and classLensDomain are the same

### DIFF
--- a/scripts/checkdisplay.py
+++ b/scripts/checkdisplay.py
@@ -1,0 +1,20 @@
+import json
+from pathlib import Path
+
+project_dir = Path(__file__).parent.parent
+displaypath = project_dir / "source/vocab/display.jsonld"
+
+with displaypath.open() as f:
+    display = json.load(f)
+
+for group in display["lensGroups"].values():
+    if g_id := group.get("@id"):
+        print(g_id)
+    for key, lens in group.get("lenses", {}).items():
+        cld = lens.get("classLensDomain")
+        if key != cld:
+            if cld is None:
+                print(f"    {key} - Missing classLensDomain")
+            else:
+                print(f"    {key} - Different classLensDomain: {cld}")
+    print()

--- a/source/vocab/display.jsonld
+++ b/source/vocab/display.jsonld
@@ -112,7 +112,7 @@
         "Role": {
           "@id": "Role-chips",
           "@type": "fresnel:Lens",
-          "classLensDomain": "Resource",
+          "classLensDomain": "Role",
           "showProperties": [
             {"alternateProperties": ["prefLabel", "altLabel", "label", "code"]},
             "inScheme",
@@ -258,7 +258,7 @@
         "TitlePart": {
           "@id": "TitlePart-chips",
           "@type": "fresnel:Lens",
-          "classLensDomain": "Title",
+          "classLensDomain": "TitlePart",
           "showProperties": ["partNumber", "partName"]
         },
         "DescriptionConventions": {
@@ -546,7 +546,7 @@
         "FrequencyPeriod": {
           "@id": "FrequencyPeriod-chips",
           "@type": "fresnel:Lens",
-          "classLensDomain": "PoliticalTendencyPeriod",
+          "classLensDomain": "FrequencyPeriod",
           "showProperties": [ "frequency", "firstIssueDate", "lastIssueDate" ]
         },
         "LanguagePeriod": {


### PR DESCRIPTION
The indexed key seems to be correct and the one actually used. The actual `classLensDomain` is (worryingly) wrong.

(This is a recurring problem best addressed by removing the well-intentioned but complicating reliance on `@container: @index` in this file. I'd gladly explain this in more detail if there is time.) 