### PR TITLE
Add RDA DescriptionConventions to kbv-enums

### DIFF
--- a/source/kbv-enums.ttl
+++ b/source/kbv-enums.ttl
@@ -2,6 +2,7 @@
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix sdo: <http://schema.org/> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix : <https://id.kb.se/vocab/> .
 @base <https://id.kb.se/term/enum/> .
 
 
@@ -31,3 +32,10 @@
     rdfs:label "Utlånas ej" ;
     skos:prefLabel "Not for check out"@en,
         "Utlånas ej"@sv .
+
+# Instances of DescriptionConventions
+
+<Rda> a :DescriptionConventions;
+    rdfs:label "RDA" ;
+    skos:prefLabel "RDA"@en, "RDA"@sv ;
+    :code "rda" .

--- a/source/vocab/platform.ttl
+++ b/source/vocab/platform.ttl
@@ -175,6 +175,7 @@
     owl:equivalentProperty bf2:descriptionLanguage .
 
 :DescriptionConventions a owl:Class;
+    :category :heuristicIdentity;
     rdfs:label "Description conventions"@en, "Katalogiseringsregler"@sv;
     rdfs:subClassOf :AdminMetadata, :Standard ;
     owl:equivalentClass bf2:DescriptionConventions .


### PR DESCRIPTION
Add entity for RDA description conventions / cataloging rules.

See https://kbse.atlassian.net/browse/LXL-3651