### PR TITLE
Add label and code to hasInstanceType

### DIFF
--- a/source/vocab/libris-search-experimental.ttl
+++ b/source/vocab/libris-search-experimental.ttl
@@ -44,6 +44,8 @@
     owl:propertyChainAxiom ( :instanceOf rdf:type ) .
 
 :hasInstanceType a owl:ObjectProperty ;
+    rdfs:label "format"@sv, "format"en ;
+    skos:notation "FORMAT"^^:LibrisQueryCode ;
     rdfs:subPropertyOf rdf:type ;
     :category :shorthand, :pending ;
     rdfs:domain :Work ;


### PR DESCRIPTION
- Distinguish from https://id.kb.se/vocab/format and https://id.kb.se/vocab/hasFormat (see also https://github.com/libris/librisxl/pull/1563)
- Display in chips
 
We can just change these labels later if needed (the term is still categorized as `:pending`).