### PR TITLE
Remove type-conflating subPropertyOf relationships

### DIFF
--- a/source/vocab/libris-search-experimental.ttl
+++ b/source/vocab/libris-search-experimental.ttl
@@ -38,7 +38,6 @@
     owl:propertyChainAxiom ( :hasItem :heldBy ) .
 
 :instanceOfType a owl:ObjectProperty ;
-    rdfs:subPropertyOf rdf:type ;
     :category :shorthand, :pending ;
     rdfs:domain :Instance ;
     owl:propertyChainAxiom ( :instanceOf rdf:type ) .
@@ -46,7 +45,6 @@
 :hasInstanceType a owl:ObjectProperty ;
     rdfs:label "format"@sv, "format"@en ;
     skos:notation "FORMAT"^^:LibrisQueryCode ;
-    rdfs:subPropertyOf rdf:type ;
     :category :shorthand, :pending ;
     rdfs:domain :Work ;
     owl:propertyChainAxiom ( :hasInstance rdf:type ) .


### PR DESCRIPTION
These gave the work all the types of the instance, and vice versa. :grimacing: :sweat_smile: 

(We should reasonably(!) also make a hotfix of this.)