### PR TITLE
Update relators: delete broader <libelant> from relator lithographer

### DIFF
--- a/source/relators.ttl
+++ b/source/relators.ttl
@@ -1720,7 +1720,6 @@ skos:related <editor> ;
     rdfs:domain :Instance ;
     owl:equivalentProperty locrel:ltg ;
     owl:sameAs <ltg> ;
-    skos:broader <libelant> ;
     skos:closeMatch rdau:P60414 ;
     skos:exactMatch locrel:ltg,
         gnd:lithographer ;


### PR DESCRIPTION
Lithographer is not a narrower term for Libelant