### PR TITLE
Fix incorrect/incomplete SSIF 2011->2025 change type

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,6 @@ source/ssif-2025-kbv.jsonld: scripts/create_ssif_science_topic_data.py cache/ssi
 # ...,2 = Sheet 2 - see <https://wiki.documentfoundation.org/ReleaseNotes/7.2#Document_Conversion>
 cache/ssif-2025.csv: cache/Nyckel_SSIF2011_SSIF2025_digg.xlsx
 	libreoffice --headless --convert-to csv:"Text - txt - csv (StarCalc)":"9,ANSI,90,,,true,true,false,false,,,2" cache/Nyckel_SSIF2011_SSIF2025_digg.xlsx --outdir cache/
-	# Fix incorrect/incomplete change type
-	sed -i '/^60411.*\tBytt benämning\t/ s/Bytt benämning/Ny kod/' "cache/Nyckel_SSIF2011_SSIF2025_digg-Nyckel SSIF2011-SSIF25.csv"
+	# Fix incomplete change type
+	sed -i '/^60411.*\tBytt benämning\t/ s/Bytt benämning/Ny kod, Bytt benämning/' "cache/Nyckel_SSIF2011_SSIF2025_digg-Nyckel SSIF2011-SSIF25.csv"
 	cp "cache/Nyckel_SSIF2011_SSIF2025_digg-Nyckel SSIF2011-SSIF25.csv" $@

--- a/Makefile
+++ b/Makefile
@@ -42,4 +42,6 @@ source/ssif-2025-kbv.jsonld: scripts/create_ssif_science_topic_data.py cache/ssi
 # ...,2 = Sheet 2 - see <https://wiki.documentfoundation.org/ReleaseNotes/7.2#Document_Conversion>
 cache/ssif-2025.csv: cache/Nyckel_SSIF2011_SSIF2025_digg.xlsx
 	libreoffice --headless --convert-to csv:"Text - txt - csv (StarCalc)":"9,ANSI,90,,,true,true,false,false,,,2" cache/Nyckel_SSIF2011_SSIF2025_digg.xlsx --outdir cache/
+	# Fix incorrect/incomplete change type
+	sed -i '/^60411.*\tBytt benämning\t/ s/Bytt benämning/Ny kod/' "cache/Nyckel_SSIF2011_SSIF2025_digg-Nyckel SSIF2011-SSIF25.csv"
 	cp "cache/Nyckel_SSIF2011_SSIF2025_digg-Nyckel SSIF2011-SSIF25.csv" $@

--- a/scripts/create_ssif_science_topic_data.py
+++ b/scripts/create_ssif_science_topic_data.py
@@ -141,6 +141,7 @@ def create_data(fpath: str, simple_skos=True, use_annots=True) -> dict:
                 "Uppdelning av ämne, bytt forskningsämnesgrupp": "as:Move",
                 "Bytt benämning": "as:Update",
                 "Ny kod": "as:Move",
+                "Ny kod, Bytt benämning": "as:Move",
                 "Nytt ämne": "as:Create",
                 "Sammanslagning av ämnen": "as:Update",  # Merge
             }.get(row.change_type, "as:Activity")
@@ -227,7 +228,7 @@ def create_data(fpath: str, simple_skos=True, use_annots=True) -> dict:
         if row.change_type:
             handled = False
 
-            if row.change_type in {"Ny kod", "Bytt forskningsämnesgrupp"}:
+            if row.change_type in {"Ny kod", "Bytt forskningsämnesgrupp", "Ny kod, Bytt benämning"}:
                 handled = True
                 add_item(
                     {
@@ -239,6 +240,8 @@ def create_data(fpath: str, simple_skos=True, use_annots=True) -> dict:
                         "isReplacedBy": [annotate({"@id": item_id}, annot)],
                     }
                 )
+                if row.change_type == "Ny kod, Bytt benämning" and row.label_2011 and row.label_2011 != label_sv:
+                    item["hiddenLabelByLang"] = {"sv": row.label_2011}
 
             if row.change_type == "Sammanslagning av ämnen":
                 handled = False

--- a/source/ssif-2025-kbv.jsonld
+++ b/source/ssif-2025-kbv.jsonld
@@ -5248,6 +5248,19 @@
       "broader": {"@id": "https://begrepp.uka.se/SSIF/604"}
     },
     {
+      "@id": "https://begrepp.uka.se/SSIF/60401",
+      "@type": "Classification",
+      "code": "60401",
+      "owl:deprecated": true,
+      "labelByLang": {"sv": "Bildkonst"},
+      "isReplacedBy": [
+        {"@id": "https://begrepp.uka.se/SSIF/60411"}
+      ],
+      "narrowMatch": [
+        {"@id": "https://begrepp.uka.se/SSIF/60411"}
+      ]
+    },
+    {
       "@id": "https://begrepp.uka.se/SSIF/60411",
       "@type": "Classification",
       "inScheme": {"@id": "https://begrepp.uka.se/SSIF"},
@@ -5256,8 +5269,7 @@
         "sv": "Fri Konst",
         "en": "Visual Arts"
       },
-      "broader": {"@id": "https://begrepp.uka.se/SSIF/604"},
-      "hiddenLabelByLang": {"sv": "Bildkonst"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/604"}
     },
     {
       "@id": "https://begrepp.uka.se/SSIF/60402",

--- a/source/ssif-2025-kbv.jsonld
+++ b/source/ssif-2025-kbv.jsonld
@@ -5269,7 +5269,8 @@
         "sv": "Fri Konst",
         "en": "Visual Arts"
       },
-      "broader": {"@id": "https://begrepp.uka.se/SSIF/604"}
+      "broader": {"@id": "https://begrepp.uka.se/SSIF/604"},
+      "hiddenLabelByLang": {"sv": "Bildkonst"}
     },
     {
       "@id": "https://begrepp.uka.se/SSIF/60402",

--- a/source/ssif-2025-skos.ttl
+++ b/source/ssif-2025-skos.ttl
@@ -2697,7 +2697,8 @@ prefix dct: <http://purl.org/dc/terms/>
   :inScheme <https://begrepp.uka.se/SSIF> ;
   :notation "60411" ;
   :prefLabel "Fri Konst"@sv , "Visual Arts"@en ;
-  :broader <https://begrepp.uka.se/SSIF/604> .
+  :broader <https://begrepp.uka.se/SSIF/604> ;
+  :hiddenLabel "Bildkonst"@sv .
 
 <https://begrepp.uka.se/SSIF/60402> a :Concept ;
   :notation "60402" ;

--- a/source/ssif-2025-skos.ttl
+++ b/source/ssif-2025-skos.ttl
@@ -2686,12 +2686,18 @@ prefix dct: <http://purl.org/dc/terms/>
   :prefLabel "Filmvetenskap"@sv , "Film Studies"@en ;
   :broader <https://begrepp.uka.se/SSIF/604> .
 
+<https://begrepp.uka.se/SSIF/60401> a :Concept ;
+  :notation "60401" ;
+  owl:deprecated true ;
+  rdfs:label "Bildkonst"@sv ;
+  dct:isReplacedBy <https://begrepp.uka.se/SSIF/60411> ;
+  :narrowMatch <https://begrepp.uka.se/SSIF/60411> .
+
 <https://begrepp.uka.se/SSIF/60411> a :Concept ;
   :inScheme <https://begrepp.uka.se/SSIF> ;
   :notation "60411" ;
   :prefLabel "Fri Konst"@sv , "Visual Arts"@en ;
-  :broader <https://begrepp.uka.se/SSIF/604> ;
-  :hiddenLabel "Bildkonst"@sv .
+  :broader <https://begrepp.uka.se/SSIF/604> .
 
 <https://begrepp.uka.se/SSIF/60402> a :Concept ;
   :notation "60402" ;


### PR DESCRIPTION
In [Översättningsnyckel mellan SSIF 2011 och SSIF 2025](https://kbse.atlassian.net/browse/SWEPUB2-1149) 60401 Bildkonst is listed as only having changed its label (to Fri Konst), but more importantly it also has a new code (60411).

We can't fix the source ourselves, so this change fixes the mistake as close to the source as possible.

The second commit - unsure whether it was really necessary - also makes sure that the new classification gets (or rather, keeps) a hiddenLabelByLang. 

https://kbse.atlassian.net/browse/SWEPUB2-1149