### PR TITLE
Add filter for free digital material

### DIFF
--- a/source/apps.jsonld
+++ b/source/apps.jsonld
@@ -98,7 +98,7 @@
         { "alias": "excludePreliminary", "filter": "NOT encodingLevel:(\"marc:PartialPreliminaryLevel\" OR \"marc:PrepublicationLevel\")", "prefLabelByLang": { "sv": "Exkludera kommande publiceringar", "en": "Exclude upcoming publications" } },
         { "alias": "includePreliminary", "filter": "NOT excludePreliminary", "prefLabelByLang": { "sv": "Inkludera kommande publiceringar", "en": "Include upcoming publications" } },
         { "alias": "existsImage", "filter": "image:*", "prefLabelByLang": { "sv": "Endast resurser med omslags-/miniatyrbild", "en": "Resources with cover/thumbnail only" } },
-        { "alias": "freeDigital", "filter": "hasInstanceType:\"Electronic\" AND (usageAndAccessPolicy.label:\"gratis\" OR \"associatedMedia.marc:publicNote\":\"*fritt tillgänglig*\")", "prefLabelByLang": { "sv": "Fritt digitalt", "en": "Free digital material" } }
+        { "alias": "freeDigital", "filter": "hasInstanceType:\"Electronic\" AND (usageAndAccessPolicy.label:\"gratis\" OR \"associatedMedia.marc:publicNote\":\"fritt tillgänglig\")", "prefLabelByLang": { "sv": "Fritt digitalt", "en": "Free digital material" } }
       ],
       "defaultSiteFilters": [
         { "filter": "excludeEplikt" },

--- a/source/apps.jsonld
+++ b/source/apps.jsonld
@@ -98,7 +98,7 @@
         { "alias": "excludePreliminary", "filter": "NOT encodingLevel:(\"marc:PartialPreliminaryLevel\" OR \"marc:PrepublicationLevel\")", "prefLabelByLang": { "sv": "Exkludera kommande publiceringar", "en": "Exclude upcoming publications" } },
         { "alias": "includePreliminary", "filter": "NOT excludePreliminary", "prefLabelByLang": { "sv": "Inkludera kommande publiceringar", "en": "Include upcoming publications" } },
         { "alias": "existsImage", "filter": "image:*", "prefLabelByLang": { "sv": "Endast resurser med omslags-/miniatyrbild", "en": "Resources with cover/thumbnail only" } },
-        { "alias": "freeDigital", "filter": "hasInstanceType:\"Electronic\" AND (usageAndAccessPolicy.label:\"gratis\" OR \"associatedMedia.marc:publicNote\":\"fritt tillgänglig\")", "prefLabelByLang": { "sv": "Fritt digitalt", "en": "Free digital material" } }
+        { "alias": "freeDigital", "filter": "hasInstanceType:Electronic AND (usageAndAccessPolicy.label:gratis OR \"associatedMedia.marc:publicNote\":\"fritt tillgänglig\")", "prefLabelByLang": { "sv": "Fritt digitalt", "en": "Free digital material" } }
       ],
       "defaultSiteFilters": [
         { "filter": "excludeEplikt" },

--- a/source/apps.jsonld
+++ b/source/apps.jsonld
@@ -98,7 +98,7 @@
         { "alias": "excludePreliminary", "filter": "NOT encodingLevel:(\"marc:PartialPreliminaryLevel\" OR \"marc:PrepublicationLevel\")", "prefLabelByLang": { "sv": "Exkludera kommande publiceringar", "en": "Exclude upcoming publications" } },
         { "alias": "includePreliminary", "filter": "NOT excludePreliminary", "prefLabelByLang": { "sv": "Inkludera kommande publiceringar", "en": "Include upcoming publications" } },
         { "alias": "existsImage", "filter": "image:*", "prefLabelByLang": { "sv": "Endast resurser med omslags-/miniatyrbild", "en": "Resources with cover/thumbnail only" } },
-        { "alias": "freeDigital", "filter": "hasInstanceType:Electronic AND (usageAndAccessPolicy.label:gratis OR \"associatedMedia.marc:publicNote\":\"fritt tillgänglig\")", "prefLabelByLang": { "sv": "Fritt digitalt", "en": "Free digital material" } }
+        { "alias": "freeDigital", "filter": "hasInstanceType:Electronic AND (usageAndAccessPolicy.label:gratis OR \"associatedMedia.marc:publicNote\":\"fritt tillgänglig\" OR usageAndAccessPolicy:(\"https://id.kb.se/policy/freely-available\" OR \"https://id.kb.se/policy/oa/gratis\"))", "prefLabelByLang": { "sv": "Fritt digitalt", "en": "Free digital material" } }
       ],
       "defaultSiteFilters": [
         { "filter": "excludeEplikt" },

--- a/source/apps.jsonld
+++ b/source/apps.jsonld
@@ -98,7 +98,7 @@
         { "alias": "excludePreliminary", "filter": "NOT encodingLevel:(\"marc:PartialPreliminaryLevel\" OR \"marc:PrepublicationLevel\")", "prefLabelByLang": { "sv": "Exkludera kommande publiceringar", "en": "Exclude upcoming publications" } },
         { "alias": "includePreliminary", "filter": "NOT excludePreliminary", "prefLabelByLang": { "sv": "Inkludera kommande publiceringar", "en": "Include upcoming publications" } },
         { "alias": "existsImage", "filter": "image:*", "prefLabelByLang": { "sv": "Endast resurser med omslags-/miniatyrbild", "en": "Resources with cover/thumbnail only" } },
-        { "alias": "freeDigital", "filter": "hasInstanceType:Electronic AND (usageAndAccessPolicy.label:gratis OR \"associatedMedia.marc:publicNote\":\"fritt tillgänglig\" OR usageAndAccessPolicy:(\"https://id.kb.se/policy/freely-available\" OR \"https://id.kb.se/policy/oa/gratis\"))", "prefLabelByLang": { "sv": "Fritt digitalt", "en": "Free digital material" } }
+        { "alias": "freeOnline", "filter": "hasInstanceType:Electronic AND (usageAndAccessPolicy.label:gratis OR \"associatedMedia.marc:publicNote\":\"fritt tillgänglig\" OR usageAndAccessPolicy:(\"https://id.kb.se/policy/freely-available\" OR \"https://id.kb.se/policy/oa/gratis\"))", "prefLabelByLang": { "sv": "Fritt online", "en": "Free online material" } }
       ],
       "defaultSiteFilters": [
         { "filter": "excludeEplikt" },
@@ -111,7 +111,7 @@
         { "filter": "includeEplikt" },
         { "filter": "includePreliminary" },
         { "filter": "existsImage" },
-        { "filter": "freeDigital" }
+        { "filter": "freeOnline" }
       ],
       "relationFilters": {
         "Agent": [ "contributor", "subject", "publisher" ],

--- a/source/apps.jsonld
+++ b/source/apps.jsonld
@@ -97,7 +97,8 @@
         { "alias": "includeEplikt", "filter": "NOT excludeEplikt", "prefLabelByLang": { "sv": "Inkludera elektroniska pliktleveranser", "en": "Include electronic legal deposit"  } },
         { "alias": "excludePreliminary", "filter": "NOT encodingLevel:(\"marc:PartialPreliminaryLevel\" OR \"marc:PrepublicationLevel\")", "prefLabelByLang": { "sv": "Exkludera kommande publiceringar", "en": "Exclude upcoming publications" } },
         { "alias": "includePreliminary", "filter": "NOT excludePreliminary", "prefLabelByLang": { "sv": "Inkludera kommande publiceringar", "en": "Include upcoming publications" } },
-        { "alias": "existsImage", "filter": "image:*", "prefLabelByLang": { "sv": "Endast resurser med omslags-/miniatyrbild", "en": "Resources with cover/thumbnail only" } }
+        { "alias": "existsImage", "filter": "image:*", "prefLabelByLang": { "sv": "Endast resurser med omslags-/miniatyrbild", "en": "Resources with cover/thumbnail only" } },
+        { "alias": "freeDigital", "filter": "hasInstanceType:\"Electronic\" AND (usageAndAccessPolicy.label:\"gratis\" OR \"associatedMedia.marc:publicNote\":\"*fritt tillgänglig*\")", "prefLabelByLang": { "sv": "Fritt digitalt", "en": "Free digital material" } }
       ],
       "defaultSiteFilters": [
         { "filter": "excludeEplikt" },
@@ -109,7 +110,8 @@
       "optionalSiteFilters": [
         { "filter": "includeEplikt" },
         { "filter": "includePreliminary" },
-        { "filter": "existsImage" }
+        { "filter": "existsImage" },
+        { "filter": "freeDigital" }
       ],
       "relationFilters": {
         "Agent": [ "contributor", "subject", "publisher" ],

--- a/source/vocab/display.jsonld
+++ b/source/vocab/display.jsonld
@@ -1144,6 +1144,13 @@
           "classLensDomain": "ImageObject",
           "showProperties": [ "fresnel:super", "thumbnail", "publisher", "usageAndAccessPolicy" ]
         },
+        "MediaObject": {
+          "@id": "MediaObject-cards",
+          "@type": "fresnel:Lens",
+          "fresnel:extends": {"@id": "MediaObject-chips"},
+          "classLensDomain": "MediaObject",
+          "showProperties": [ "fresnel:super" ]
+        },
         "License": {
           "@id": "License-cards",
           "@type": "fresnel:Lens",
@@ -1488,6 +1495,10 @@
         "AdministrativeAction": {
           "fresnel:extends": {"@id": "AdministrativeAction-cards"},
           "showProperties": [ "fresnel:super", {"inverseOf": "concerning"} ]
+        },
+        "MediaObject": {
+          "fresnel:extends": {"@id": "MediaObject-cards"},
+          "showProperties": [ "fresnel:super", "marc:publicNote" ]
         }
       }
     },


### PR DESCRIPTION
See description in [LWS-242](https://kbse.atlassian.net/browse/LWS-242). 

* Add optional filter for free e-resources for lxl-web/Libris sök. The filter can be formulated in the lxl web query language like so (which is sort of a hack, but will do until the free nature of things is expressed more clearly in the data): 
```
(usageAndAccessPolicy.label:"gratis" OR "associatedMedia.marc:publicNote":"*fritt tillgänglig*") AND hasInstanceType:"Electronic"
```
 * Add MediaObject-cards definition to include marc:publicNote in the search index, and hence facilitate the query above.

Edit: @olovy pointed out that we should probably add https://id.kb.se/policy/freely-available and https://id.kb.se/policy/oa/gratis to the filter, so those two access policies are also included now.  