### PR TITLE
Update contentAccessibility

### DIFF
--- a/source/vocab/bf-map.ttl
+++ b/source/vocab/bf-map.ttl
@@ -19,6 +19,8 @@ kbv:accompanies rdfs:domain kbv:Creation .
 kbv:accompaniedBy rdfs:domain kbv:Creation .
 kbv:summary rdfs:domain kbv:Endeavour .
 
+kbv:contentAccessibility rdfs:domain kbv:Instance . # NOTE: tightens implied bf2 domain.
+
 kbv:hasTitle owl:equivalentProperty bf2:title .
 kbv:contentType owl:equivalentProperty bf2:content .
 kbv:mediaType owl:equivalentProperty bf2:media .

--- a/source/vocab/bf-map.ttl
+++ b/source/vocab/bf-map.ttl
@@ -19,8 +19,6 @@ kbv:accompanies rdfs:domain kbv:Creation .
 kbv:accompaniedBy rdfs:domain kbv:Creation .
 kbv:summary rdfs:domain kbv:Endeavour .
 
-kbv:contentAccessibility rdfs:domain kbv:Instance . # NOTE: tightens implied bf2 domain.
-
 kbv:hasTitle owl:equivalentProperty bf2:title .
 kbv:contentType owl:equivalentProperty bf2:content .
 kbv:mediaType owl:equivalentProperty bf2:media .

--- a/source/vocab/details.ttl
+++ b/source/vocab/details.ttl
@@ -1282,7 +1282,8 @@
     rdfs:label "Content accessibility information"@en, "information om innehållets tillgänglighet"@sv;
     rdfs:range :ContentAccessibility;
     rdfs:comment "Information för personer med sensoriska funktionsnedsättningar om alternativa sätt och hjälpmedel för att ta till sig innehållet i en resurs."@sv ;
-    owl:equivalentProperty bf2:contentAccessibility, rdam:P30452 .
+    # skos:relatedMatch rdam:P30452 ; keep as comment until we can establish proper relationship.
+    owl:equivalentProperty bf2:contentAccessibility .
 
 :CopyrightRegistration a owl:Class;
     rdfs:label "Copyright registration"@en;

--- a/source/vocab/details.ttl
+++ b/source/vocab/details.ttl
@@ -1281,7 +1281,7 @@
 :contentAccessibility a owl:ObjectProperty;
     rdfs:label "Content accessibility information"@en, "information om innehållets tillgänglighet"@sv;
     rdfs:range :ContentAccessibility;
-    rdfs:comment "Information för personer med sensoriska funktionsnedsättningar om alternativa sätt och hjälpmedel att ta till sig innehållet i en resurs."@sv ;
+    rdfs:comment "Information för personer med sensoriska funktionsnedsättningar om alternativa sätt och hjälpmedel för att ta till sig innehållet i en resurs."@sv ;
     owl:equivalentProperty bf2:contentAccessibility, rdam:P30452 .
 
 :CopyrightRegistration a owl:Class;

--- a/source/vocab/details.ttl
+++ b/source/vocab/details.ttl
@@ -18,6 +18,7 @@
 @prefix bflc: <http://id.loc.gov/ontologies/bflc/> .
 
 @prefix rdael: <http://rdvocab.info/Elements/> .
+@prefix rdam: <http://rdaregistry.info/Elements/m/> .
 @prefix rdaz: <http://rdaregistry.info/Elements/z/> .
 @prefix rdau: <http://rdaregistry.info/Elements/u/> .
 
@@ -1274,13 +1275,14 @@
     rdfs:label "Anmärkning om medverkan"@sv .
 
 :ContentAccessibility a owl:Class;
-    rdfs:label "Content accessibility information"@en, "Anmärkning om komplement för ökad tillgänglighet"@sv;
+    rdfs:label "Content accessibility information"@en, "Information om innehållets tillgänglighet"@sv;
     owl:equivalentClass bf2:ContentAccessibility .
 
 :contentAccessibility a owl:ObjectProperty;
-    rdfs:label "Content accessibility information"@en, "Anmärkning om komplement för ökad tillgänglighet"@sv;
+    rdfs:label "Content accessibility information"@en, "information om innehållets tillgänglighet"@sv;
     rdfs:range :ContentAccessibility;
-    owl:equivalentProperty bf2:contentAccessibility .
+    rdfs:comment "Information för personer med sensoriska funktionsnedsättningar om alternativa sätt och hjälpmedel att ta till sig innehållet i en resurs."@sv ;
+    owl:equivalentProperty bf2:contentAccessibility, rdam:P30452 .
 
 :CopyrightRegistration a owl:Class;
     rdfs:label "Copyright registration"@en;

--- a/source/vocab/display.jsonld
+++ b/source/vocab/display.jsonld
@@ -143,6 +143,12 @@
             {"alternateProperties": [ "prefLabel", "label" ]}
           ]
         },
+        "ContentAccessibility": {
+          "@id": "ContentAccessibility-chips",
+          "@type": "fresnel:Lens",
+          "classLensDomain": "ContentAccessibility",
+          "showProperties": [ "prefLabel", "label", "code" ]
+        },
         "AccessModeType": {
           "@id": "AccessModeType-chips",
           "@type": "fresnel:Lens",
@@ -676,6 +682,7 @@
             "intendedAudience",
             "associatedMedia",
             "usageAndAccessPolicy",
+            "contentAccessibility",
             "accessMode",
             "isIssueOf",
             "isPartOf",


### PR DESCRIPTION
First PR in the Accessibility update. Making contentAccessibility usable as a general baseclass/property.

- [x] - Make `contentAccessibility` ~~domain only on Instance preventing it from being used on work as suggested in BF2.~~ Keep creation (instance/work) for now, see comments on 341 for example. We can revisit this later.
- [x] - Update swedish labels and add definition.
- [x] - Add ~~equivalence~~  _comment for relatedMatch_ `hasAccessibilityContent` in RDA.
- [x] - Add boilerplate Chip for `ContentAccessibility` class.
- [x] - Add `contentAccessibility` property to Instance Card.

See FMT-26 for details.