### PR TITLE
Feature/lws 401 search lenses

### DIFF
--- a/source/vocab/display.jsonld
+++ b/source/vocab/display.jsonld
@@ -27,43 +27,6 @@
     {"@id": "https://id.kb.se/vocab/display"}
   ],
   "lensGroups": {
-    "search-tokens": {
-      "@id": "search-tokens",
-      "@type": "fresnel:Group",
-      "lenses": {
-        "Creation": {
-          "@type": "fresnel:Lens",
-          "classLensDomain": "Creation",
-          "showProperties": [
-            {
-              "alternateProperties": [
-                {
-                  "@type": "fresnel:fslselector",
-                  "@value": "hasTitle/KeyTitle/mainTitle"
-                },
-                {
-                  "@type": "fresnel:fslselector",
-                  "@value": "hasTitle/Title/mainTitle"
-                },
-                {
-                  "@type": "fresnel:fslselector",
-                  "@value": "hasTitle/*/mainTitle"
-                }
-              ]
-            }
-          ]
-        },
-        "Person": {
-          "@type": "fresnel:Lens",
-          "classLensDomain": "Person",
-          "showProperties": [
-            "givenName",
-            "familyName",
-            "name"
-          ]
-        }
-      }
-    },
     "tokens": {
       "@id": "tokens",
       "@type": "fresnel:Group",
@@ -1492,6 +1455,43 @@
         "AdministrativeAction": {
           "fresnel:extends": {"@id": "AdministrativeAction-cards"},
           "showProperties": [ "fresnel:super", {"inverseOf": "concerning"} ]
+        }
+      }
+    },
+    "search-tokens": {
+      "@id": "search-tokens",
+      "@type": "fresnel:Group",
+      "lenses": {
+        "Creation": {
+          "@type": "fresnel:Lens",
+          "classLensDomain": "Creation",
+          "showProperties": [
+            {
+              "alternateProperties": [
+                {
+                  "@type": "fresnel:fslselector",
+                  "@value": "hasTitle/KeyTitle/mainTitle"
+                },
+                {
+                  "@type": "fresnel:fslselector",
+                  "@value": "hasTitle/Title/mainTitle"
+                },
+                {
+                  "@type": "fresnel:fslselector",
+                  "@value": "hasTitle/*/mainTitle"
+                }
+              ]
+            }
+          ]
+        },
+        "Person": {
+          "@type": "fresnel:Lens",
+          "classLensDomain": "Person",
+          "showProperties": [
+            "givenName",
+            "familyName",
+            "name"
+          ]
         }
       }
     },


### PR DESCRIPTION
- Add new lens group `search-tokens`.
- Extend Work search-card with instance fields (responsibilityStatement and tableOfContents)

Depends on https://github.com/libris/librisxl/pull/1611 and https://github.com/libris/librisxl/pull/1612 to take effect.