### PR TITLE
Map :controlNumber to ONR query code

### DIFF
--- a/source/vocab/libris-search-experimental.ttl
+++ b/source/vocab/libris-search-experimental.ttl
@@ -31,6 +31,8 @@
 
 :language skos:notation "SPRÅK"^^:LibrisQueryCode . # See ./relations.ttl for full definition of :language
 
+:controlNumber skos:notation "ONR"^^:LibrisQueryCode . # See ./platform.ttl for full definition of :controlNumber
+
 :itemHeldBy a owl:ObjectProperty ;
     rdfs:label "Bibliotek"@sv, "Library"@en ;
     :category :shorthand, :pending ;


### PR DESCRIPTION
Example usage with in new XL find API: `/find?_q=ONR:13576674`

`ONR` maps to `:controlNumber` and since `:controlNumber` has the domain `:Record`, it automatically expands to `meta.controlNumber` (see https://github.com/libris/librisxl/blob/a7cbe4d8ffe7a05a484d9b5c314c4be08ccb2a30/whelk-core/src/main/groovy/whelk/search2/querytree/Path.java#L111).