### PR TITLE
Create SAOGF patch file for matching LCGFT terms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,3 +45,6 @@ cache/ssif-2025.csv: cache/Nyckel_SSIF2011_SSIF2025_digg.xlsx
 	# Fix incomplete change type
 	sed -i '/^60411.*\tBytt benämning\t/ s/Bytt benämning/Ny kod, Bytt benämning/' "cache/Nyckel_SSIF2011_SSIF2025_digg-Nyckel SSIF2011-SSIF25.csv"
 	cp "cache/Nyckel_SSIF2011_SSIF2025_digg-Nyckel SSIF2011-SSIF25.csv" $@
+
+cache/lcgft.ttl.gz:
+	curl -sL "https://id.loc.gov/download/authorities/genreForms.skosrdf.ttl.gz" -o $@

--- a/source/saogf/saogf-lcgft-patch.trig
+++ b/source/saogf/saogf-lcgft-patch.trig
@@ -1,6 +1,18 @@
 prefix : <https://id.kb.se/vocab/>
 prefix saogf: <https://id.kb.se/term/saogf/>
 
+## Saknar closeMatch - felstavning eller broadMatch?
+#saogf:F%C3%B6retagshandlingar%20%28dokument%29
+#saogf:Filmprogram
+#saogf:Homoerotiska%20skildringar
+#saogf:Lantm%C3%A4terihandlingar
+#saogf:Sportprogram%20%28text%29
+
+# TODO[69e799a0]: Dubbla match; ändra en till broadMatch och ta bort andra om :broader/:closeMatch?
+#saogf:Tal%20%28retorik%29
+#saogf:Karikatyrer%20och%20sk%C3%A4mtteckningar
+#saogf:Bibliska%20ber%C3%A4ttelser
+
 saogf:%C3%84ventyrsfilmer :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026005> ;
   :prefLabel "Action and adventure films"@en .
 
@@ -40,7 +52,8 @@ saogf:Anagram :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026043
 saogf:Animerade%20filmer :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026049> ;
   :prefLabel "Animated films"@en .
 
-saogf:Annaler%20och%20kr%C3%B6nikor :prefLabel "Annals and chronicals"@en .
+saogf:Annaler%20och%20kr%C3%B6nikor :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026045> ;
+  :prefLabel "Annals and chronicles"@en .
 
 saogf:Anteckningar :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026133> ;
   :prefLabel "Notebooks"@en .
@@ -72,7 +85,8 @@ saogf:Avlatsbrev :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026
 saogf:B%C3%B6cker%20med%20ljudeffekter :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026177> ;
   :prefLabel "Sound books"@en .
 
-saogf:Bakl%C3%A4ngeslexikon :prefLabel "Reverse indexes"@en .
+saogf:Bakl%C3%A4ngeslexikon :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026167> ;
+  :prefLabel "Reverse dictionaries"@en .
 
 saogf:Barn-%20och%20familjefilmer :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026123> ;
   :prefLabel "Children's films"@en .
@@ -104,10 +118,11 @@ saogf:Bibliografier :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014
 saogf:Bibliotekskataloger :closeMatch <http://id.loc.gov/authorities/genreForms/gf2015026003> ;
   :prefLabel "Library catalogs"@en .
 
-saogf:Bibliska%20ber%C3%A4ttelser :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026240> ,
-    <http://id.loc.gov/authorities/genreForms/gf2014026242> ;
-  :prefLabel "Bible fiction"@en ,
-    "Bible stories"@en .
+# TODO[69e799a0]
+#saogf:Bibliska%20ber%C3%A4ttelser :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026240> ,
+#    <http://id.loc.gov/authorities/genreForms/gf2014026242> ;
+#  :prefLabel "Bible fiction"@en ,
+#    "Bible stories"@en .
 
 saogf:Bilder :closeMatch <http://id.loc.gov/authorities/genreForms/gf2017027251> ;
   :prefLabel "Pictures"@en .
@@ -154,10 +169,9 @@ saogf:Bossa%20nova :closeMatch <http://id.loc.gov/authorities/genreForms/gf20140
 saogf:Br%C3%B6llopsdikter :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026317> ;
   :prefLabel "Epithalamia"@en .
 
-saogf:Brevromaner :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026314> ,
-    <http://id.loc.gov/authorities/genreForms/gf2015026020> ;
-  :prefLabel "Epistolary fiction"@en ,
-    "Novels"@en .
+saogf:Brevromaner :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026314> ;
+  :prefLabel "Epistolary fiction"@en ;
+  :altLabel "Novels in letters"@en .
 
 saogf:Burlesker :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026254> ;
   :prefLabel "Burlesques (Literature)"@en .
@@ -203,8 +217,7 @@ saogf:Dagb%C3%B6cker :closeMatch <http://id.loc.gov/authorities/genreForms/gf201
 
 saogf:Dagboksromaner :closeMatch <http://id.loc.gov/authorities/genreForms/gf2015026020> ,
     <http://id.loc.gov/authorities/genreForms/gf2014026286> ;
-  :prefLabel "Novels"@en ,
-    "Diary fiction"@en .
+  :prefLabel "Diary fiction"@en .
 
 saogf:Dagstidningar :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026132> ;
   :prefLabel "Newspapers"@en .
@@ -227,10 +240,8 @@ saogf:Death%20metal :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014
 saogf:Debatter :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026083> ;
   :prefLabel "Debates"@en .
 
-saogf:Deckare :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026280> ,
-    <http://id.loc.gov/authorities/genreForms/gf2014026452> ;
-  :prefLabel "Detective and mystery fiction"@en ,
-    "Noir fiction"@en .
+saogf:Deckare :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026280> ;
+  :prefLabel "Detective and mystery fiction"@en .
 
 saogf:Diagram :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026061> ;
   :prefLabel "Graphs"@en .
@@ -327,7 +338,8 @@ saogf:F%C3%B6rel%C3%A4sningar :closeMatch <http://id.loc.gov/authorities/genreFo
 
 saogf:F%C3%B6retagshandlingar%20%28dokument%29 :prefLabel "Corporate resolutions"@en .
 
-saogf:F%C3%B6rkortade%20verk :prefLabel "Abridgements"@en .
+saogf:F%C3%B6rkortade%20verk :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026037> ;
+  :prefLabel "Abridgments"@en .
 
 saogf:F%C3%B6rordningar :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026030> ;
   :prefLabel "Administrative regulations"@en .
@@ -377,16 +389,16 @@ saogf:Fiktiva%20filmer :closeMatch <http://id.loc.gov/authorities/genreForms/gf2
 saogf:Film-%20och%20tv-bearbetningar :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026254> ;
   :prefLabel "Film adaptations"@en .
 
-saogf:Filmad%20st%C3%A5uppkomik :prefLabel "Filmed stand-up comedy routines"@en .
+#saogf:Filmad%20st%C3%A5uppkomik :prefLabel "Filmed stand-up comedy routines"@en .
 
-saogf:Filmade%20dansf%C3%B6rest%C3%A4llningar :prefLabel "Filmed dance"@en .
-
-saogf:Filmade%20intervjuer :prefLabel "Filmed interviews"@en .
-
-saogf:Filmade%20konserter :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026161> ;
-  :prefLabel "Concert films"@en .
-
-saogf:Filmade%20teaterf%C3%B6rest%C3%A4llningar :prefLabel "Filmed plays"@en .
+#saogf:Filmade%20dansf%C3%B6rest%C3%A4llningar :prefLabel "Filmed dance"@en .
+#
+#saogf:Filmade%20intervjuer :prefLabel "Filmed interviews"@en .
+#
+#saogf:Filmade%20konserter :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026161> ;
+#  :prefLabel "Concert films"@en .
+#
+#saogf:Filmade%20teaterf%C3%B6rest%C3%A4llningar :prefLabel "Filmed plays"@en .
 
 saogf:Filmer :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026406> ;
   :prefLabel "Motion pictures"@en .
@@ -468,7 +480,8 @@ saogf:Handb%C3%B6cker%2C%20manualer%20etc\. :closeMatch <http://id.loc.gov/autho
 saogf:Handlingar%20%28dokument%29 :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026163> ;
   :prefLabel "Records (Documents)"@en .
 
-saogf:Handlingar%20och%20intriger :prefLabel "Plot summeries"@en .
+saogf:Handlingar%20och%20intriger :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026149> ;
+  :prefLabel "Plot summaries"@en .
 
 saogf:Hardcore :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026850> ;
   :prefLabel "Hardcore (Music)"@en .
@@ -562,10 +575,11 @@ saogf:K%C3%A4rleksskildringar :closeMatch <http://id.loc.gov/authorities/genreFo
 saogf:Kalendrar :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026055> ;
   :prefLabel "Calendars"@en .
 
-saogf:Karikatyrer%20och%20sk%C3%A4mtteckningar :closeMatch <http://id.loc.gov/authorities/genreForms/gf2017027224> ,
-    <http://id.loc.gov/authorities/genreForms/gf2017027225> ;
-  :prefLabel "Caricatures"@en ,
-    "Cartoons (Humor)"@en .
+# TODO[69e799a0]
+#saogf:Karikatyrer%20och%20sk%C3%A4mtteckningar :closeMatch <http://id.loc.gov/authorities/genreForms/gf2017027224> ,
+#    <http://id.loc.gov/authorities/genreForms/gf2017027225> ;
+#  :prefLabel "Caricatures"@en ,
+#    "Cartoons (Humor)"@en .
 
 saogf:Kartb%C3%B6cker :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026058> ;
   :prefLabel "Atlases"@en .
@@ -615,7 +629,8 @@ saogf:Konsertprogram :closeMatch <http://id.loc.gov/authorities/genreForms/gf201
 saogf:Konstsagor :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026329> ;
   :prefLabel "Fairy tales"@en .
 
-saogf:Kontrafaktisk%20historia :prefLabel "Alternative histories (fiction)"@en .
+saogf:Kontrafaktisk%20historia :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026220> ;
+  :prefLabel "Alternative histories (Fiction)"@en .
 
 saogf:Kontrollerade%20vokabul%C3%A4rer :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026070> ;
   :prefLabel "Controlled vocabularies"@en .
@@ -662,7 +677,8 @@ saogf:Kursmaterial :closeMatch <http://id.loc.gov/authorities/genreForms/gf20140
 saogf:Kyrkohandb%C3%B6cker :closeMatch <http://id.loc.gov/authorities/genreForms/gf2015026039> ;
   :prefLabel "Liturgical books"@en .
 
-saogf:L%C3%A4rarhandledningar :prefLabel "Teachers’ guides"@en .
+saogf:L%C3%A4rarhandledningar :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026188> ;
+  :prefLabel "Teachers' guides"@en .
 
 saogf:L%C3%A4romedel :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026191> ;
   :prefLabel "Textbooks"@en .
@@ -723,7 +739,8 @@ saogf:Mekaniska%20b%C3%B6cker :closeMatch <http://id.loc.gov/authorities/genreFo
 saogf:Merengue :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026933> ;
   :prefLabel "Merengues (Music)"@en .
 
-saogf:Miniatyrb%C3%B6cker :prefLabel "Miniature books—Specimens"@en .
+saogf:Miniatyrb%C3%B6cker :closeMatch <http://id.loc.gov/authorities/subjects/sh85085644> ;
+  :prefLabel "Miniature books—Specimens"@en .
 
 saogf:Minnesbevarande%20verk :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026064> ;
   :prefLabel "Commemorative works"@en .
@@ -731,7 +748,8 @@ saogf:Minnesbevarande%20verk :closeMatch <http://id.loc.gov/authorities/genreFor
 saogf:Musikfilmer :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026414> ;
   :prefLabel "Musical films"@en .
 
-saogf:Musikrecensioner :prefLabel "Music reviews"@en .
+saogf:Musikrecensioner :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026130> ;
+  :prefLabel "Music criticism and reviews"@en .
 
 saogf:Musikvideor :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026413> ;
   :prefLabel "Music videos"@en .
@@ -781,7 +799,9 @@ saogf:Parodier :closeMatch <http://id.loc.gov/authorities/genreForms/gf201402647
 saogf:Partimenti :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026985> ;
   :prefLabel "Partimenti"@en .
 
-saogf:Passagerarlistor :prefLabel "Passanger lists"@en .
+saogf:Passagerarlistor :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026138> ;
+  :prefLabel "Passenger lists"@en .
+
 
 saogf:Patent :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026438> ;
   :prefLabel "Patents"@en .
@@ -795,10 +815,8 @@ saogf:Personlig%20utveckling :closeMatch <http://id.loc.gov/authorities/genreFor
 saogf:Personliga%20ber%C3%A4ttelser :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026142> ;
   :prefLabel "Personal narratives"@en .
 
-saogf:Pikareskromaner :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026479> ,
-    <http://id.loc.gov/authorities/genreForms/gf2015026020> ;
-  :prefLabel "Picaresque fiction"@en ,
-    "Novels"@en .
+saogf:Pikareskromaner :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026479> ;
+  :prefLabel "Picaresque fiction"@en .
 
 saogf:Poesi :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026481> ;
   :prefLabel "Poetry"@en .
@@ -830,9 +848,12 @@ saogf:Pressmeddelanden :closeMatch <http://id.loc.gov/authorities/genreForms/gf2
 saogf:Privatfilmer :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026038> ;
   :prefLabel "Amateur films"@en .
 
-saogf:Problemsamlingar :prefLabel "Problems, exercises, etc."@en .
+saogf:Problemsamlingar :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026154> ;
+  :prefLabel "Problems and exercises"@en .
 
-saogf:Produktkataloger :prefLabel "Manufacturers' catalogs"@en .
+saogf:Produktkataloger :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026198> ;
+  :prefLabel "Trade catalogs"@en ;
+  :altLabel "Manufacturers' catalogs"@en .
 
 saogf:Program%20%28publikationer%29 :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026156> ;
   :prefLabel "Programs (Publications)"@en .
@@ -846,7 +867,8 @@ saogf:Propagandafilmer :closeMatch <http://id.loc.gov/authorities/genreForms/gf2
 saogf:Prosadikter :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026488> ;
   :prefLabel "Prose poems"@en .
 
-saogf:Protokoll :prefLabel "Minutes (records)"@en .
+saogf:Protokoll :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026128> ;
+  :prefLabel "Minutes (Records)"@en .
 
 saogf:Prov%20och%20examinationer :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026096> ;
   :prefLabel "Examinations"@en .
@@ -857,7 +879,8 @@ saogf:Psalmb%C3%B6cker :closeMatch <http://id.loc.gov/authorities/genreForms/gf2
 saogf:Psalmer%20%28musik%29 :closeMatch <http://id.loc.gov/authorities/genreForms/gf2017026134> ;
   :prefLabel "Hymn tunes"@en .
 
-saogf:Psaltarpsalmer%20%28musik%29 :prefLabel "Psalms (music)"@en .
+saogf:Psaltarpsalmer%20%28musik%29 :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014027023> ;
+  :prefLabel "Psalms (Music)"@en .
 
 saogf:Psykedelia :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014027024> ;
   :prefLabel "Psychedelic rock music"@en .
@@ -979,7 +1002,8 @@ saogf:Romantisk%20komedi%20%28film%29 :closeMatch <http://id.loc.gov/authorities
 saogf:Rumba :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014027059> ;
   :prefLabel "Rumbas (Music)"@en .
 
-saogf:Rymdopera :prefLabel "Space operas"@en .
+saogf:Rymdopera :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026551> ;
+  :prefLabel "Space operas (Fiction)"@en .
 
 saogf:S%C3%B6khj%C3%A4lper :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026103> ;
   :prefLabel "Finding aids"@en .
@@ -1020,7 +1044,9 @@ saogf:Science%20fiction :closeMatch <http://id.loc.gov/authorities/genreForms/gf
 saogf:Science%20fiction-filmer :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026556> ;
   :prefLabel "Science fiction films"@en .
 
-saogf:Scrapbooks :prefLabel "Scrapbooks"@en .
+saogf:Scrapbooks :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026173> ;
+  :prefLabel "Albums (Books)"@en ;
+  :altLabel "Scrapbooks"@en .
 
 saogf:Screentryck :closeMatch <http://id.loc.gov/authorities/genreForms/gf2017027258> ;
   :prefLabel "Screen prints"@en .
@@ -1123,10 +1149,11 @@ saogf:Tabeller :closeMatch <http://id.loc.gov/authorities/genreForms/gf201402618
 saogf:Taktila%20verk :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026187> ;
   :prefLabel "Tactile works"@en .
 
-saogf:Tal%20%28retorik%29 :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026363> ,
-    <http://id.loc.gov/authorities/genreForms/gf2014026196> ;
-  :prefLabel "Speeches"@en ,
-    "Toasts (Speeches)"@en .
+# TODO[69e799a0]
+#saogf:Tal%20%28retorik%29 :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026363> ,
+#    <http://id.loc.gov/authorities/genreForms/gf2014026196> ;
+#  :prefLabel "Speeches"@en ,
+#    "Toasts (Speeches)"@en .
 
 saogf:Talb%C3%B6cker :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026630> ;
   :prefLabel "Talking books"@en .
@@ -1191,7 +1218,8 @@ saogf:Trycksaker :closeMatch <http://id.loc.gov/authorities/genreForms/gf2017027
 saogf:Tv-program :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026673> ;
   :prefLabel "Television programs"@en .
 
-saogf:Tv-recensioner :prefLabel "Television programs reviews"@en .
+saogf:Tv-recensioner :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026190> ;
+  :prefLabel "Television program reviews"@en .
 
 saogf:Tv-serier :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026680> ;
   :prefLabel "Television series"@en .
@@ -1199,7 +1227,8 @@ saogf:Tv-serier :closeMatch <http://id.loc.gov/authorities/genreForms/gf20110266
 saogf:UK%20garage :closeMatch <http://id.loc.gov/authorities/genreForms/gf2020026048> ;
   :prefLabel "UK garage (Music)"@en .
 
-saogf:Unders%C3%B6kningar :prefLabel "Surveys"@en .
+saogf:Unders%C3%B6kningar :closeMatch <http://id.loc.gov/authorities/subjects/sh99001768> ;
+  :prefLabel "Surveys"@en .
 
 saogf:Undervisningsfilmer :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026219> ;
   :prefLabel "Educational films"@en .
@@ -1404,12 +1433,12 @@ graph <#delete> {
         :inScheme <https://id.kb.se/term/lcsh> ;
         :prefLabel "Library catalogs" ] .
 
-  saogf:Bibliska%20ber%C3%A4ttelser :closeMatch [ a :GenreForm ;
-        :inScheme <https://id.kb.se/term/lcsh> ;
-        :prefLabel "Bible fiction" ] ,
-      [ a :GenreForm ;
-        :inScheme <https://id.kb.se/term/lcsh> ;
-        :prefLabel "Bible stories" ] .
+  #saogf:Bibliska%20ber%C3%A4ttelser :closeMatch [ a :GenreForm ;
+  #      :inScheme <https://id.kb.se/term/lcsh> ;
+  #      :prefLabel "Bible fiction" ] ,
+  #    [ a :GenreForm ;
+  #      :inScheme <https://id.kb.se/term/lcsh> ;
+  #      :prefLabel "Bible stories" ] .
 
   saogf:Bilder :closeMatch [ a :GenreForm ;
         :inScheme <https://id.kb.se/term/lcgft> ;
@@ -1589,10 +1618,7 @@ graph <#delete> {
 
   saogf:Deckare :closeMatch [ a :GenreForm ;
         :inScheme <https://id.kb.se/term/lcsh> ;
-        :prefLabel "Detective and mystery fiction" ] ,
-      [ a :GenreForm ;
-        :inScheme <https://id.kb.se/term/lcsh> ;
-        :prefLabel "Noir fiction" ] .
+        :prefLabel "Detective and mystery fiction" ] .
 
   saogf:Diagram :closeMatch [ a :GenreForm ;
         :inScheme <https://id.kb.se/term/lcgft> ;
@@ -1735,7 +1761,7 @@ graph <#delete> {
 
   saogf:F%C3%B6rkortade%20verk :closeMatch [ a :GenreForm ;
         :inScheme <https://id.kb.se/term/lcgft> ;
-        :prefLabel "Abridgements" ] .
+        :prefLabel "Abridgments" ] .
 
   saogf:F%C3%B6rordningar :closeMatch [ a :GenreForm ;
         :inScheme <https://id.kb.se/term/lcsh> ;
@@ -1803,25 +1829,25 @@ graph <#delete> {
         :inScheme <https://id.kb.se/term/lcgft> ;
         :prefLabel "Film adaptations" ] .
 
-  saogf:Filmad%20st%C3%A5uppkomik :closeMatch [ a :GenreForm ;
-        :inScheme <https://id.kb.se/term/lcgft> ;
-        :prefLabel "Filmed stand-up comedy routines" ] .
+  #saogf:Filmad%20st%C3%A5uppkomik :closeMatch [ a :GenreForm ;
+  #      :inScheme <https://id.kb.se/term/lcgft> ;
+  #      :prefLabel "Filmed stand-up comedy routines" ] .
 
-  saogf:Filmade%20dansf%C3%B6rest%C3%A4llningar :closeMatch [ a :GenreForm ;
-        :inScheme <https://id.kb.se/term/lcgft> ;
-        :prefLabel "Filmed dance" ] .
+  #saogf:Filmade%20dansf%C3%B6rest%C3%A4llningar :closeMatch [ a :GenreForm ;
+  #      :inScheme <https://id.kb.se/term/lcgft> ;
+  #      :prefLabel "Filmed dance" ] .
 
-  saogf:Filmade%20intervjuer :closeMatch [ a :GenreForm ;
-        :inScheme <https://id.kb.se/term/lcgft> ;
-        :prefLabel "Filmed interviews" ] .
+  #saogf:Filmade%20intervjuer :closeMatch [ a :GenreForm ;
+  #      :inScheme <https://id.kb.se/term/lcgft> ;
+  #      :prefLabel "Filmed interviews" ] .
 
-  saogf:Filmade%20konserter :closeMatch [ a :GenreForm ;
-        :inScheme <https://id.kb.se/term/lcgft> ;
-        :prefLabel "Concert films" ] .
+  #saogf:Filmade%20konserter :closeMatch [ a :GenreForm ;
+  #      :inScheme <https://id.kb.se/term/lcgft> ;
+  #      :prefLabel "Concert films" ] .
 
-  saogf:Filmade%20teaterf%C3%B6rest%C3%A4llningar :closeMatch [ a :GenreForm ;
-        :inScheme <https://id.kb.se/term/lcgft> ;
-        :prefLabel "Filmed plays" ] .
+  #saogf:Filmade%20teaterf%C3%B6rest%C3%A4llningar :closeMatch [ a :GenreForm ;
+  #      :inScheme <https://id.kb.se/term/lcgft> ;
+  #      :prefLabel "Filmed plays" ] .
 
   saogf:Filmer :closeMatch [ a :GenreForm ;
         :inScheme <https://id.kb.se/term/lcgft> ;
@@ -1943,7 +1969,7 @@ graph <#delete> {
 
   saogf:Handlingar%20och%20intriger :closeMatch [ a :GenreForm ;
         :inScheme <https://id.kb.se/term/lcgft> ;
-        :prefLabel "Plot summeries" ] .
+        :prefLabel "Plot summaries" ] .
 
   saogf:Hardcore :closeMatch [ a :GenreForm ;
         :inScheme <https://id.kb.se/term/lcgft> ;
@@ -2085,14 +2111,14 @@ graph <#delete> {
         :inScheme <https://id.kb.se/term/lcgft> ;
         :prefLabel "Calendars" ] .
 
-  saogf:Karikatyrer%20och%20sk%C3%A4mtteckningar :closeMatch [ a :GenreForm ;
-        :inScheme <https://id.kb.se/term/lcgft> ;
-        :prefLabel "Caricatures" ;
-        :uri "http://id.loc.gov/authorities/genreForms/gf2017027224"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] ,
-      [ a :GenreForm ;
-        :inScheme <https://id.kb.se/term/lcgft> ;
-        :prefLabel "Cartoons (Humor)" ;
-        :uri "http://id.loc.gov/authorities/genreForms/gf2017027225"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+  #saogf:Karikatyrer%20och%20sk%C3%A4mtteckningar :closeMatch [ a :GenreForm ;
+  #      :inScheme <https://id.kb.se/term/lcgft> ;
+  #      :prefLabel "Caricatures" ;
+  #      :uri "http://id.loc.gov/authorities/genreForms/gf2017027224"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] ,
+  #    [ a :GenreForm ;
+  #      :inScheme <https://id.kb.se/term/lcgft> ;
+  #      :prefLabel "Cartoons (Humor)" ;
+  #      :uri "http://id.loc.gov/authorities/genreForms/gf2017027225"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
 
   saogf:Kartb%C3%B6cker :closeMatch [ a :GenreForm ;
         :inScheme <https://id.kb.se/term/lcgft> ;
@@ -2168,7 +2194,7 @@ graph <#delete> {
 
   saogf:Kontrafaktisk%20historia :closeMatch [ a :GenreForm ;
         :inScheme <https://id.kb.se/term/lcsh> ;
-        :prefLabel "Alternative histories (fiction)" ] .
+        :prefLabel "Alternative histories (Fiction)" ] .
 
   saogf:Kontrollerade%20vokabul%C3%A4rer :closeMatch [ a :GenreForm ;
         :inScheme <https://id.kb.se/term/lcgft> ;
@@ -2336,7 +2362,7 @@ graph <#delete> {
 
   saogf:Musikrecensioner :closeMatch [ a :GenreForm ;
         :inScheme <https://id.kb.se/term/lcgft> ;
-        :prefLabel "Music reviews" ] .
+        :prefLabel "Music criticism and reviews" ] .
 
   saogf:Musikvideor :closeMatch [ a :GenreForm ;
         :inScheme <https://id.kb.se/term/lcgft> ;
@@ -2408,7 +2434,7 @@ graph <#delete> {
 
   saogf:Passagerarlistor :closeMatch [ a :GenreForm ;
         :inScheme <https://id.kb.se/term/lcgft> ;
-        :prefLabel "Passanger lists" ] .
+        :prefLabel "Passenger lists" ] .
 
   saogf:Patent :closeMatch [ a :GenreForm ;
         :inScheme <https://id.kb.se/term/lcgft> ;
@@ -2479,11 +2505,11 @@ graph <#delete> {
 
   saogf:Problemsamlingar :closeMatch [ a :GenreForm ;
         :inScheme <https://id.kb.se/term/lcgft> ;
-        :prefLabel "Problems, exercises, etc." ] .
+        :prefLabel "Problems and exercises" ] .
 
   saogf:Produktkataloger :closeMatch [ a :GenreForm ;
         :inScheme <https://id.kb.se/term/lcgft> ;
-        :prefLabel "Manufacturers' catalogs" ] .
+        :prefLabel "Trade catalogs" ] .
 
   saogf:Program%20%28publikationer%29 :closeMatch [ a :GenreForm ;
         :inScheme <https://id.kb.se/term/lcgft> ;
@@ -2505,7 +2531,7 @@ graph <#delete> {
 
   saogf:Protokoll :closeMatch [ a :GenreForm ;
         :inScheme <https://id.kb.se/term/lcsh> ;
-        :prefLabel "Minutes (records)" ] .
+        :prefLabel "Minutes (Records)" ] .
 
   saogf:Prov%20och%20examinationer :closeMatch [ a :GenreForm ;
         :inScheme <https://id.kb.se/term/lcgft> ;
@@ -2523,7 +2549,7 @@ graph <#delete> {
 
   saogf:Psaltarpsalmer%20%28musik%29 :closeMatch [ a :GenreForm ;
         :inScheme <https://id.kb.se/term/lcgft> ;
-        :prefLabel "Psalms (music)" ;
+        :prefLabel "Psalms (Music)" ;
         :uri "http://id.loc.gov/authorities/genreForms/gf2014027023"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
 
   saogf:Psykedelia :closeMatch [ a :GenreForm ;
@@ -2706,7 +2732,7 @@ graph <#delete> {
 
   saogf:Rymdopera :closeMatch [ a :GenreForm ;
         :inScheme <https://id.kb.se/term/lcsh> ;
-        :prefLabel "Space operas" ] .
+        :prefLabel "Space operas (Fiction)" ] .
 
   saogf:S%C3%B6khj%C3%A4lper :closeMatch [ a :GenreForm ;
         :inScheme <https://id.kb.se/term/lcgft> ;
@@ -2764,7 +2790,7 @@ graph <#delete> {
 
   saogf:Scrapbooks :closeMatch [ a :GenreForm ;
         :inScheme <https://id.kb.se/term/lcgft> ;
-        :prefLabel "Scrapbooks" ] .
+        :prefLabel "Albums (Books)" ] .
 
   saogf:Screentryck :closeMatch [ a :GenreForm ;
         :inScheme <https://id.kb.se/term/lcgft> ;
@@ -2911,12 +2937,12 @@ graph <#delete> {
         :inScheme <https://id.kb.se/term/lcgft> ;
         :prefLabel "Tactile works" ] .
 
-  saogf:Tal%20%28retorik%29 :closeMatch [ a :GenreForm ;
-        :inScheme <https://id.kb.se/term/lcgft> ;
-        :prefLabel "Speeches" ] ,
-      [ a :GenreForm ;
-        :inScheme <https://id.kb.se/term/lcgft> ;
-        :prefLabel "Toasts (Speeches)" ] .
+  #saogf:Tal%20%28retorik%29 :closeMatch [ a :GenreForm ;
+  #      :inScheme <https://id.kb.se/term/lcgft> ;
+  #      :prefLabel "Speeches" ] ,
+  #    [ a :GenreForm ;
+  #      :inScheme <https://id.kb.se/term/lcgft> ;
+  #      :prefLabel "Toasts (Speeches)" ] .
 
   saogf:Talb%C3%B6cker :closeMatch [ a :GenreForm ;
         :inScheme <https://id.kb.se/term/lcsh> ;
@@ -3014,7 +3040,7 @@ graph <#delete> {
 
   saogf:Tv-recensioner :closeMatch [ a :GenreForm ;
         :inScheme <https://id.kb.se/term/lcgft> ;
-        :prefLabel "Television programs reviews" ] .
+        :prefLabel "Television program reviews" ] .
 
   saogf:Tv-serier :closeMatch [ a :GenreForm ;
         :inScheme <https://id.kb.se/term/lcgft> ;

--- a/source/saogf/saogf-lcgft-patch.trig
+++ b/source/saogf/saogf-lcgft-patch.trig
@@ -1,0 +1,3102 @@
+prefix : <https://id.kb.se/vocab/>
+prefix saogf: <https://id.kb.se/term/saogf/>
+
+saogf:%C3%84ventyrsfilmer :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026005> ;
+  :prefLabel "Action and adventure films"@en .
+
+saogf:%C3%84ventyrsskildringar :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026217> ;
+  :prefLabel "Action and adventure fiction"@en .
+
+saogf:%C3%85rsb%C3%B6cker :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026208> ;
+  :prefLabel "Yearbooks"@en .
+
+saogf:Actionfilmer :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026005> ;
+  :prefLabel "Action and adventure films"@en .
+
+saogf:Adresskalendrar :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026087> ;
+  :prefLabel "Directories"@en .
+
+saogf:Aff%C3%A4rskorrespondens :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026054> ;
+  :prefLabel "Business correspondence"@en .
+
+saogf:Afrobeat :closeMatch <http://id.loc.gov/authorities/genreForms/gf2015026088> ;
+  :prefLabel "Afrobeat"@en .
+
+saogf:Allegorier :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026218> ;
+  :prefLabel "Allegories"@en .
+
+saogf:Almanackor :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026042> ;
+  :prefLabel "Almanacs"@en .
+
+saogf:Ambient%20musik :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014027185> ;
+  :prefLabel "Ambient music (Electronica)"@en .
+
+saogf:Americana :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026630> ;
+  :prefLabel "Alternative country music"@en .
+
+saogf:Anagram :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026043> ;
+  :prefLabel "Anagrams"@en .
+
+saogf:Animerade%20filmer :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026049> ;
+  :prefLabel "Animated films"@en .
+
+saogf:Annaler%20och%20kr%C3%B6nikor :prefLabel "Annals and chronicals"@en .
+
+saogf:Anteckningar :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026133> ;
+  :prefLabel "Notebooks"@en .
+
+saogf:Apokalyptiska%20skildringar :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026226> ;
+  :prefLabel "Apocalyptic fiction"@en .
+
+saogf:Apologetiska%20verk :closeMatch <http://id.loc.gov/authorities/genreForms/gf2015026027> ;
+  :prefLabel "Apologetic writings"@en .
+
+saogf:Arbetsbeskrivningar :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026117> ;
+  :prefLabel "Job descriptions"@en .
+
+saogf:Artists%27%20books :closeMatch <http://id.loc.gov/authorities/genreForms/gf2017027220> ;
+  :prefLabel "Artists' books"@en .
+
+saogf:Artursagan :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026227> ;
+  :prefLabel "Arthurian romances"@en .
+
+saogf:Automatisk%20skrift :closeMatch <http://id.loc.gov/authorities/genreForms/gf2015026052> ;
+  :prefLabel "Spirit writings"@en .
+
+saogf:Avhandlingar :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026039> ;
+  :prefLabel "Academic theses"@en .
+
+saogf:Avlatsbrev :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026328> ;
+  :prefLabel "Indulgences (Canon law)"@en .
+
+saogf:B%C3%B6cker%20med%20ljudeffekter :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026177> ;
+  :prefLabel "Sound books"@en .
+
+saogf:Bakl%C3%A4ngeslexikon :prefLabel "Reverse indexes"@en .
+
+saogf:Barn-%20och%20familjefilmer :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026123> ;
+  :prefLabel "Children's films"@en .
+
+saogf:Bearbetningar :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026041> ;
+  :prefLabel "Adaptations"@en .
+
+saogf:Bebop :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026670> ;
+  :prefLabel "Bop (Music)"@en .
+
+saogf:Befolkningsstatistik :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026207> ;
+  :prefLabel "Vital statistics"@en .
+
+saogf:Begravningar%20%28program%29 :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026126> ;
+  :prefLabel "Memorial service programs"@en .
+
+saogf:Begravningsdikter :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026311> ;
+  :prefLabel "Epicedia"@en .
+
+saogf:Begravningsstatistik :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026082> ;
+  :prefLabel "Death registers"@en .
+
+saogf:Ber%C3%A4ttelser%20fr%C3%A5n%20f%C3%A5ngenskap :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026056> ;
+  :prefLabel "Captivity narratives"@en .
+
+saogf:Bibliografier :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026048> ;
+  :prefLabel "Bibliographies"@en .
+
+saogf:Bibliotekskataloger :closeMatch <http://id.loc.gov/authorities/genreForms/gf2015026003> ;
+  :prefLabel "Library catalogs"@en .
+
+saogf:Bibliska%20ber%C3%A4ttelser :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026240> ,
+    <http://id.loc.gov/authorities/genreForms/gf2014026242> ;
+  :prefLabel "Bible fiction"@en ,
+    "Bible stories"@en .
+
+saogf:Bilder :closeMatch <http://id.loc.gov/authorities/genreForms/gf2017027251> ;
+  :prefLabel "Pictures"@en .
+
+saogf:Bildlexikon :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026146> ;
+  :prefLabel "Picture dictionaries"@en .
+
+saogf:Biografier :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026049> ;
+  :prefLabel "Biographies"@en .
+
+saogf:Biografiska%20filmer :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026089> ;
+  :prefLabel "Biographical films"@en .
+
+saogf:Biografiska%20skildringar :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026246> ;
+  :prefLabel "Biographical fiction"@en .
+
+saogf:Black%20metal :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026663> ;
+  :prefLabel "Black metal (Music)"@en .
+
+saogf:Blanketter :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026050> ;
+  :prefLabel "Blank forms"@en .
+
+saogf:Bloggar :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026051> ;
+  :prefLabel "Blogs"@en .
+
+saogf:Bluegrass :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026664> ;
+  :prefLabel "Bluegrass music"@en .
+
+saogf:Blues :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026665> ;
+  :prefLabel "Blues (Music)"@en .
+
+saogf:Bluesrock :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026666> ;
+  :prefLabel "Blues-rock music"@en .
+
+saogf:Bokrecensioner :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026052> ;
+  :prefLabel "Book reviews"@en .
+
+saogf:Bolero%20%28musik%29 :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026667> ;
+  :prefLabel "Boleros (Music)"@en .
+
+saogf:Bossa%20nova :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026671> ;
+  :prefLabel "Bossa nova (Music)"@en .
+
+saogf:Br%C3%B6llopsdikter :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026317> ;
+  :prefLabel "Epithalamia"@en .
+
+saogf:Brevromaner :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026314> ,
+    <http://id.loc.gov/authorities/genreForms/gf2015026020> ;
+  :prefLabel "Epistolary fiction"@en ,
+    "Novels"@en .
+
+saogf:Burlesker :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026254> ;
+  :prefLabel "Burlesques (Literature)"@en .
+
+saogf:Cajun%20%28musik%29 :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026679> ;
+  :prefLabel "Cajun music"@en .
+
+saogf:Calypso :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026680> ;
+  :prefLabel "Calypso (Music)"@en .
+
+saogf:Census%20%28statistik%29 :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026059> ;
+  :prefLabel "Census data"@en .
+
+saogf:Cha-cha :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026702> ;
+  :prefLabel "Cha-chas (Music)"@en .
+
+saogf:Charader :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026060> ;
+  :prefLabel "Charades"@en .
+
+saogf:Citat :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026159> ;
+  :prefLabel "Quotations"@en .
+
+saogf:Cool%20jazz :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026730> ;
+  :prefLabel "Cool jazz"@en .
+
+saogf:Countrymusik :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026739> ;
+  :prefLabel "Country music"@en .
+
+saogf:Countryrock :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026740> ;
+  :prefLabel "Country rock music"@en .
+
+saogf:Cumbia :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026749> ;
+  :prefLabel "Cumbia (Music)"@en .
+
+saogf:Cyberpunk :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026275> ;
+  :prefLabel "Cyberpunk fiction"@en .
+
+saogf:D%C3%B6dsfallsregister :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026082> ;
+  :prefLabel "Death registers"@en .
+
+saogf:Dagb%C3%B6cker :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026085> ;
+  :prefLabel "Diaries"@en .
+
+saogf:Dagboksromaner :closeMatch <http://id.loc.gov/authorities/genreForms/gf2015026020> ,
+    <http://id.loc.gov/authorities/genreForms/gf2014026286> ;
+  :prefLabel "Novels"@en ,
+    "Diary fiction"@en .
+
+saogf:Dagstidningar :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026132> ;
+  :prefLabel "Newspapers"@en .
+
+saogf:Dancehall :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026754> ;
+  :prefLabel "Dancehall (Music)"@en .
+
+saogf:Dansrecensioner :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026079> ;
+  :prefLabel "Dance reviews"@en .
+
+saogf:Databaser :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026081> ;
+  :prefLabel "Databases"@en .
+
+saogf:Datorspelsmusik :closeMatch <http://id.loc.gov/authorities/genreForms/gf2016026066> ;
+  :prefLabel "Computer and video game music"@en .
+
+saogf:Death%20metal :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026761> ;
+  :prefLabel "Death metal (Music)"@en .
+
+saogf:Debatter :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026083> ;
+  :prefLabel "Debates"@en .
+
+saogf:Deckare :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026280> ,
+    <http://id.loc.gov/authorities/genreForms/gf2014026452> ;
+  :prefLabel "Detective and mystery fiction"@en ,
+    "Noir fiction"@en .
+
+saogf:Diagram :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026061> ;
+  :prefLabel "Graphs"@en .
+
+saogf:Dialektlitteratur :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026283> ;
+  :prefLabel "Dialect fiction"@en .
+
+saogf:Disco%20%28musik%29 :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026768> ;
+  :prefLabel "Disco (Music)"@en .
+
+saogf:Diskografier :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026088> ;
+  :prefLabel "Discographies"@en .
+
+saogf:Dockfilmer :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026480> ;
+  :prefLabel "Puppet films"@en .
+
+saogf:Dokument%C3%A4ra%20skildringar :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026454> ;
+  :prefLabel "Nonfiction novels"@en .
+
+saogf:Dokument%C3%A4rfilmer :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026205> ;
+  :prefLabel "Documentary films"@en .
+
+saogf:Doom%20metal :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026774> ;
+  :prefLabel "Doom metal (Music)"@en .
+
+saogf:Dramatik :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026297> ;
+  :prefLabel "Drama"@en .
+
+saogf:Dramatisk%20och%20scenisk%20musik :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026775> ;
+  :prefLabel "Dramatic music"@en .
+
+saogf:Drum%20%27n%27%20bass%20%28jungle%29 :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026887> ;
+  :prefLabel "Jungle (Music)"@en .
+
+saogf:Dub :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026778> ;
+  :prefLabel "Dub (Music)"@en .
+
+saogf:Dubstep :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026779> ;
+  :prefLabel "Dubstep (Music)"@en .
+
+saogf:Dystopier :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026302> ;
+  :prefLabel "Dystopian fiction"@en .
+
+saogf:Dystopiska%20filmer :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026217> ;
+  :prefLabel "Dystopian films"@en .
+
+saogf:Efem%C3%A4rt%20material :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026093> ;
+  :prefLabel "Ephemera"@en .
+
+saogf:Electronic%20body%20music :closeMatch <http://id.loc.gov/authorities/genreForms/gf2017026062> ;
+  :prefLabel "Industrial dance music"@en .
+
+saogf:Electronica :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026783> ;
+  :prefLabel "Electronica (Music)"@en .
+
+saogf:Elektronisk%20popul%C3%A4rmusik :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026783> ;
+  :prefLabel "Electronica (Music)"@en .
+
+saogf:Emblemb%C3%B6cker :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026091> ;
+  :prefLabel "Emblem books"@en .
+
+saogf:Encyklopedier :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026092> ;
+  :prefLabel "Encyclopedias"@en .
+
+saogf:Episka%20skildringar :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026309> ;
+  :prefLabel "Epic fiction"@en .
+
+saogf:Erotiska%20skildringar :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026320> ;
+  :prefLabel "Erotic fiction"@en .
+
+saogf:Ess%C3%A4er :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026094> ;
+  :prefLabel "Essays"@en .
+
+saogf:Etnografiska%20filmer :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026232> ;
+  :prefLabel "Ethnographic films"@en .
+
+saogf:Evighetskalendrar :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026140> ;
+  :prefLabel "Perpetual calendars"@en .
+
+saogf:Examenstidningar :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026172> ;
+  :prefLabel "School yearbooks"@en .
+
+saogf:Experimentell%20sk%C3%B6nlitteratur :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026325> ;
+  :prefLabel "Experimental fiction"@en .
+
+saogf:Experimentfilmer :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026235> ;
+  :prefLabel "Experimental films"@en .
+
+saogf:F%C3%B6ljetonger :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026537> ;
+  :prefLabel "Serialized fiction"@en .
+
+saogf:F%C3%B6rel%C3%A4sningar :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026122> ;
+  :prefLabel "Lectures"@en .
+
+saogf:F%C3%B6retagshandlingar%20%28dokument%29 :prefLabel "Corporate resolutions"@en .
+
+saogf:F%C3%B6rkortade%20verk :prefLabel "Abridgements"@en .
+
+saogf:F%C3%B6rordningar :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026030> ;
+  :prefLabel "Administrative regulations"@en .
+
+saogf:F%C3%B6rteckningar :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026166> ;
+  :prefLabel "Registers (Lists)"@en .
+
+saogf:FAQ%3Aer :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026101> ;
+  :prefLabel "FAQs"@en .
+
+saogf:Fabler :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026327> ;
+  :prefLabel "Fables"@en .
+
+saogf:Fakeb%C3%B6cker%20%28musik%29 :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026798> ;
+  :prefLabel "Fakebooks (Music)"@en .
+
+saogf:Faksimiler :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026099> ;
+  :prefLabel "Facsimiles"@en .
+
+saogf:Fallstudier :closeMatch <http://id.loc.gov/authorities/genreForms/gf2017026140> ;
+  :prefLabel "Case studies"@en .
+
+saogf:Familjeskildringar :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026295> ;
+  :prefLabel "Domestic fiction"@en .
+
+saogf:Fanfiction :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026330> ;
+  :prefLabel "Fan fiction"@en .
+
+saogf:Fantasy :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026333> ;
+  :prefLabel "Fantasy fiction"@en .
+
+saogf:Fantasyfilmer :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026242> ;
+  :prefLabel "Fantasy films"@en .
+
+saogf:Fanziner :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026210> ;
+  :prefLabel "Zines"@en .
+
+saogf:Farmakope%C3%A9r :closeMatch <http://id.loc.gov/authorities/genreForms/gf2017026039> ;
+  :prefLabel "Pharmacopoeias"@en .
+
+saogf:Festskrifter :closeMatch <http://id.loc.gov/authorities/genreForms/gf2016026082> ;
+  :prefLabel "Festschriften"@en .
+
+saogf:Fiktiva%20filmer :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026250> ;
+  :prefLabel "Fiction films"@en .
+
+saogf:Film-%20och%20tv-bearbetningar :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026254> ;
+  :prefLabel "Film adaptations"@en .
+
+saogf:Filmad%20st%C3%A5uppkomik :prefLabel "Filmed stand-up comedy routines"@en .
+
+saogf:Filmade%20dansf%C3%B6rest%C3%A4llningar :prefLabel "Filmed dance"@en .
+
+saogf:Filmade%20intervjuer :prefLabel "Filmed interviews"@en .
+
+saogf:Filmade%20konserter :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026161> ;
+  :prefLabel "Concert films"@en .
+
+saogf:Filmade%20teaterf%C3%B6rest%C3%A4llningar :prefLabel "Filmed plays"@en .
+
+saogf:Filmer :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026406> ;
+  :prefLabel "Motion pictures"@en .
+
+saogf:Filmmanus :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026533> ;
+  :prefLabel "Screenplays"@en .
+
+saogf:Filmografi :closeMatch <http://id.loc.gov/authorities/genreForms/gf2019026014> ;
+  :prefLabel "Filmographies"@en .
+
+saogf:Filmprogram :prefLabel "Film festival programs"@en .
+
+saogf:Filmrecensioner :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026129> ;
+  :prefLabel "Motion picture reviews"@en .
+
+saogf:Flamenco%20%28musik%29 :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026806> ;
+  :prefLabel "Flamenco music"@en .
+
+saogf:Folkdiktning :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026342> ;
+  :prefLabel "Folk literature"@en .
+
+saogf:Folkrock :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026810> ;
+  :prefLabel "Folk-rock music"@en .
+
+saogf:Folksagor :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026344> ;
+  :prefLabel "Folk tales"@en .
+
+saogf:Fortbildningsmaterial :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026069> ;
+  :prefLabel "Continuing education materials"@en .
+
+saogf:Fotob%C3%B6cker :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026144> ;
+  :prefLabel "Photobooks"@en .
+
+saogf:Fotografier :closeMatch <http://id.loc.gov/authorities/genreForms/gf2017027249> ;
+  :prefLabel "Photographs"@en .
+
+saogf:Funk%20%28musik%29 :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026823> ;
+  :prefLabel "Funk (Music)"@en .
+
+saogf:Fusion%20%28musik%29 :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026880> ;
+  :prefLabel "Jazz-rock (Music)"@en .
+
+saogf:G%C3%A5tor :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026169> ;
+  :prefLabel "Riddles"@en .
+
+saogf:Genealogiskt%20material :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026106> ;
+  :prefLabel "Genealogical tables"@en .
+
+saogf:Gospel :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026839> ;
+  :prefLabel "Gospel music"@en .
+
+saogf:Gotiska%20ber%C3%A4ttelser :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026360> ;
+  :prefLabel "Gothic fiction"@en .
+
+saogf:Grunge :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026844> ;
+  :prefLabel "Grunge music"@en .
+
+saogf:Guideb%C3%B6cker :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026108> ;
+  :prefLabel "Guidebooks"@en .
+
+saogf:Gula%20sidorna :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026209> ;
+  :prefLabel "Yellow pages"@en .
+
+saogf:H%C3%A4rledda%20verk :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026084> ;
+  :prefLabel "Derivative works"@en .
+
+saogf:H%C3%A5rdrock :closeMatch <http://id.loc.gov/authorities/genreForms/gf2023026068> ;
+  :prefLabel "Hard rock music"@en .
+
+saogf:Habanera :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026848> ;
+  :prefLabel "Habaneras (Music)"@en .
+
+saogf:Haiku-dikter :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026366> ;
+  :prefLabel "Haiku"@en .
+
+saogf:Handb%C3%B6cker%2C%20manualer%20etc\. :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026109> ;
+  :prefLabel "Handbooks and manuals"@en .
+
+saogf:Handlingar%20%28dokument%29 :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026163> ;
+  :prefLabel "Records (Documents)"@en .
+
+saogf:Handlingar%20och%20intriger :prefLabel "Plot summeries"@en .
+
+saogf:Hardcore :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026850> ;
+  :prefLabel "Hardcore (Music)"@en .
+
+saogf:Heavy%20metal :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026854> ;
+  :prefLabel "Heavy metal (Music)"@en .
+
+saogf:Herdabrev :closeMatch <http://id.loc.gov/authorities/genreForms/gf2015026047> ;
+  :prefLabel "Pastoral letters and charges"@en .
+
+saogf:Highlife :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026858> ;
+  :prefLabel "Highlife (Music)"@en .
+
+saogf:Hiphop%20%28musik%29 :closeMatch <http://id.loc.gov/authorities/genreForms/gf2017026156> ;
+  :prefLabel "Hip-hop (Music)"@en .
+
+saogf:Historiska%20filmer :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026311> ;
+  :prefLabel "Historical films"@en .
+
+saogf:Historiska%20skildringar :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026370> ;
+  :prefLabel "Historical fiction"@en .
+
+saogf:Hj%C3%A4ltediktning :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026310> ;
+  :prefLabel "Epic poetry"@en .
+
+saogf:Homoerotiska%20skildringar :prefLabel "Gay erotic fiction"@en .
+
+saogf:House%20%28musik%29 :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026865> ;
+  :prefLabel "House music"@en .
+
+saogf:Humor :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026110> ;
+  :prefLabel "Humor"@en .
+
+saogf:Humoristiska%20skildringar :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026377> ;
+  :prefLabel "Humorous fiction"@en .
+
+saogf:Humorprogram%20p%C3%A5%20tv :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026654> ;
+  :prefLabel "Television comedies"@en .
+
+saogf:Hyllningsdikter :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026403> ;
+  :prefLabel "Laudatory poetry"@en .
+
+saogf:Hyllningstal :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026095> ;
+  :prefLabel "Eulogies"@en .
+
+saogf:Icke-fiktiva%20filmer :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026423> ;
+  :prefLabel "Nonfiction films"@en .
+
+saogf:Icke-fiktiva%20serier :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026453> ;
+  :prefLabel "Nonfiction comics"@en .
+
+saogf:Illustrerade%20verk :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026111> ;
+  :prefLabel "Illustrated works"@en .
+
+saogf:Industrimusik :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026874> ;
+  :prefLabel "Industrial music"@en .
+
+saogf:Informationsfilmer :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026219> ;
+  :prefLabel "Educational films"@en .
+
+saogf:Informativa%20verk :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026113> ;
+  :prefLabel "Informational works"@en .
+
+saogf:Instruktions-%20och%20undervisningsmaterial :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026114> ;
+  :prefLabel "Instructional and educational works"@en .
+
+saogf:Instruktionsfilmer :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026333> ;
+  :prefLabel "Instructional films"@en .
+
+saogf:Intervjuer :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026115> ;
+  :prefLabel "Interviews"@en .
+
+saogf:Jaktskildringar :closeMatch <http://id.loc.gov/authorities/genreForms/gf2017026141> ;
+  :prefLabel "Hunting fiction"@en .
+
+saogf:Jazz :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026879> ;
+  :prefLabel "Jazz"@en .
+
+saogf:Jojk :closeMatch <http://id.loc.gov/authorities/genreForms/gf2017026024> ;
+  :prefLabel "Yoiks"@en .
+
+saogf:Journalfilmer :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026420> ;
+  :prefLabel "Newsreels"@en .
+
+saogf:Juridiskt%20material :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026351> ;
+  :prefLabel "Law materials"@en .
+
+saogf:K%C3%A4rleksskildringar :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026516> ;
+  :prefLabel "Romance fiction"@en .
+
+saogf:Kalendrar :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026055> ;
+  :prefLabel "Calendars"@en .
+
+saogf:Karikatyrer%20och%20sk%C3%A4mtteckningar :closeMatch <http://id.loc.gov/authorities/genreForms/gf2017027224> ,
+    <http://id.loc.gov/authorities/genreForms/gf2017027225> ;
+  :prefLabel "Caricatures"@en ,
+    "Cartoons (Humor)"@en .
+
+saogf:Kartb%C3%B6cker :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026058> ;
+  :prefLabel "Atlases"@en .
+
+saogf:Kartglober :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026300> ;
+  :prefLabel "Globes"@en .
+
+saogf:Kartografiskt%20material :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026113> ;
+  :prefLabel "Cartographic materials"@en .
+
+saogf:Kartor :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026387> ;
+  :prefLabel "Maps"@en .
+
+saogf:Kataloger :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026057> ;
+  :prefLabel "Catalogs"@en .
+
+saogf:Katekeser :closeMatch <http://id.loc.gov/authorities/genreForms/gf2015026029> ;
+  :prefLabel "Catechisms"@en .
+
+saogf:Keltisk%20musik :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026697> ;
+  :prefLabel "Celtic music"@en .
+
+saogf:Klezmer :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026896> ;
+  :prefLabel "Klezmer music"@en .
+
+saogf:Kokb%C3%B6cker :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026169> ;
+  :prefLabel "Cookbooks"@en .
+
+saogf:Komedier%20%28film%29 :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026147> ;
+  :prefLabel "Comedy films"@en .
+
+saogf:Konferenser :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026068> ;
+  :prefLabel "Conference papers and proceedings"@en .
+
+saogf:Konferensmaterial :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026067> ;
+  :prefLabel "Conference materials"@en .
+
+saogf:Konkordanser :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026066> ;
+  :prefLabel "Concordances"@en .
+
+saogf:Konkret%20poesi :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026270> ;
+  :prefLabel "Concrete poetry"@en .
+
+saogf:Konsertprogram :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026065> ;
+  :prefLabel "Concert programs"@en .
+
+saogf:Konstsagor :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026329> ;
+  :prefLabel "Fairy tales"@en .
+
+saogf:Kontrafaktisk%20historia :prefLabel "Alternative histories (fiction)"@en .
+
+saogf:Kontrollerade%20vokabul%C3%A4rer :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026070> ;
+  :prefLabel "Controlled vocabularies"@en .
+
+saogf:Konverteringstabeller :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026071> ;
+  :prefLabel "Conversion tables"@en .
+
+saogf:Koraler :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026713> ;
+  :prefLabel "Chorales"@en .
+
+saogf:Korsord :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026075> ;
+  :prefLabel "Crossword puzzles"@en .
+
+saogf:Kortfilmer :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026570> ;
+  :prefLabel "Short films"@en .
+
+saogf:Kortprosa :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026543> ;
+  :prefLabel "Flash fiction"@en .
+
+saogf:Kortromaner :closeMatch <http://id.loc.gov/authorities/genreForms/gf2015026019> ;
+  :prefLabel "Novellas"@en .
+
+saogf:Krautrock :closeMatch <http://id.loc.gov/authorities/genreForms/gf2015026098> ;
+  :prefLabel "Krautrock (Music)"@en .
+
+saogf:Krigsfilmer :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026729> ;
+  :prefLabel "War films"@en .
+
+saogf:Krigsskildringar :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026590> ;
+  :prefLabel "War fiction"@en .
+
+saogf:Kriminalfilmer :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026177> ;
+  :prefLabel "Crime films"@en .
+
+saogf:Kronologier :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026062> ;
+  :prefLabel "Chronologies"@en .
+
+saogf:Kryptogram :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026077> ;
+  :prefLabel "Cryptograms"@en .
+
+saogf:Kursmaterial :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026073> ;
+  :prefLabel "Course materials"@en .
+
+saogf:Kyrkohandb%C3%B6cker :closeMatch <http://id.loc.gov/authorities/genreForms/gf2015026039> ;
+  :prefLabel "Liturgical books"@en .
+
+saogf:L%C3%A4rarhandledningar :prefLabel "Teachers’ guides"@en .
+
+saogf:L%C3%A4romedel :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026191> ;
+  :prefLabel "Textbooks"@en .
+
+saogf:L%C3%A4seb%C3%B6cker :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026160> ;
+  :prefLabel "Readers (Publications)"@en .
+
+saogf:L%C3%A5ngfilmer :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026247> ;
+  :prefLabel "Feature films"@en .
+
+saogf:Laboratoriehandb%C3%B6cker :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026120> ;
+  :prefLabel "Laboratory manuals"@en .
+
+saogf:Lagkommentarer :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026150> ;
+  :prefLabel "Law commentaries"@en .
+
+saogf:Lantm%C3%A4terihandlingar :prefLabel "Land surveys"@en .
+
+saogf:Legender :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026407> ;
+  :prefLabel "Legends"@en .
+
+saogf:Lexikon :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026086> ;
+  :prefLabel "Dictionaries"@en .
+
+saogf:Litter%C3%A4r%20sakprosa :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026074> ;
+  :prefLabel "Creative nonfiction"@en .
+
+saogf:Ljudb%C3%B6cker :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026063> ;
+  :prefLabel "Audiobooks"@en .
+
+saogf:Ljudbearbetningar :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026484> ;
+  :prefLabel "Radio adaptations"@en .
+
+saogf:Logiska%20pussel :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026124> ;
+  :prefLabel "Logic puzzles"@en .
+
+saogf:M%C3%A5larb%C3%B6cker :closeMatch <http://id.loc.gov/authorities/genreForms/gf2017026082> ;
+  :prefLabel "Coloring books"@en .
+
+saogf:Magisk%20realism :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026424> ;
+  :prefLabel "Magic realist fiction"@en .
+
+saogf:Mambo :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026920> ;
+  :prefLabel "Mambos (Music)"@en .
+
+saogf:Manga :closeMatch <http://id.loc.gov/authorities/genreForms/gf2022026036> ;
+  :prefLabel "Manga"@en .
+
+saogf:Matprogram%20p%C3%A5%20tv :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026656> ;
+  :prefLabel "Television cooking shows"@en .
+
+saogf:Matsedlar :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026127> ;
+  :prefLabel "Menus"@en .
+
+saogf:Mekaniska%20b%C3%B6cker :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026197> ;
+  :prefLabel "Toy and movable books"@en .
+
+saogf:Merengue :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026933> ;
+  :prefLabel "Merengues (Music)"@en .
+
+saogf:Miniatyrb%C3%B6cker :prefLabel "Miniature books—Specimens"@en .
+
+saogf:Minnesbevarande%20verk :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026064> ;
+  :prefLabel "Commemorative works"@en .
+
+saogf:Musikfilmer :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026414> ;
+  :prefLabel "Musical films"@en .
+
+saogf:Musikrecensioner :prefLabel "Music reviews"@en .
+
+saogf:Musikvideor :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026413> ;
+  :prefLabel "Music videos"@en .
+
+saogf:Naturfilmer :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026416> ;
+  :prefLabel "Nature films"@en .
+
+saogf:Nekrologer :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026134> ;
+  :prefLabel "Obituaries"@en .
+
+saogf:New%20age%20%28musik%29 :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026962> ;
+  :prefLabel "New Age music"@en .
+
+saogf:Noise%20%28musik%29 :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026967> ;
+  :prefLabel "Noise music"@en .
+
+saogf:Noveller :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026542> ;
+  :prefLabel "Short stories"@en .
+
+saogf:Nu%20jazz :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026971> ;
+  :prefLabel "Nu jazz"@en .
+
+saogf:Nyckelromaner :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026518> ;
+  :prefLabel "Romans à clef"@en .
+
+saogf:Nyhetsbrev :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026131> ;
+  :prefLabel "Newsletters"@en .
+
+saogf:Operaprogram :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026135> ;
+  :prefLabel "Opera programs"@en .
+
+saogf:Ordspr%C3%A5k%20och%20tales%C3%A4tt :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026170> ;
+  :prefLabel "Sayings"@en .
+
+saogf:Palindromer :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026137> ;
+  :prefLabel "Palindromes"@en .
+
+saogf:Pamfletter :closeMatch <http://id.loc.gov/authorities/genreForms/gf2015026053> ;
+  :prefLabel "Tracts (Ephemera)"@en .
+
+saogf:Parl%C3%B6rer :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026145> ;
+  :prefLabel "Phrase books"@en .
+
+saogf:Parodier :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026470> ;
+  :prefLabel "Parodies (Literature)"@en .
+
+saogf:Partimenti :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026985> ;
+  :prefLabel "Partimenti"@en .
+
+saogf:Passagerarlistor :prefLabel "Passanger lists"@en .
+
+saogf:Patent :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026438> ;
+  :prefLabel "Patents"@en .
+
+saogf:Periodika :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026139> ;
+  :prefLabel "Periodicals"@en .
+
+saogf:Personlig%20utveckling :closeMatch <http://id.loc.gov/authorities/genreForms/gf2016026102> ;
+  :prefLabel "Self-help publications"@en .
+
+saogf:Personliga%20ber%C3%A4ttelser :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026142> ;
+  :prefLabel "Personal narratives"@en .
+
+saogf:Pikareskromaner :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026479> ,
+    <http://id.loc.gov/authorities/genreForms/gf2015026020> ;
+  :prefLabel "Picaresque fiction"@en ,
+    "Novels"@en .
+
+saogf:Poesi :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026481> ;
+  :prefLabel "Poetry"@en .
+
+saogf:Politiska%20skildringar :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026482> ;
+  :prefLabel "Political fiction"@en .
+
+saogf:Pop :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014027009> ;
+  :prefLabel "Popular music"@en .
+
+saogf:Pop-up-b%C3%B6cker :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026150> ;
+  :prefLabel "Pop-up books"@en .
+
+saogf:Popul%C3%A4rmusik :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014027009> ;
+  :prefLabel "Popular music"@en .
+
+saogf:Pornografiska%20filmer :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026460> ;
+  :prefLabel "Pornographic films"@en .
+
+saogf:Pornografiska%20skildringar :closeMatch <http://id.loc.gov/authorities/genreForms/gf2019026139> ;
+  :prefLabel "Pornographic fiction"@en .
+
+saogf:Portr%C3%A4tt :closeMatch <http://id.loc.gov/authorities/genreForms/gf2017027254> ;
+  :prefLabel "Portraits"@en .
+
+saogf:Pressmeddelanden :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026153> ;
+  :prefLabel "Press releases"@en .
+
+saogf:Privatfilmer :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026038> ;
+  :prefLabel "Amateur films"@en .
+
+saogf:Problemsamlingar :prefLabel "Problems, exercises, etc."@en .
+
+saogf:Produktkataloger :prefLabel "Manufacturers' catalogs"@en .
+
+saogf:Program%20%28publikationer%29 :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026156> ;
+  :prefLabel "Programs (Publications)"@en .
+
+saogf:Progressiv%20rock :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014027018> ;
+  :prefLabel "Progressive rock (Music)"@en .
+
+saogf:Propagandafilmer :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026472> ;
+  :prefLabel "Propaganda films"@en .
+
+saogf:Prosadikter :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026488> ;
+  :prefLabel "Prose poems"@en .
+
+saogf:Protokoll :prefLabel "Minutes (records)"@en .
+
+saogf:Prov%20och%20examinationer :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026096> ;
+  :prefLabel "Examinations"@en .
+
+saogf:Psalmb%C3%B6cker :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026871> ;
+  :prefLabel "Hymnals"@en .
+
+saogf:Psalmer%20%28musik%29 :closeMatch <http://id.loc.gov/authorities/genreForms/gf2017026134> ;
+  :prefLabel "Hymn tunes"@en .
+
+saogf:Psaltarpsalmer%20%28musik%29 :prefLabel "Psalms (music)"@en .
+
+saogf:Psykedelia :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014027024> ;
+  :prefLabel "Psychedelic rock music"@en .
+
+saogf:Psykologiska%20skildringar :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026492> ;
+  :prefLabel "Psychological fiction"@en .
+
+saogf:Punkrock :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014027025> ;
+  :prefLabel "Punk rock music"@en .
+
+saogf:Punktskriftsb%C3%B6cker :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026053> ;
+  :prefLabel "Braille books"@en .
+
+saogf:Pussel :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026147> ;
+  :prefLabel "Picture puzzles"@en .
+
+saogf:R%26B%20%28musik%29 :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014027052> ;
+  :prefLabel "Rhythm and blues music"@en .
+
+saogf:Radiobearbetningar :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026484> ;
+  :prefLabel "Radio adaptations"@en .
+
+saogf:Radioprogram :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026506> ;
+  :prefLabel "Radio programs"@en .
+
+saogf:Radioteater :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026499> ;
+  :prefLabel "Radio plays"@en .
+
+saogf:Ragtime :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014027034> ;
+  :prefLabel "Ragtime music"@en .
+
+saogf:Ramber%C3%A4ttelser :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026347> ;
+  :prefLabel "Frame stories"@en .
+
+saogf:Realism%20%28film%29 :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026589> ;
+  :prefLabel "Social problem films"@en .
+
+saogf:Reality-tv :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026522> ;
+  :prefLabel "Reality television programs"@en .
+
+saogf:Rebusar :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026161> ;
+  :prefLabel "Rebuses"@en .
+
+saogf:Recensioner :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026168> ;
+  :prefLabel "Reviews"@en .
+
+saogf:Recept :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026162> ;
+  :prefLabel "Recipes"@en .
+
+saogf:Referensverk :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026165> ;
+  :prefLabel "Reference works"@en .
+
+saogf:Reggae :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014027045> ;
+  :prefLabel "Reggae music"@en .
+
+saogf:Reggaet%C3%B3n :closeMatch <http://id.loc.gov/authorities/genreForms/gf2018026122> ;
+  :prefLabel "Reggaeton"@en .
+
+saogf:Reklamfilmer :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026470> ;
+  :prefLabel "Promotional films"@en .
+
+saogf:Religi%C3%B6sa%20filmer :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026526> ;
+  :prefLabel "Religious films"@en .
+
+saogf:Religi%C3%B6sa%20skildringar :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026502> ;
+  :prefLabel "Religious fiction"@en .
+
+saogf:Religi%C3%B6sa%20verk :closeMatch <http://id.loc.gov/authorities/genreForms/gf2015026026> ;
+  :prefLabel "Religious materials"@en .
+
+saogf:Reseskildringar :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026200> ;
+  :prefLabel "Travel writing"@en .
+
+saogf:Reseskildringar%20%28film%29 :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026704> ;
+  :prefLabel "Travelogues (Motion pictures)"@en .
+
+saogf:Responsorier :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014027049> ;
+  :prefLabel "Responses (Music)"@en .
+
+saogf:Revyer :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014027050> ;
+  :prefLabel "Revues"@en .
+
+saogf:Rhythm%20%26%20blues :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014027052> ;
+  :prefLabel "Rhythm and blues music"@en .
+
+saogf:Riddardiktning :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026517> ;
+  :prefLabel "Romances"@en .
+
+saogf:Risografier :closeMatch <http://id.loc.gov/authorities/genreForms/gf2021026034> ;
+  :prefLabel "Risographs"@en .
+
+saogf:Robinsonader :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026514> ;
+  :prefLabel "Robinsonades"@en .
+
+saogf:Rock :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014027054> ;
+  :prefLabel "Rock music"@en .
+
+saogf:Rock%27n%27roll :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014027054> ;
+  :prefLabel "Rock music"@en .
+
+saogf:Roliga%20historier :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026157> ;
+  :prefLabel "Puns"@en .
+
+saogf:Rollspel :closeMatch <http://id.loc.gov/authorities/genreForms/gf2020026012> ;
+  :prefLabel "Role-playing games"@en .
+
+saogf:Rollspel%20%28datorspel%29 :closeMatch <http://id.loc.gov/authorities/genreForms/gf2020026012> ;
+  :prefLabel "Role-playing games"@en .
+
+saogf:Romaner :closeMatch <http://id.loc.gov/authorities/genreForms/gf2015026020> ;
+  :prefLabel "Novels"@en .
+
+saogf:Romantik%20%28film%29 :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026543> ;
+  :prefLabel "Romance films"@en .
+
+saogf:Romantisk%20komedi%20%28film%29 :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026545> ;
+  :prefLabel "Romantic comedy films"@en .
+
+saogf:Rumba :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014027059> ;
+  :prefLabel "Rumbas (Music)"@en .
+
+saogf:Rymdopera :prefLabel "Space operas"@en .
+
+saogf:S%C3%B6khj%C3%A4lper :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026103> ;
+  :prefLabel "Finding aids"@en .
+
+saogf:Sagalitteratur :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026522> ;
+  :prefLabel "Sagas"@en .
+
+saogf:Sagor :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026329> ;
+  :prefLabel "Fairy tales"@en .
+
+saogf:Salsa :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014027066> ;
+  :prefLabel "Salsa (Music)"@en .
+
+saogf:Samba :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014027069> ;
+  :prefLabel "Sambas (Music)"@en .
+
+saogf:Samh%C3%A4llskritiska%20skildringar :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026482> ;
+  :prefLabel "Political fiction"@en .
+
+saogf:Samkataloger :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026205> ;
+  :prefLabel "Union catalogs"@en .
+
+saogf:Sammanfattningar :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026038> ;
+  :prefLabel "Abstracts"@en .
+
+saogf:Sanna%20%C3%A4ventyrsber%C3%A4ttelser :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026202> ;
+  :prefLabel "True adventure stories"@en .
+
+saogf:Sanna%20kriminalhistorier :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026203> ;
+  :prefLabel "True crime stories"@en .
+
+saogf:Satir :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026525> ;
+  :prefLabel "Satirical literature"@en .
+
+saogf:Science%20fiction :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026529> ;
+  :prefLabel "Science fiction"@en .
+
+saogf:Science%20fiction-filmer :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026556> ;
+  :prefLabel "Science fiction films"@en .
+
+saogf:Scrapbooks :prefLabel "Scrapbooks"@en .
+
+saogf:Screentryck :closeMatch <http://id.loc.gov/authorities/genreForms/gf2017027258> ;
+  :prefLabel "Screen prints"@en .
+
+saogf:Sedeskildringar :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026536> ;
+  :prefLabel "Sentimental novels"@en .
+
+saogf:Seriella%20publikationer :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026174> ;
+  :prefLabel "Serial publications"@en .
+
+saogf:Serieromaner :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026362> ;
+  :prefLabel "Graphic novels"@en .
+
+saogf:Sj%C3%A4lvbiografier :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026047> ;
+  :prefLabel "Autobiographies"@en .
+
+saogf:Sj%C3%A4lvbiografiska%20skildringar :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026231> ;
+  :prefLabel "Autobiographical fiction"@en .
+
+saogf:Sj%C3%A4lvinstruerande%20material :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026155> ;
+  :prefLabel "Programmed instructional materials"@en .
+
+saogf:Sk%C3%B6nlitteratur :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026415> ;
+  :prefLabel "Literature"@en .
+
+saogf:Ska :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014027095> ;
+  :prefLabel "Ska (Music)"@en .
+
+saogf:Skr%C3%A4ck :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026373> ;
+  :prefLabel "Horror fiction"@en .
+
+saogf:Skr%C3%A4ckfilmer :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026321> ;
+  :prefLabel "Horror films"@en .
+
+saogf:Skr%C3%B6nor :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026565> ;
+  :prefLabel "Tall tales"@en .
+
+saogf:Sl%C3%A4ktber%C3%A4ttelser :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026100> ;
+  :prefLabel "Family histories"@en .
+
+saogf:Soca :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014027098> ;
+  :prefLabel "Soca (Music)"@en .
+
+saogf:Sonetter :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026549> ;
+  :prefLabel "Sonnets"@en .
+
+saogf:Soul%20%28musik%29 :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014027106> ;
+  :prefLabel "Soul music"@en .
+
+saogf:Sp%C3%B6khistorier :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026357> ;
+  :prefLabel "Ghost stories"@en .
+
+saogf:Spel%20och%20tanken%C3%B6tter :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026158> ;
+  :prefLabel "Puzzles and games"@en .
+
+saogf:Spirituals :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014027110> ;
+  :prefLabel "Spirituals (Songs)"@en .
+
+saogf:Sportfilmer :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026601> ;
+  :prefLabel "Sports films"@en .
+
+saogf:Sportprogram%20%28text%29 :prefLabel "Sports programs"@en .
+
+saogf:St%C3%A5uppkomik :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026180> ;
+  :prefLabel "Stand-up comedy routines"@en .
+
+saogf:Stadgar :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026104> ;
+  :prefLabel "By-laws"@en .
+
+saogf:Statistik :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026181> ;
+  :prefLabel "Statistics"@en .
+
+saogf:Steampunk :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026558> ;
+  :prefLabel "Steampunk fiction"@en .
+
+saogf:Stilmanualer :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026183> ;
+  :prefLabel "Style manuals"@en .
+
+saogf:Studiehandledningar :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026182> ;
+  :prefLabel "Study guides"@en .
+
+saogf:Stumfilmer :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026575> ;
+  :prefLabel "Silent films"@en .
+
+saogf:Sudokun :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026184> ;
+  :prefLabel "Sudoku puzzles"@en .
+
+saogf:Swing%20%26%20sweet :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014027119> ;
+  :prefLabel "Swing (Music)"@en .
+
+saogf:Synonymlexikon :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026195> ;
+  :prefLabel "Thesauri (Dictionaries)"@en .
+
+saogf:Syntpop :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014027122> ;
+  :prefLabel "Synthpop (Music)"@en .
+
+saogf:Tabeller :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026186> ;
+  :prefLabel "Tables (Data)"@en .
+
+saogf:Taktila%20verk :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026187> ;
+  :prefLabel "Tactile works"@en .
+
+saogf:Tal%20%28retorik%29 :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026363> ,
+    <http://id.loc.gov/authorities/genreForms/gf2014026196> ;
+  :prefLabel "Speeches"@en ,
+    "Toasts (Speeches)"@en .
+
+saogf:Talb%C3%B6cker :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026630> ;
+  :prefLabel "Talking books"@en .
+
+saogf:Tango :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014027127> ;
+  :prefLabel "Tangos (Music)"@en .
+
+saogf:Teaterprogram :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026193> ;
+  :prefLabel "Theater programs"@en .
+
+saogf:Teaterrecensioner :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026194> ;
+  :prefLabel "Theater reviews"@en .
+
+saogf:Techno :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014027130> ;
+  :prefLabel "Techno (Music)"@en .
+
+saogf:Tecknade%20serier :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026266> ;
+  :prefLabel "Comics (Graphic works)"@en .
+
+saogf:Teckningar :closeMatch <http://id.loc.gov/authorities/genreForms/gf2017027231> ;
+  :prefLabel "Drawings"@en .
+
+saogf:Telefonkataloger :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026189> ;
+  :prefLabel "Telephone directories"@en .
+
+saogf:Thrash%20metal :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014027138> ;
+  :prefLabel "Thrash metal (Music)"@en .
+
+saogf:Thrillers :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026571> ;
+  :prefLabel "Thrillers (Fiction)"@en .
+
+saogf:Thrillers%20%28film%29 :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026692> ;
+  :prefLabel "Thrillers (Motion pictures)"@en .
+
+saogf:Tidsf%C3%B6rdriv :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026164> ;
+  :prefLabel "Recreational works"@en .
+
+saogf:Tillf%C3%A4llespoesi :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026460> ;
+  :prefLabel "Occasional verse"@en .
+
+saogf:Tradjazz :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014027142> ;
+  :prefLabel "Trad jazz"@en .
+
+saogf:Tragedier%20%28dramatik%29 :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026576> ;
+  :prefLabel "Tragedies (Drama)"@en .
+
+saogf:Tragikomedier :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026577> ;
+  :prefLabel "Tragicomedies"@en .
+
+saogf:Trailrar :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026263> ;
+  :prefLabel "Film trailers"@en .
+
+saogf:Trip-hop :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014027146> ;
+  :prefLabel "Trip-hop (Music)"@en .
+
+saogf:Trivia%20och%20varia :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026201> ;
+  :prefLabel "Trivia and miscellanea"@en .
+
+saogf:Trycksaker :closeMatch <http://id.loc.gov/authorities/genreForms/gf2017027255> ;
+  :prefLabel "Prints"@en .
+
+saogf:Tv-program :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026673> ;
+  :prefLabel "Television programs"@en .
+
+saogf:Tv-recensioner :prefLabel "Television programs reviews"@en .
+
+saogf:Tv-serier :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026680> ;
+  :prefLabel "Television series"@en .
+
+saogf:UK%20garage :closeMatch <http://id.loc.gov/authorities/genreForms/gf2020026048> ;
+  :prefLabel "UK garage (Music)"@en .
+
+saogf:Unders%C3%B6kningar :prefLabel "Surveys"@en .
+
+saogf:Undervisningsfilmer :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026219> ;
+  :prefLabel "Educational films"@en .
+
+saogf:Urklipp :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026097> ;
+  :prefLabel "Excerpts"@en .
+
+saogf:Utkast%20och%20sammandrag :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026136> ;
+  :prefLabel "Outlines and syllabi"@en .
+
+saogf:Utopier :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026583> ;
+  :prefLabel "Utopian fiction"@en .
+
+saogf:Utst%C3%A4llningskataloger :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026098> ;
+  :prefLabel "Exhibition catalogs"@en .
+
+saogf:Utvecklingsromaner :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026243> ;
+  :prefLabel "Bildungsromans"@en .
+
+saogf:V%C3%A4sternskildringar :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026594> ;
+  :prefLabel "Western fiction"@en .
+
+saogf:Varum%C3%A4rkesf%C3%B6rteckningar :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026199> ;
+  :prefLabel "Trademark lists"@en .
+
+saogf:Verk%20med%20samtalsliknande%20karakt%C3%A4r :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026089> ;
+  :prefLabel "Discursive works"@en .
+
+saogf:Verkf%C3%B6rteckningar :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026058> ;
+  :prefLabel "Catalogues raisonnés"@en .
+
+saogf:Verksamhetsber%C3%A4ttelser :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026046> ;
+  :prefLabel "Annual reports"@en .
+
+saogf:Versber%C3%A4ttelser :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026559> ;
+  :prefLabel "Stories in rhyme"@en .
+
+saogf:Videokonst :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026722> ;
+  :prefLabel "Video installations (Art)"@en .
+
+saogf:Visuell%20poesi :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026588> ;
+  :prefLabel "Visual poetry"@en .
+
+saogf:Vykort :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026151> ;
+  :prefLabel "Postcards"@en .
+
+saogf:Westernfilmer :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026735> ;
+  :prefLabel "Western films"@en .
+
+saogf:Zydeco :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014027177> ;
+  :prefLabel "Zydeco music"@en .
+
+graph <#delete> {
+
+  saogf:%C3%84ventyrsfilmer :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Action and adventure films" ] .
+
+  saogf:%C3%84ventyrsskildringar :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Action and adventure fiction" ] .
+
+  saogf:%C3%85rsb%C3%B6cker :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Yearbooks" ] .
+
+  saogf:Actionfilmer :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Action and adventure films" ] .
+
+  saogf:Adresskalendrar :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Directories" ] .
+
+  saogf:Aff%C3%A4rskorrespondens :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Business correspondence" ] .
+
+  saogf:Afrobeat :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Afrobeat" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2015026088"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Allegorier :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Allegories" ] .
+
+  saogf:Almanackor :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Almanacs" ] .
+
+  saogf:Ambient%20musik :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Ambient music (Electronica)" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014027185"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Americana :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Alternative country music" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014026630"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Anagram :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Anagrams" ] .
+
+  saogf:Animerade%20filmer :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Animated films" ] .
+
+  saogf:Annaler%20och%20kr%C3%B6nikor :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Annals and chronicals" ] .
+
+  saogf:Anteckningar :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Notebooks" ] .
+
+  saogf:Apokalyptiska%20skildringar :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Apocalyptic fiction" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014026226"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Apologetiska%20verk :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Apologetic writings" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2015026027"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Arbetsbeskrivningar :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Job descriptions" ] .
+
+  saogf:Artists%27%20books :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Artists' books" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2017027220"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Artursagan :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Arthurian romances" ] .
+
+  saogf:Automatisk%20skrift :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Spirit writings" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2015026052"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Avhandlingar :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Academic theses" ] .
+
+  saogf:Avlatsbrev :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Indulgences (Canon law)" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2011026328"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:B%C3%B6cker%20med%20ljudeffekter :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Sound books" ] .
+
+  saogf:Bakl%C3%A4ngeslexikon :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Reverse indexes" ] .
+
+  saogf:Barn-%20och%20familjefilmer :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Children's films" ] .
+
+  saogf:Bearbetningar :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Adaptations" ] .
+
+  saogf:Bebop :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Bop (Music)" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014026670"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Befolkningsstatistik :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Vital statistics" ] .
+
+  saogf:Begravningar%20%28program%29 :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Memorial service programs" ] .
+
+  saogf:Begravningsdikter :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Epicedia" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014026311"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Begravningsstatistik :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Death registers" ] .
+
+  saogf:Ber%C3%A4ttelser%20fr%C3%A5n%20f%C3%A5ngenskap :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Captivity narratives" ] .
+
+  saogf:Bibliografier :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Bibliographies" ] .
+
+  saogf:Bibliotekskataloger :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Library catalogs" ] .
+
+  saogf:Bibliska%20ber%C3%A4ttelser :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Bible fiction" ] ,
+      [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Bible stories" ] .
+
+  saogf:Bilder :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Pictures" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2017027251"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Bildlexikon :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Picture dictionaries" ] .
+
+  saogf:Biografier :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Biographies" ] .
+
+  saogf:Biografiska%20filmer :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Biographical films" ] .
+
+  saogf:Biografiska%20skildringar :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Biographical fiction" ] .
+
+  saogf:Black%20metal :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Black metal (Music)" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014026663"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Blanketter :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Blank forms" ] .
+
+  saogf:Bloggar :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Blogs" ] .
+
+  saogf:Bluegrass :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Bluegrass music" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014026664"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Blues :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Blues (Music)" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014026665"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Bluesrock :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Blues-rock music" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014026666"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Bokrecensioner :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Book reviews" ] .
+
+  saogf:Bolero%20%28musik%29 :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Boleros (Music)" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014026667"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Bossa%20nova :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Bossa nova (Music)" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014026671"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Br%C3%B6llopsdikter :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Epithalamia" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014026317"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Brevromaner :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Epistolary fiction" ] ,
+      [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Novels" ] .
+
+  saogf:Burlesker :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Burlesques (Literature)" ] .
+
+  saogf:Cajun%20%28musik%29 :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Cajun music" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014026679"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Calypso :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Calypso (Music)" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014026680"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Census%20%28statistik%29 :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Census data" ] .
+
+  saogf:Cha-cha :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Cha-chas (Music)" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014026702"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Charader :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Charades" ] .
+
+  saogf:Citat :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Quotations" ] .
+
+  saogf:Cool%20jazz :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Cool jazz" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014026730"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Countrymusik :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Country music" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014026739"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Countryrock :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Country rock music" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014026740"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Cumbia :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Cumbia (Music)" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014026749"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Cyberpunk :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Cyberpunk fiction" ] .
+
+  saogf:D%C3%B6dsfallsregister :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Death registers" ] .
+
+  saogf:Dagb%C3%B6cker :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Diaries" ] .
+
+  saogf:Dagboksromaner :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Novels" ] ,
+      [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Diary fiction" ] .
+
+  saogf:Dagstidningar :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Newspapers" ] .
+
+  saogf:Dancehall :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Dancehall (Music)" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014026754"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Dansrecensioner :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Dance reviews" ] .
+
+  saogf:Databaser :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Databases" ] .
+
+  saogf:Datorspelsmusik :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Computer and video game music" ;
+        :uri "https://id.loc.gov/authorities/genreForms/gf2016026066.html"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Death%20metal :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Death metal (Music)" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014026761"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Debatter :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Debates" ] .
+
+  saogf:Deckare :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Detective and mystery fiction" ] ,
+      [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Noir fiction" ] .
+
+  saogf:Diagram :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Graphs" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014026061"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Dialektlitteratur :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Dialect fiction" ] .
+
+  saogf:Disco%20%28musik%29 :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Disco (Music)" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014026768"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Diskografier :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Discographies" ] .
+
+  saogf:Dockfilmer :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Puppet films" ] .
+
+  saogf:Dokument%C3%A4ra%20skildringar :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Nonfiction novels" ] .
+
+  saogf:Dokument%C3%A4rfilmer :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Documentary films" ] .
+
+  saogf:Doom%20metal :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Doom metal (Music)" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014026774"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Dramatik :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Drama" ] .
+
+  saogf:Dramatisk%20och%20scenisk%20musik :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Dramatic music" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014026775"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Drum%20%27n%27%20bass%20%28jungle%29 :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Jungle (Music)" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014026887"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Dub :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Dub (Music)" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014026778"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Dubstep :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Dubstep (Music)" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014026779"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Dystopier :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Dystopian fiction" ] .
+
+  saogf:Dystopiska%20filmer :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Dystopian films" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2011026217"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Efem%C3%A4rt%20material :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Ephemera" ] .
+
+  saogf:Electronic%20body%20music :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Industrial dance music" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2017026062"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Electronica :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Electronica (Music)" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014026783"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Elektronisk%20popul%C3%A4rmusik :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Electronica (Music)" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014026783"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Emblemb%C3%B6cker :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Emblem books" ] .
+
+  saogf:Encyklopedier :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Encyclopedias" ] .
+
+  saogf:Episka%20skildringar :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Epic fiction" ] .
+
+  saogf:Erotiska%20skildringar :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Erotic fiction" ] .
+
+  saogf:Ess%C3%A4er :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Essays" ] .
+
+  saogf:Etnografiska%20filmer :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Ethnographic films" ] .
+
+  saogf:Evighetskalendrar :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Perpetual calendars" ] .
+
+  saogf:Examenstidningar :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "School yearbooks" ] .
+
+  saogf:Experimentell%20sk%C3%B6nlitteratur :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Experimental fiction" ] .
+
+  saogf:Experimentfilmer :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Experimental films" ] .
+
+  saogf:F%C3%B6ljetonger :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Serialized fiction" ] .
+
+  saogf:F%C3%B6rel%C3%A4sningar :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Lectures" ] .
+
+  saogf:F%C3%B6retagshandlingar%20%28dokument%29 :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Corporate resolutions" ] .
+
+  saogf:F%C3%B6rkortade%20verk :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Abridgements" ] .
+
+  saogf:F%C3%B6rordningar :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Administrative regulations" ] .
+
+  saogf:F%C3%B6rteckningar :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Registers (Lists)" ] .
+
+  saogf:FAQ%3Aer :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "FAQs" ] .
+
+  saogf:Fabler :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Fables" ] .
+
+  saogf:Fakeb%C3%B6cker%20%28musik%29 :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Fakebooks (Music)" ] .
+
+  saogf:Faksimiler :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Facsimiles" ] .
+
+  saogf:Fallstudier :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Case studies" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2017026140"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Familjeskildringar :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Domestic fiction" ] .
+
+  saogf:Fanfiction :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Fan fiction" ] .
+
+  saogf:Fantasy :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Fantasy fiction" ] .
+
+  saogf:Fantasyfilmer :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Fantasy films" ] .
+
+  saogf:Fanziner :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Zines" ] .
+
+  saogf:Farmakope%C3%A9r :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Pharmacopoeias" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2017026039"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Festskrifter :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Festschriften" ] .
+
+  saogf:Fiktiva%20filmer :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Fiction films" ] .
+
+  saogf:Film-%20och%20tv-bearbetningar :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Film adaptations" ] .
+
+  saogf:Filmad%20st%C3%A5uppkomik :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Filmed stand-up comedy routines" ] .
+
+  saogf:Filmade%20dansf%C3%B6rest%C3%A4llningar :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Filmed dance" ] .
+
+  saogf:Filmade%20intervjuer :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Filmed interviews" ] .
+
+  saogf:Filmade%20konserter :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Concert films" ] .
+
+  saogf:Filmade%20teaterf%C3%B6rest%C3%A4llningar :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Filmed plays" ] .
+
+  saogf:Filmer :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Motion pictures" ] .
+
+  saogf:Filmmanus :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Screenplays" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014026533"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Filmografi :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Filmographies" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2019026014"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Filmprogram :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Film festival programs" ] .
+
+  saogf:Filmrecensioner :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Motion picture reviews" ] .
+
+  saogf:Flamenco%20%28musik%29 :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Flamenco music" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014026806"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Folkdiktning :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Folk literature" ] .
+
+  saogf:Folkrock :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Folk-rock music" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014026810"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Folksagor :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Folk tales" ] .
+
+  saogf:Fortbildningsmaterial :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Continuing education materials" ] .
+
+  saogf:Fotob%C3%B6cker :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Photobooks" ] .
+
+  saogf:Fotografier :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Photographs" ] .
+
+  saogf:Funk%20%28musik%29 :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Funk (Music)" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014026823"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Fusion%20%28musik%29 :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Jazz-rock (Music)" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014026880"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:G%C3%A5tor :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Riddles" ] .
+
+  saogf:Genealogiskt%20material :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Genealogical tables" ] .
+
+  saogf:Gospel :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Gospel music" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014026839"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Gotiska%20ber%C3%A4ttelser :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Gothic fiction" ] .
+
+  saogf:Grunge :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Grunge music" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014026844"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Guideb%C3%B6cker :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Guidebooks" ] .
+
+  saogf:Gula%20sidorna :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Yellow pages" ] .
+
+  saogf:H%C3%A4rledda%20verk :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Derivative works" ] .
+
+  saogf:H%C3%A5rdrock :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Hard rock music" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2023026068"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Habanera :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Habaneras (Music)" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014026848"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Haiku-dikter :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Haiku" ] .
+
+  saogf:Handb%C3%B6cker%2C%20manualer%20etc\. :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Handbooks and manuals" ] .
+
+  saogf:Handlingar%20%28dokument%29 :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Records (Documents)" ] .
+
+  saogf:Handlingar%20och%20intriger :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Plot summeries" ] .
+
+  saogf:Hardcore :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Hardcore (Music)" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014026850"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Heavy%20metal :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Heavy metal (Music)" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014026854"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Herdabrev :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Pastoral letters and charges" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2015026047"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Highlife :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Highlife (Music)" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014026858"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Hiphop%20%28musik%29 :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Hip-hop (Music)" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2017026156"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Historiska%20filmer :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Historical films" ] .
+
+  saogf:Historiska%20skildringar :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Historical fiction" ] .
+
+  saogf:Hj%C3%A4ltediktning :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Epic poetry" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014026310"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Homoerotiska%20skildringar :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Gay erotic fiction" ] .
+
+  saogf:House%20%28musik%29 :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "House music" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014026865"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Humor :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Humor" ] .
+
+  saogf:Humoristiska%20skildringar :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Humorous fiction" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014026377"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Humorprogram%20p%C3%A5%20tv :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Television comedies" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2011026654"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Hyllningsdikter :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Laudatory poetry" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014026403"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Hyllningstal :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Eulogies" ] .
+
+  saogf:Icke-fiktiva%20filmer :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Nonfiction films" ] .
+
+  saogf:Icke-fiktiva%20serier :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Nonfiction comics" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014026453"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Illustrerade%20verk :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Illustrated works" ] .
+
+  saogf:Industrimusik :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Industrial music" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014026874"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Informationsfilmer :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Educational films" ] .
+
+  saogf:Informativa%20verk :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Informational works" ] .
+
+  saogf:Instruktions-%20och%20undervisningsmaterial :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Instructional and educational works" ] .
+
+  saogf:Instruktionsfilmer :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Instructional films" ] .
+
+  saogf:Intervjuer :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Interviews" ] .
+
+  saogf:Jaktskildringar :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Hunting fiction" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2017026141"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Jazz :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Jazz" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014026879"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Jojk :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Yoiks" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2017026024"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Journalfilmer :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Newsreels" ] .
+
+  saogf:Juridiskt%20material :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Law materials" ] .
+
+  saogf:K%C3%A4rleksskildringar :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Romance fiction" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014026516"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Kalendrar :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Calendars" ] .
+
+  saogf:Karikatyrer%20och%20sk%C3%A4mtteckningar :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Caricatures" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2017027224"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] ,
+      [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Cartoons (Humor)" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2017027225"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Kartb%C3%B6cker :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Atlases" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2011026058"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Kartglober :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Globes" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2011026300"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Kartografiskt%20material :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Cartographic materials" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2011026113"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Kartor :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Maps" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2011026387"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Kataloger :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Catalogs" ] .
+
+  saogf:Katekeser :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Catechisms" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2015026029"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Keltisk%20musik :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Celtic music" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014026697"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Klezmer :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Klezmer music" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014026896"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Kokb%C3%B6cker :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Cookbooks" ] .
+
+  saogf:Komedier%20%28film%29 :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Comedy films" ] .
+
+  saogf:Konferenser :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Conference papers and proceedings" ] .
+
+  saogf:Konferensmaterial :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Conference materials" ] .
+
+  saogf:Konkordanser :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Concordances" ] .
+
+  saogf:Konkret%20poesi :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Concrete poetry" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014026270"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Konsertprogram :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Concert programs" ] .
+
+  saogf:Konstsagor :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Fairy tales" ] .
+
+  saogf:Kontrafaktisk%20historia :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Alternative histories (fiction)" ] .
+
+  saogf:Kontrollerade%20vokabul%C3%A4rer :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Controlled vocabularies" ] .
+
+  saogf:Konverteringstabeller :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Conversion tables" ] .
+
+  saogf:Koraler :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Chorales" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014026713"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Korsord :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Crossword puzzles" ] .
+
+  saogf:Kortfilmer :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Short films" ] .
+
+  saogf:Kortprosa :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Flash fiction" ] .
+
+  saogf:Kortromaner :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Novellas" ] .
+
+  saogf:Krautrock :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Krautrock (Music)" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2015026098"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Krigsfilmer :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "War films" ] .
+
+  saogf:Krigsskildringar :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "War fiction" ] .
+
+  saogf:Kriminalfilmer :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Crime films" ] .
+
+  saogf:Kronologier :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Chronologies" ] .
+
+  saogf:Kryptogram :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Cryptograms" ] .
+
+  saogf:Kursmaterial :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Course materials" ] .
+
+  saogf:Kyrkohandb%C3%B6cker :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Liturgical books" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2015026039"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:L%C3%A4rarhandledningar :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Teachers’ guides" ] .
+
+  saogf:L%C3%A4romedel :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Textbooks" ] .
+
+  saogf:L%C3%A4seb%C3%B6cker :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Readers (Publications)" ] .
+
+  saogf:L%C3%A5ngfilmer :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Feature films" ] .
+
+  saogf:Laboratoriehandb%C3%B6cker :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Laboratory manuals" ] .
+
+  saogf:Lagkommentarer :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Law commentaries" ] .
+
+  saogf:Lantm%C3%A4terihandlingar :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Land surveys" ] .
+
+  saogf:Legender :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Legends" ] .
+
+  saogf:Lexikon :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Dictionaries" ] .
+
+  saogf:Litter%C3%A4r%20sakprosa :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Creative nonfiction" ] .
+
+  saogf:Ljudb%C3%B6cker :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Audiobooks" ] .
+
+  saogf:Ljudbearbetningar :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Radio adaptations" ] .
+
+  saogf:Logiska%20pussel :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Logic puzzles" ] .
+
+  saogf:M%C3%A5larb%C3%B6cker :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Coloring books" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2017026082"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Magisk%20realism :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Magic realist fiction" ] .
+
+  saogf:Mambo :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Mambos (Music)" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014026920"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Manga :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Manga" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2022026036"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Matprogram%20p%C3%A5%20tv :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Television cooking shows" ] .
+
+  saogf:Matsedlar :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Menus" ] .
+
+  saogf:Mekaniska%20b%C3%B6cker :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Toy and movable books" ] .
+
+  saogf:Merengue :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Merengues (Music)" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014026933"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Miniatyrb%C3%B6cker :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Miniature books—Specimens" ;
+        :uri "http://id.loc.gov/authorities/subjects/sh85085644"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Minnesbevarande%20verk :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Commemorative works" ] .
+
+  saogf:Musikfilmer :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Musical films" ] .
+
+  saogf:Musikrecensioner :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Music reviews" ] .
+
+  saogf:Musikvideor :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Music videos" ] .
+
+  saogf:Naturfilmer :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Nature films" ] .
+
+  saogf:Nekrologer :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Obituaries" ] .
+
+  saogf:New%20age%20%28musik%29 :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "New Age music" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014026962"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Noise%20%28musik%29 :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Noise music" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014026967"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Noveller :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Short stories" ] .
+
+  saogf:Nu%20jazz :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Nu jazz" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014026971"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Nyckelromaner :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Romans à clef" ] .
+
+  saogf:Nyhetsbrev :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Newsletters" ] .
+
+  saogf:Operaprogram :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Opera programs" ] .
+
+  saogf:Ordspr%C3%A5k%20och%20tales%C3%A4tt :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Sayings" ] .
+
+  saogf:Palindromer :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Palindromes" ] .
+
+  saogf:Pamfletter :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Tracts (Ephemera)" ] .
+
+  saogf:Parl%C3%B6rer :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Phrase books" ] .
+
+  saogf:Parodier :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Parodies (Literature)" ] .
+
+  saogf:Partimenti :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Partimenti" ;
+        :uri "http://id.loc.gov/authorities/subjects/sh2002002615"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Passagerarlistor :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Passanger lists" ] .
+
+  saogf:Patent :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Patents" ] .
+
+  saogf:Periodika :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Periodicals" ] .
+
+  saogf:Personlig%20utveckling :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Self-help publications" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2016026102"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Personliga%20ber%C3%A4ttelser :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Personal narratives" ] .
+
+  saogf:Pikareskromaner :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Picaresque fiction" ] ,
+      [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Novels" ] .
+
+  saogf:Poesi :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Poetry" ] .
+
+  saogf:Politiska%20skildringar :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Political fiction" ] .
+
+  saogf:Pop :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Popular music" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014027009"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Pop-up-b%C3%B6cker :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Pop-up books" ] .
+
+  saogf:Popul%C3%A4rmusik :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Popular music" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014027009"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Pornografiska%20filmer :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Pornographic films" ] .
+
+  saogf:Pornografiska%20skildringar :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Pornographic fiction" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2019026139"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Portr%C3%A4tt :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Portraits" ] .
+
+  saogf:Pressmeddelanden :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Press releases" ] .
+
+  saogf:Privatfilmer :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Amateur films" ] .
+
+  saogf:Problemsamlingar :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Problems, exercises, etc." ] .
+
+  saogf:Produktkataloger :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Manufacturers' catalogs" ] .
+
+  saogf:Program%20%28publikationer%29 :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Programs (Publications)" ] .
+
+  saogf:Progressiv%20rock :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Progressive rock (Music)" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014027018"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Propagandafilmer :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Propaganda films" ] .
+
+  saogf:Prosadikter :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Prose poems" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014026488"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Protokoll :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Minutes (records)" ] .
+
+  saogf:Prov%20och%20examinationer :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Examinations" ] .
+
+  saogf:Psalmb%C3%B6cker :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Hymnals" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014026871"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Psalmer%20%28musik%29 :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Hymn tunes" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2017026134"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Psaltarpsalmer%20%28musik%29 :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Psalms (music)" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014027023"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Psykedelia :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Psychedelic rock music" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014027024"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Psykologiska%20skildringar :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Psychological fiction" ] .
+
+  saogf:Punkrock :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Punk rock music" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014027025"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Punktskriftsb%C3%B6cker :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Braille books" ] .
+
+  saogf:Pussel :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Picture puzzles" ] .
+
+  saogf:R%26B%20%28musik%29 :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Rhythm and blues music" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014027052"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Radiobearbetningar :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Radio adaptations" ] .
+
+  saogf:Radioprogram :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Radio programs" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2011026506"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Radioteater :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Radio plays" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014026499"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Ragtime :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Ragtime music" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014027034"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Ramber%C3%A4ttelser :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Frame stories" ] .
+
+  saogf:Realism%20%28film%29 :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Social problem films" ] .
+
+  saogf:Reality-tv :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Reality television programs" ] .
+
+  saogf:Rebusar :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Rebuses" ] .
+
+  saogf:Recensioner :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Reviews" ] .
+
+  saogf:Recept :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Recipes" ] .
+
+  saogf:Referensverk :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Reference works" ] .
+
+  saogf:Reggae :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Reggae music" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014027045"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Reggaet%C3%B3n :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Reggaeton" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2018026122"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Reklamfilmer :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Promotional films" ] .
+
+  saogf:Religi%C3%B6sa%20filmer :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Religious films" ] .
+
+  saogf:Religi%C3%B6sa%20skildringar :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Religious fiction" ] .
+
+  saogf:Religi%C3%B6sa%20verk :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Religious materials" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2015026026"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Reseskildringar :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Travel writing" ] .
+
+  saogf:Reseskildringar%20%28film%29 :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Travelogues (Motion pictures)" ] .
+
+  saogf:Responsorier :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Responses (Music)" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014027049"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Revyer :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Revues" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014027050"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Rhythm%20%26%20blues :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Rhythm and blues music" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014027052"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Riddardiktning :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Romances" ] .
+
+  saogf:Risografier :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Risographs" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2021026034"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Robinsonader :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Robinsonades" ] .
+
+  saogf:Rock :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Rock music" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014027054"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Rock%27n%27roll :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Rock music" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014027054"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Roliga%20historier :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Puns" ] .
+
+  saogf:Rollspel :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Role-playing games" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2020026012"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Rollspel%20%28datorspel%29 :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Role-playing games" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2020026012"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Romaner :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Novels" ] .
+
+  saogf:Romantik%20%28film%29 :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Romance films" ] .
+
+  saogf:Romantisk%20komedi%20%28film%29 :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Romantic comedy films" ] .
+
+  saogf:Rumba :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Rumbas (Music)" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014027059"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Rymdopera :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Space operas" ] .
+
+  saogf:S%C3%B6khj%C3%A4lper :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Finding aids" ] .
+
+  saogf:Sagalitteratur :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Sagas" ] .
+
+  saogf:Sagor :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Fairy tales" ] .
+
+  saogf:Salsa :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Salsa (Music)" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014027066"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Samba :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Sambas (Music)" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014027069"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Samh%C3%A4llskritiska%20skildringar :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Political fiction" ] .
+
+  saogf:Samkataloger :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Union catalogs" ] .
+
+  saogf:Sammanfattningar :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Abstracts" ] .
+
+  saogf:Sanna%20%C3%A4ventyrsber%C3%A4ttelser :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "True adventure stories" ] .
+
+  saogf:Sanna%20kriminalhistorier :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "True crime stories" ] .
+
+  saogf:Satir :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Satirical literature" ] .
+
+  saogf:Science%20fiction :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Science fiction" ] .
+
+  saogf:Science%20fiction-filmer :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Science fiction films" ] .
+
+  saogf:Scrapbooks :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Scrapbooks" ] .
+
+  saogf:Screentryck :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Screen prints" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2017027258"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Sedeskildringar :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Sentimental novels" ] .
+
+  saogf:Seriella%20publikationer :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Serial publications" ] .
+
+  saogf:Serieromaner :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Graphic novels" ] .
+
+  saogf:Sj%C3%A4lvbiografier :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Autobiographies" ] .
+
+  saogf:Sj%C3%A4lvbiografiska%20skildringar :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Autobiographical fiction" ] .
+
+  saogf:Sj%C3%A4lvinstruerande%20material :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Programmed instructional materials" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014026155"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Sk%C3%B6nlitteratur :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Literature" ] .
+
+  saogf:Ska :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Ska (Music)" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014027095"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Skr%C3%A4ck :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Horror fiction" ] .
+
+  saogf:Skr%C3%A4ckfilmer :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Horror films" ] .
+
+  saogf:Skr%C3%B6nor :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Tall tales" ] .
+
+  saogf:Sl%C3%A4ktber%C3%A4ttelser :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Family histories" ] .
+
+  saogf:Soca :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Soca (Music)" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014027098"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Sonetter :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Sonnets" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014026549"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Soul%20%28musik%29 :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Soul music" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014027106"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Sp%C3%B6khistorier :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Ghost stories" ] .
+
+  saogf:Spel%20och%20tanken%C3%B6tter :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Puzzles and games" ] .
+
+  saogf:Spirituals :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Spirituals (Songs)" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014027110"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Sportfilmer :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Sports films" ] .
+
+  saogf:Sportprogram%20%28text%29 :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Sports programs" ] .
+
+  saogf:St%C3%A5uppkomik :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Stand-up comedy routines" ] .
+
+  saogf:Stadgar :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "By-laws" ] .
+
+  saogf:Statistik :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Statistics" ] .
+
+  saogf:Steampunk :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Steampunk fiction" ] .
+
+  saogf:Stilmanualer :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Style manuals" ] .
+
+  saogf:Studiehandledningar :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Study guides" ] .
+
+  saogf:Stumfilmer :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Silent films" ] .
+
+  saogf:Sudokun :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Sudoku puzzles" ] .
+
+  saogf:Swing%20%26%20sweet :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Swing (Music)" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014027119"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Synonymlexikon :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Thesauri (Dictionaries)" ] .
+
+  saogf:Syntpop :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Synthpop (Music)" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014027122"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Tabeller :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Tables (Data)" ] .
+
+  saogf:Taktila%20verk :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Tactile works" ] .
+
+  saogf:Tal%20%28retorik%29 :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Speeches" ] ,
+      [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Toasts (Speeches)" ] .
+
+  saogf:Talb%C3%B6cker :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Talking books" ] .
+
+  saogf:Tango :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Tangos (Music)" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014027127"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Teaterprogram :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Theater programs" ] .
+
+  saogf:Teaterrecensioner :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Theater reviews" ] .
+
+  saogf:Techno :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Techno (Music)" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014027130"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Tecknade%20serier :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Comics (Graphic works)" ] .
+
+  saogf:Teckningar :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Drawings" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2017027231"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Telefonkataloger :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Telephone directories" ] .
+
+  saogf:Thrash%20metal :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Thrash metal (Music)" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014027138"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Thrillers :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Thrillers (Fiction)" ] .
+
+  saogf:Thrillers%20%28film%29 :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Thrillers (Motion pictures)" ] .
+
+  saogf:Tidsf%C3%B6rdriv :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Recreational works" ] .
+
+  saogf:Tillf%C3%A4llespoesi :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Occasional verse" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014026460"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Tradjazz :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Trad jazz" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014027142"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Tragedier%20%28dramatik%29 :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Tragedies (Drama)" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014026576"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Tragikomedier :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Tragicomedies" ] .
+
+  saogf:Trailrar :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Film trailers" ] .
+
+  saogf:Trip-hop :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Trip-hop (Music)" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014027146"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Trivia%20och%20varia :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Trivia and miscellanea" ] .
+
+  saogf:Trycksaker :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Prints" ;
+        :uri "http://id.loc.gov/authorities/subjects/sh85106831"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Tv-program :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Television programs" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2011026673"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Tv-recensioner :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Television programs reviews" ] .
+
+  saogf:Tv-serier :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Television series" ] .
+
+  saogf:UK%20garage :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "UK garage (Music)" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2020026048"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Unders%C3%B6kningar :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Surveys" ] .
+
+  saogf:Undervisningsfilmer :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Educational films" ] .
+
+  saogf:Urklipp :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Excerpts" ] .
+
+  saogf:Utkast%20och%20sammandrag :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Outlines and syllabi" ] .
+
+  saogf:Utopier :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Utopian fiction" ] .
+
+  saogf:Utst%C3%A4llningskataloger :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Exhibition catalogs" ] .
+
+  saogf:Utvecklingsromaner :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Bildungsromans" ] .
+
+  saogf:V%C3%A4sternskildringar :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Western fiction" ] .
+
+  saogf:Varum%C3%A4rkesf%C3%B6rteckningar :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Trademark lists" ] .
+
+  saogf:Verk%20med%20samtalsliknande%20karakt%C3%A4r :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Discursive works" ] .
+
+  saogf:Verkf%C3%B6rteckningar :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Catalogues raisonnés" ] .
+
+  saogf:Verksamhetsber%C3%A4ttelser :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Annual reports" ] .
+
+  saogf:Versber%C3%A4ttelser :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Stories in rhyme" ] .
+
+  saogf:Videokonst :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Video installations (Art)" ] .
+
+  saogf:Visuell%20poesi :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Visual poetry" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014026588"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+  saogf:Vykort :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Postcards" ] .
+
+  saogf:Westernfilmer :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Western films" ] .
+
+  saogf:Zydeco :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Zydeco music" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2014027177"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+
+}

--- a/source/saogf/saogf-lcgft-patch.trig
+++ b/source/saogf/saogf-lcgft-patch.trig
@@ -1,18 +1,6 @@
 prefix : <https://id.kb.se/vocab/>
 prefix saogf: <https://id.kb.se/term/saogf/>
 
-## Saknar closeMatch - felstavning eller broadMatch?
-#saogf:F%C3%B6retagshandlingar%20%28dokument%29
-#saogf:Filmprogram
-#saogf:Homoerotiska%20skildringar
-#saogf:Lantm%C3%A4terihandlingar
-#saogf:Sportprogram%20%28text%29
-
-# TODO[69e799a0]: Dubbla match; ändra en till broadMatch och ta bort andra om :broader/:closeMatch?
-#saogf:Tal%20%28retorik%29
-#saogf:Karikatyrer%20och%20sk%C3%A4mtteckningar
-#saogf:Bibliska%20ber%C3%A4ttelser
-
 saogf:%C3%84ventyrsfilmer :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026005> ;
   :prefLabel "Action and adventure films"@en .
 
@@ -118,11 +106,10 @@ saogf:Bibliografier :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014
 saogf:Bibliotekskataloger :closeMatch <http://id.loc.gov/authorities/genreForms/gf2015026003> ;
   :prefLabel "Library catalogs"@en .
 
-# TODO[69e799a0]
-#saogf:Bibliska%20ber%C3%A4ttelser :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026240> ,
-#    <http://id.loc.gov/authorities/genreForms/gf2014026242> ;
-#  :prefLabel "Bible fiction"@en ,
-#    "Bible stories"@en .
+saogf:Bibliska%20ber%C3%A4ttelser :narrowMatch <http://id.loc.gov/authorities/genreForms/gf2014026240> ,
+    <http://id.loc.gov/authorities/genreForms/gf2014026242> ;
+  :prefLabel "Bible stories"@en ;
+  :altLabel "Bible fiction"@en .
 
 saogf:Bilder :closeMatch <http://id.loc.gov/authorities/genreForms/gf2017027251> ;
   :prefLabel "Pictures"@en .
@@ -169,9 +156,10 @@ saogf:Bossa%20nova :closeMatch <http://id.loc.gov/authorities/genreForms/gf20140
 saogf:Br%C3%B6llopsdikter :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026317> ;
   :prefLabel "Epithalamia"@en .
 
-saogf:Brevromaner :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026314> ;
-  :prefLabel "Epistolary fiction"@en ;
-  :altLabel "Novels in letters"@en .
+saogf:Brevromaner :broadMatch <http://id.loc.gov/authorities/genreForms/gf2014026314> ;
+  :prefLabel "Epistolary novels"@en ;
+  :altLabel "Novels in letters"@en ,
+    "Epistolary fiction"@en .
 
 saogf:Burlesker :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026254> ;
   :prefLabel "Burlesques (Literature)"@en .
@@ -575,11 +563,11 @@ saogf:K%C3%A4rleksskildringar :closeMatch <http://id.loc.gov/authorities/genreFo
 saogf:Kalendrar :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026055> ;
   :prefLabel "Calendars"@en .
 
-# TODO[69e799a0]
-#saogf:Karikatyrer%20och%20sk%C3%A4mtteckningar :closeMatch <http://id.loc.gov/authorities/genreForms/gf2017027224> ,
-#    <http://id.loc.gov/authorities/genreForms/gf2017027225> ;
-#  :prefLabel "Caricatures"@en ,
-#    "Cartoons (Humor)"@en .
+saogf:Karikatyrer%20och%20sk%C3%A4mtteckningar :narrowMatch <http://id.loc.gov/authorities/genreForms/gf2017027224> ,
+    <http://id.loc.gov/authorities/genreForms/gf2017027225> ;
+  :prefLabel "Caricatures and Cartoons"@en ;
+  :altLabel "Caricatures"@en ,
+    "Cartoons (Humor)"@en .
 
 saogf:Kartb%C3%B6cker :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026058> ;
   :prefLabel "Atlases"@en .
@@ -1149,11 +1137,8 @@ saogf:Tabeller :closeMatch <http://id.loc.gov/authorities/genreForms/gf201402618
 saogf:Taktila%20verk :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026187> ;
   :prefLabel "Tactile works"@en .
 
-# TODO[69e799a0]
-#saogf:Tal%20%28retorik%29 :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026363> ,
-#    <http://id.loc.gov/authorities/genreForms/gf2014026196> ;
-#  :prefLabel "Speeches"@en ,
-#    "Toasts (Speeches)"@en .
+saogf:Tal%20%28retorik%29 :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026363> ;
+  :prefLabel "Speeches"@en .
 
 saogf:Talb%C3%B6cker :closeMatch <http://id.loc.gov/authorities/genreForms/gf2011026630> ;
   :prefLabel "Talking books"@en .
@@ -1433,12 +1418,12 @@ graph <#delete> {
         :inScheme <https://id.kb.se/term/lcsh> ;
         :prefLabel "Library catalogs" ] .
 
-  #saogf:Bibliska%20ber%C3%A4ttelser :closeMatch [ a :GenreForm ;
-  #      :inScheme <https://id.kb.se/term/lcsh> ;
-  #      :prefLabel "Bible fiction" ] ,
-  #    [ a :GenreForm ;
-  #      :inScheme <https://id.kb.se/term/lcsh> ;
-  #      :prefLabel "Bible stories" ] .
+  saogf:Bibliska%20ber%C3%A4ttelser :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Bible fiction" ] ,
+      [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcsh> ;
+        :prefLabel "Bible stories" ] .
 
   saogf:Bilder :closeMatch [ a :GenreForm ;
         :inScheme <https://id.kb.se/term/lcgft> ;
@@ -2111,14 +2096,14 @@ graph <#delete> {
         :inScheme <https://id.kb.se/term/lcgft> ;
         :prefLabel "Calendars" ] .
 
-  #saogf:Karikatyrer%20och%20sk%C3%A4mtteckningar :closeMatch [ a :GenreForm ;
-  #      :inScheme <https://id.kb.se/term/lcgft> ;
-  #      :prefLabel "Caricatures" ;
-  #      :uri "http://id.loc.gov/authorities/genreForms/gf2017027224"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] ,
-  #    [ a :GenreForm ;
-  #      :inScheme <https://id.kb.se/term/lcgft> ;
-  #      :prefLabel "Cartoons (Humor)" ;
-  #      :uri "http://id.loc.gov/authorities/genreForms/gf2017027225"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
+  saogf:Karikatyrer%20och%20sk%C3%A4mtteckningar :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Caricatures" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2017027224"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] ,
+      [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Cartoons (Humor)" ;
+        :uri "http://id.loc.gov/authorities/genreForms/gf2017027225"^^<http://www.w3.org/2001/XMLSchema#anyURI> ] .
 
   saogf:Kartb%C3%B6cker :closeMatch [ a :GenreForm ;
         :inScheme <https://id.kb.se/term/lcgft> ;
@@ -2937,12 +2922,9 @@ graph <#delete> {
         :inScheme <https://id.kb.se/term/lcgft> ;
         :prefLabel "Tactile works" ] .
 
-  #saogf:Tal%20%28retorik%29 :closeMatch [ a :GenreForm ;
-  #      :inScheme <https://id.kb.se/term/lcgft> ;
-  #      :prefLabel "Speeches" ] ,
-  #    [ a :GenreForm ;
-  #      :inScheme <https://id.kb.se/term/lcgft> ;
-  #      :prefLabel "Toasts (Speeches)" ] .
+  saogf:Tal%20%28retorik%29 :closeMatch [ a :GenreForm ;
+        :inScheme <https://id.kb.se/term/lcgft> ;
+        :prefLabel "Speeches" ] .
 
   saogf:Talb%C3%B6cker :closeMatch [ a :GenreForm ;
         :inScheme <https://id.kb.se/term/lcsh> ;

--- a/source/saogf/saogf-lcgft-patch.trig
+++ b/source/saogf/saogf-lcgft-patch.trig
@@ -397,7 +397,8 @@ saogf:Filmmanus :closeMatch <http://id.loc.gov/authorities/genreForms/gf20140265
 saogf:Filmografi :closeMatch <http://id.loc.gov/authorities/genreForms/gf2019026014> ;
   :prefLabel "Filmographies"@en .
 
-saogf:Filmprogram :prefLabel "Film festival programs"@en .
+saogf:Filmprogram :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026102> ;
+  :prefLabel "Festival programs"@en .
 
 saogf:Filmrecensioner :closeMatch <http://id.loc.gov/authorities/genreForms/gf2014026129> ;
   :prefLabel "Motion picture reviews"@en .


### PR DESCRIPTION
To be run with the whelktool RDF patch script.

For each SAOGF term with a `closeMatch` to an LCGFT term:

- Add English `prefLabel`
- Link to matching LCGFT term
- Delete local (blank) `closeMatch`-description
