### PR TITLE
Feature/item search filter

### DIFF
--- a/source/vocab/libris-search-experimental.ttl
+++ b/source/vocab/libris-search-experimental.ttl
@@ -270,7 +270,7 @@ ls:itemCreated a owl:DatatypeProperty ;
      rdfs:range xsd:dateTime ;
      owl:propertyChainAxiom ( :hasItem :meta :created ) .
 
-ls:itemSubject a owl:DatatypeProperty ;
+ls:itemSubject a owl:ObjectProperty ;
      :category :shorthand, :pending ;
      rdfs:subPropertyOf ls:itemInformation ;
      rdfs:label "lokalt ämnesord"@sv, "item subject"@en ;

--- a/source/vocab/libris-search-experimental.ttl
+++ b/source/vocab/libris-search-experimental.ttl
@@ -218,8 +218,14 @@ ls:title a owl:ObjectProperty ;
         ( :seriesMembership :inSeries :instanceOf :hasTitle ),
         ( :relationship :entity :hasTitle ) .
 
+ls:itemInformation a owl:DatatypeProperty ;
+      :category :searchfilter, ls:composite, :pending ;
+      rdfs:label "bestånd"@sv, "item"@en ;
+      rdfs:domain :Instance .
+
 ls:itemShelf a owl:DatatypeProperty ;
-      :category :searchfilter, :shorthand, :pending ;
+      :category :shorthand, :pending ;
+      rdfs:subPropertyOf ls:itemInformation ;
       skos:notation "WHYL"^^ls:QueryCode ;
       rdfs:label "hyllsignum"@sv, "item shelf"@en ;
       rdfs:domain :Instance ;
@@ -236,7 +242,8 @@ ls:shelf a owl:DatatypeProperty ;
         [ owl:propertyChainAxiom ( :shelfMark :label ) ] .
 
 ls:hasItemNote a owl:DatatypeProperty ;
-      :category :searchfilter, :shorthand, :pending ;
+      :category :shorthand, :pending ;
+      rdfs:subPropertyOf ls:itemInformation ;
       rdfs:label "lokal anmärkning"@sv, "local note"@en ;
       rdfs:domain :Instance ;
       owl:propertyChainAxiom ( :hasItem ls:itemNote ) .
@@ -264,7 +271,8 @@ ls:itemCreated a owl:DatatypeProperty ;
      owl:propertyChainAxiom ( :hasItem :meta :created ) .
 
 ls:itemSubject a owl:DatatypeProperty ;
-     :category :shorthand, :pending, :searchfilter ;
+     :category :shorthand, :pending ;
+     rdfs:subPropertyOf ls:itemInformation ;
      rdfs:label "lokalt ämnesord"@sv, "item subject"@en ;
      rdfs:domain :Instance ;
      owl:propertyChainAxiom ( :hasItem :subject ) .


### PR DESCRIPTION
Enables using `bestånd:` for searching:
- "hyllsignum"
- "lokal anmärkning"
- "lokalt ämnesord"

**TODO?** 
Align search filters with how data is presented in the item panel:
- Replace`ls:hasItemNote` (lokal anmärkning) with a filter that matches values shown under Beståndsuppgift
- Replace `ls:itemShelf` (hyllsignum) with a filter that matches values shown under Placering
- Add an additional filter to cover remaining fields to be searchable via `bestånd:`
