### PR TITLE
Add composite search filter ls:library

### DIFF
--- a/source/vocab/libris-search-experimental.ttl
+++ b/source/vocab/libris-search-experimental.ttl
@@ -133,23 +133,28 @@ ls:isxn a owl:DatatypeProperty ;
     :category ls:composite, :pending, :searchfilter ;
     rdfs:label "ISXN"@sv, "ISXN"@en .
 
+ls:library a owl:ObjectProperty ;
+   :category :searchfilter, :impliedByObject, ls:composite, :pending ;
+   rdfs:label "bibliotek"@sv, "library"@en ;
+   skos:notation "bath.possessingInstitution"^^ls:QueryCode,
+                 "BIBL"^^ls:QueryCode,
+                 "LIB"^^ls:QueryCode, # TODO deprecate?
+                 "OCODE"^^ls:QueryCode ;
+   rdfs:domain :Instance ;
+   sdo:rangeIncludes :Library, bibdb:Organization .
+
 ls:itemHeldBy a owl:ObjectProperty ;
-    rdfs:label "Bibliotek"@sv, "Library"@en ;
-    skos:notation "bath.possessingInstitution"^^ls:QueryCode ;
-    skos:notation "BIBL"^^ls:QueryCode ;
-    skos:notation "LIBRARY"^^ls:QueryCode ;
-    # skos:notation "LIB"^^ls:QueryCode ; # TODO deprecate?
-    :category :searchfilter, :impliedByObject, :shorthand, :pending ;
-    rdfs:domain :Instance ;
-    sdo:rangeIncludes :Library ;
+    :category :pending, ls:coercing ;
+    rdfs:subPropertyOf ls:library ;
+    rdfs:range :Library ;
+    ls:indexKey "@reverse.itemOf.heldBy" ; # FIXME: Implement support for ls:coercing + :shorthand in XL
     owl:propertyChainAxiom ( :hasItem :heldBy ) .
 
 ls:itemHeldByOrg a owl:ObjectProperty ;
-    rdfs:label "Biblioteksorganisation"@sv, "Library organization"@en ;
-    skos:notation "OCODE"^^ls:QueryCode ;
-    :category :searchfilter, :impliedByObject, :shorthand, :pending ;
-    rdfs:domain :Instance ;
-    sdo:rangeIncludes bibdb:Organization ;
+    :category :pending, ls:coercing ;
+    rdfs:subPropertyOf ls:library ;
+    rdfs:range bibdb:Organization ;
+    ls:indexKey "@reverse.itemOf.heldBy.isPartOf" ; # FIXME: Implement support for ls:coercing + :shorthand in XL
     owl:propertyChainAxiom ( :hasItem :heldBy :isPartOf ) .
 
 ls:workType a owl:ObjectProperty ;

--- a/source/vocab/libris-search-experimental.ttl
+++ b/source/vocab/libris-search-experimental.ttl
@@ -150,7 +150,7 @@ ls:itemHeldBy a owl:ObjectProperty ;
     :category :searchfilter, :pending, ls:coercing ;
     rdfs:subPropertyOf ls:library ;
     rdfs:label "bibliotek (sigel)"@sv, "library (sigel)"@en ;
-    skos:notation bath.possessingInstitution"^^ls:QueryCode ;
+    skos:notation bath.possessingInstitution"^^ls:QueryCode,
         "BIBL"^^ls:QueryCode,
         "LIB"^^ls:QueryCode, # TODO deprecate?
         "BIB"^^ls:QueryCode .

--- a/source/vocab/libris-search-experimental.ttl
+++ b/source/vocab/libris-search-experimental.ttl
@@ -143,24 +143,26 @@ ls:isxn a owl:DatatypeProperty ;
 ls:library a owl:ObjectProperty ;
    :category :searchfilter, :impliedByObject, ls:composite, :pending ;
    rdfs:label "bibliotek"@sv, "library"@en ;
-   skos:notation "bath.possessingInstitution"^^ls:QueryCode,
-                 "BIBL"^^ls:QueryCode,
-                 "LIB"^^ls:QueryCode, # TODO deprecate?
-                 "BIB"^^ls:QueryCode,
-                 "OCODE"^^ls:QueryCode ;
    rdfs:domain :Instance ;
    sdo:rangeIncludes :Library, bibdb:Organization .
 
 ls:itemHeldBy a owl:ObjectProperty ;
-    :category :pending, ls:coercing ;
+    :category :searchfilter, :pending, ls:coercing ;
     rdfs:subPropertyOf ls:library ;
+    rdfs:label "bibliotek (sigel)"@sv, "library (sigel)"@en ;
+    skos:notation bath.possessingInstitution"^^ls:QueryCode ;
+        "BIBL"^^ls:QueryCode,
+        "LIB"^^ls:QueryCode, # TODO deprecate?
+        "BIB"^^ls:QueryCode .
     rdfs:range :Library ;
     ls:indexKey "@reverse.itemOf.heldBy" ; # FIXME: Implement support for ls:coercing + :shorthand in XL
     owl:propertyChainAxiom ( :hasItem :heldBy ) .
 
 ls:itemHeldByOrg a owl:ObjectProperty ;
-    :category :pending, ls:coercing ;
+    :category :searchfilter, :pending, ls:coercing ;
     rdfs:subPropertyOf ls:library ;
+    rdfs:label "biblioteksorganisation"@sv, "library organization"@en ;
+    skos:notation "OCODE"^^ls:QueryCode ;
     rdfs:range bibdb:Organization ;
     ls:indexKey "@reverse.itemOf.heldBy.isPartOf" ; # FIXME: Implement support for ls:coercing + :shorthand in XL
     owl:propertyChainAxiom ( :hasItem :heldBy :isPartOf ) .


### PR DESCRIPTION
Refactor how libraries are queried:

- Downgrade `ls:itemHeldBy` and `ls:itemHeldByOrg` to auxiliary sub-properties.
- Introduce `ls:library` as a composite super-property, now used as the primary filter for searching both `Library` and `bibdb:Organization`.
- Mark the sub-properties with `:category :coercing` to mirror the behavior of `ls:workCategory` and its sub-properties.
- Retain `ls:itemHeldByOrg` in facets where results should be limited to organizations.
- Adjustments in XL: https://github.com/libris/librisxl/pull/1754  
- Minor adjustment in API tests: https://github.com/libris/lxl_api_tests/pull/47