### PR TITLE
Make item search properties repeatable

### DIFF
--- a/sys/context/kbv.jsonld
+++ b/sys/context/kbv.jsonld
@@ -238,6 +238,10 @@
 
     "librissearch": "https://id.kb.se/ns/librissearch/",
     "librissearch:merges": { "@container": "@set"},
+    "librissearch:additionalItemInformation": {"@container": "@set"},
+    "librissearch:internalItemNote": {"@container": "@set"},
+    "librissearch:itemStatement": {"@container": "@set"},
+    "librissearch:shelf": {"@container": "@set"},
 
     "marc": "https://id.kb.se/marc/",
 


### PR DESCRIPTION
To get nested grouping right in Elastic queries