### PR TITLE
Add category at the end of work chip

### DIFF
--- a/source/vocab/display.jsonld
+++ b/source/vocab/display.jsonld
@@ -187,7 +187,8 @@
             },
             "version",
             "marc:arrangedStatementForMusic",
-            "originDate"
+            "originDate",
+            "category"
           ]
         },
         "DataCatalog": {


### PR DESCRIPTION
https://kbse.atlassian.net/browse/FMT-552

Use case: Användare ska kunna se skillnad på verk av olika slag (t.ex. ljud/text) Libris Katalogisering, utan att behöva öppna upp verket. Detta är särskilt viktigt vid länkning till verk.

Med denna ändring blir egenskaperna i verkschipet
- Allmänna, finns på merparten verk: hasTitle, contribution, language, category
- Specialiserade, finns på en mindre mängd verk: legalDate, originDate, version, marc:arrangedStatementForMusic
