### PR TITLE
Add MediaObject search chip including marc:publicNote

### DIFF
--- a/source/vocab/display.jsonld
+++ b/source/vocab/display.jsonld
@@ -1826,6 +1826,11 @@
           "classLensDomain": "ToCEntry",
           "fresnel:extends": {"@id": "ToCEntry-chips"},
           "showProperties": [ "fresnel:super", "responsibilityStatement" ]
+        },
+        "MediaObject": {
+          "classLensDomain": "MediaObject",
+          "fresnel:extends": {"@id": "MediaObject-chips"},
+          "showProperties": [ "fresnel:super", "marc:publicNote" ]
         }
       }
     },


### PR DESCRIPTION
To make `marc:publicNote` searchable in Libris