### PR TITLE
Feature/instance record search filters

### DIFF
--- a/source/vocab/display.jsonld
+++ b/source/vocab/display.jsonld
@@ -1865,6 +1865,18 @@
             {
               "@type": "fresnel:fslselector",
               "@value": "meta/*/controlNumber"
+            },
+            {
+              "@type": "fresnel:fslselector",
+              "@value": "meta/*/created"
+            },
+            {
+              "@type": "fresnel:fslselector",
+              "@value": "meta/*/modified"
+            },
+            {
+              "@type": "fresnel:fslselector",
+              "@value": "meta/*/encodingLevel"
             }
           ]
         },

--- a/source/vocab/libris-search-experimental.ttl
+++ b/source/vocab/libris-search-experimental.ttl
@@ -328,7 +328,7 @@ ls:instanceModified a owl:DatatypeProperty ;
      rdfs:domain :Instance ;
      skos:notation "BDAT"^^ls:QueryCode ;
      rdfs:range xsd:dateTime ;
-     owl:propertyChainAxiom ( :meta :modified ) .
+     owl:propertyChainAxiom ( [ rdfs:subPropertyOf :meta ; rdfs:domain :Instance ] :modified ) .
 
 ls:instanceCreated a owl:DatatypeProperty ;
      :category :searchfilter, :shorthand, :pending ;
@@ -337,7 +337,7 @@ ls:instanceCreated a owl:DatatypeProperty ;
      rdfs:domain :Instance ;
      skos:notation "DAT"^^ls:QueryCode ;
      rdfs:range xsd:dateTime ;
-     owl:propertyChainAxiom ( :meta :created ) .
+     owl:propertyChainAxiom ( [ rdfs:subPropertyOf :meta ; rdfs:domain :Instance ] :created ) .
 
 ls:itemSubject a owl:ObjectProperty ;
      :category :searchfilter, :shorthand, :pending ;

--- a/source/vocab/libris-search-experimental.ttl
+++ b/source/vocab/libris-search-experimental.ttl
@@ -311,7 +311,7 @@ ls:additionalItemInformation a owl:DatatypeProperty ;
         [ owl:propertyChainAxiom ( :immediateAcquisition :identifiedBy :value ) ],
         [ owl:propertyChainAxiom ( :classification :code ) ] .
 
-ls:itemCreated a owl:DatatypeProperty ;
+ls:itemRecordCreated a owl:DatatypeProperty ;
      :category :searchfilter, :shorthand, :pending ;
      rdfs:label "registreringsdatum"@sv, "item created"@en ;
      rdfs:comment "Datum när exemplar/bestånd registrerades."@sv, "Date when item/holding/copy was registered."@en;
@@ -321,7 +321,7 @@ ls:itemCreated a owl:DatatypeProperty ;
      rdfs:range xsd:dateTime ;
      owl:propertyChainAxiom ( :hasItem :meta :created ) .
 
-ls:instanceModified a owl:DatatypeProperty ;
+ls:instanceRecordModified a owl:DatatypeProperty ;
      :category :searchfilter, :shorthand, :pending ;
      rdfs:label "uppdateringsdatum (instans)"@sv, "modified date (instance)"@en ;
      rdfs:comment "Datum när bibliografisk post uppdaterades."@sv, "Date when bibliographic record was updated."@en;
@@ -330,7 +330,7 @@ ls:instanceModified a owl:DatatypeProperty ;
      rdfs:range xsd:dateTime ;
      owl:propertyChainAxiom ( [ rdfs:subPropertyOf :meta ; rdfs:domain :Instance ] :modified ) .
 
-ls:instanceCreated a owl:DatatypeProperty ;
+ls:instanceRecordCreated a owl:DatatypeProperty ;
      :category :searchfilter, :shorthand, :pending ;
      rdfs:label "registreringsdatum (instans)"@sv, "created date (instance)"@en ;
      rdfs:comment "Datum när bibliografisk post skapades."@sv, "Date when bibliographic record was created."@en;


### PR DESCRIPTION
- Fix definitions to get correct query expansion for `DAT` / `BDAT` query codes.
- Ensure `meta.created`, `meta.modified` and `meta.encodingLevel` are indexed for embedded instances.

Maybe we should create similar shorthands for all record search filters? For example define
```
ls:bibliography owl:propertyChainAxiom ( [ rdfs:subPropertyOf :meta ; rdfs:domain :Instance ] :bibliography ) .
```
I think this would simplify things because then the correct query expansion can be inferred directly from the definition instead of having special handling of record properties in the implementation.