### PR TITLE
Make additionalClassificationDdc available for search

### DIFF
--- a/source/vocab/display.jsonld
+++ b/source/vocab/display.jsonld
@@ -1899,8 +1899,17 @@
             "relationship",
             "hasPart",
             {
-              "@type": "fresnel:fslselector",
-              "@value": "additionalClassificationDdc/ClassificationDdc/code"
+              "fresnel:mergeProperties": [
+                {
+                  "@type": "fresnel:fslselector",
+                  "@value": "additionalClassificationDdc/ClassificationDdc/code"
+                },
+                {
+                  "@type": "fresnel:fslselector",
+                  "@value": "classification/ClassificationDdc/code"
+                }
+              ],
+              "fresnel:use": "librissearch:dewey"
             },
             {
               "@type": "fresnel:fslselector",

--- a/source/vocab/display.jsonld
+++ b/source/vocab/display.jsonld
@@ -1900,6 +1900,10 @@
             "hasPart",
             {
               "@type": "fresnel:fslselector",
+              "@value": "additionalClassificationDdc/ClassificationDdc/code"
+            },
+            {
+              "@type": "fresnel:fslselector",
               "@value": "meta/*/controlNumber"
             }
           ]

--- a/source/vocab/libris-search-experimental.ttl
+++ b/source/vocab/libris-search-experimental.ttl
@@ -408,9 +408,14 @@ ls:sab a owl:DatatypeProperty ;
         :code
     ) .
 
+ls:dewey a owl:DatatypeProperty ;
+    :category ls:composite, :pending, :searchfilter ;
+    rdfs:label "Dewey-klassifikation"@sv, "Dewey classification"@en .
+
 ls:ddc a owl:DatatypeProperty ;
     :category :shorthand, :pending, :searchfilter ;
-    rdfs:label "Dewey-klassifikation"@sv, "Dewey classification"@en ;
+    rdfs:label "Dewey-klassifikation (primär)"@sv, "Dewey classification (primary)"@en ;
+    rdfs:subPropertyOf ls:dewey ;
     ls:indexKey "classification._ddc" ;
     skos:notation "DDK"^^ls:QueryCode ;
     sdo:domainIncludes :Work ;
@@ -421,6 +426,14 @@ ls:ddc a owl:DatatypeProperty ;
         ]
         :code
     ) .
+
+ls:ddc2 a owl:DatatypeProperty ;
+    :category :shorthand, :pending, :searchfilter ;
+    rdfs:label "Dewey-klassifikation (sekundär)"@sv, "Dewey classification (secondary)"@en ;
+    rdfs:subPropertyOf ls:dewey ;
+    skos:notation "DDK2"^^ls:QueryCode ;
+    sdo:domainIncludes :Work ;
+    owl:propertyChainAxiom ( :additionalClassificationDdc :code ) .
 
 ls:udc a owl:DatatypeProperty ;
     :category :shorthand, :pending, :searchfilter ;

--- a/source/vocab/libris-search-experimental.ttl
+++ b/source/vocab/libris-search-experimental.ttl
@@ -409,31 +409,22 @@ ls:sab a owl:DatatypeProperty ;
     ) .
 
 ls:dewey a owl:DatatypeProperty ;
-    :category ls:composite, :pending, :searchfilter ;
-    rdfs:label "Dewey-klassifikation"@sv, "Dewey classification"@en .
-
-ls:ddc a owl:DatatypeProperty ;
-    :category :shorthand, :pending, :searchfilter ;
-    rdfs:label "Dewey-klassifikation (primär)"@sv, "Dewey classification (primary)"@en ;
-    rdfs:subPropertyOf ls:dewey ;
-    ls:indexKey "classification._ddc" ;
-    skos:notation "DDK"^^ls:QueryCode ;
+    :category ls:merged, :pending, :searchfilter ;
+    rdfs:label "Dewey-klassifikation"@sv, "Dewey classification"@en ;
+    skos:notation "DDC"^^ls:QueryCode,
+        "DDC2"^^ls:QueryCode,
+        "DDK"^^ls:QueryCode ;
     sdo:domainIncludes :Work ;
-    owl:propertyChainAxiom (
+    ls:merges [ owl:propertyChainAxiom ( :additionalClassificationDdc :code ) ],
         [
-            rdfs:subPropertyOf :classification ;
-            rdfs:range :ClassificationDdc
-        ]
-        :code
-    ) .
-
-ls:ddc2 a owl:DatatypeProperty ;
-    :category :shorthand, :pending, :searchfilter ;
-    rdfs:label "Dewey-klassifikation (sekundär)"@sv, "Dewey classification (secondary)"@en ;
-    rdfs:subPropertyOf ls:dewey ;
-    skos:notation "DDK2"^^ls:QueryCode ;
-    sdo:domainIncludes :Work ;
-    owl:propertyChainAxiom ( :additionalClassificationDdc :code ) .
+            owl:propertyChainAxiom (
+                [
+                    rdfs:subPropertyOf :classification ;
+                    rdfs:range :ClassificationDdc
+                ]
+                :code
+            )
+        ] .
 
 ls:udc a owl:DatatypeProperty ;
     :category :shorthand, :pending, :searchfilter ;


### PR DESCRIPTION
Add search filter corresponding to legacy code `DDC2` as well as a composite filter for searching both `DDC` and `DDC2`.