### PR TITLE
Feature/libris search filter adjustments

### DIFF
--- a/source/apps.jsonld
+++ b/source/apps.jsonld
@@ -101,7 +101,7 @@
       "filterAliases": [
         { "alias": "excludeEplikt", "filter": "NOT (bibliography:\"sigel:EPLK\" AND itemHeldBy:\"sigel:APIS\" AND reverseLinks.totalItemsByRelation.itemOf.instanceOf=1)", "prefLabelByLang": { "sv": "Exkludera elektroniska pliktleveranser", "en": "Exclude electronic legal deposit" } },
         { "alias": "includeEplikt", "filter": "NOT excludeEplikt", "prefLabelByLang": { "sv": "Inkludera elektroniska pliktleveranser", "en": "Include electronic legal deposit"  } },
-        { "alias": "excludePreliminary", "filter": "NOT encodingLevel:(\"marc:PartialPreliminaryLevel\" OR \"marc:PrepublicationLevel\")", "prefLabelByLang": { "sv": "Exkludera kommande publiceringar", "en": "Exclude upcoming publications" } },
+        { "alias": "excludePreliminary", "filter": "NOT recordType:VirtualRecord OR (NOT encodingLevel:(\"marc:PartialPreliminaryLevel\" OR \"marc:PrepublicationLevel\"))", "prefLabelByLang": { "sv": "Exkludera kommande publiceringar", "en": "Exclude upcoming publications" } },
         { "alias": "includePreliminary", "filter": "NOT excludePreliminary", "prefLabelByLang": { "sv": "Inkludera kommande publiceringar", "en": "Include upcoming publications" } },
         { "alias": "existsImage", "filter": "image:*", "prefLabelByLang": { "sv": "Har omslags-/miniatyrbild", "en": "Has cover/thumbnail" } },
         { "alias": "freeOnline", "filter": "instanceType:DigitalResource AND (usageAndAccessPolicy.label:gratis OR \"associatedMedia.marc:publicNote\":\"fritt tillgänglig\" OR usageAndAccessPolicy:(\"https://id.kb.se/policy/freely-available\" OR \"https://id.kb.se/policy/oa/gratis\"))", "prefLabelByLang": { "sv": "Fritt online", "en": "Free online material" } },
@@ -236,7 +236,7 @@
       "filterAliases": [
         { "alias": "excludeEplikt", "filter": "NOT (bibliography:\"sigel:EPLK\" AND itemHeldBy:\"sigel:APIS\" AND reverseLinks.totalItemsByRelation.itemOf.instanceOf=1)", "prefLabelByLang": { "sv": "Exkludera elektroniska pliktleveranser", "en": "Exclude electronic legal deposit" } },
         { "alias": "includeEplikt", "filter": "NOT excludeEplikt", "prefLabelByLang": { "sv": "Inkludera elektroniska pliktleveranser", "en": "Include electronic legal deposit"  } },
-        { "alias": "excludePreliminary", "filter": "NOT encodingLevel:(\"marc:PartialPreliminaryLevel\" OR \"marc:PrepublicationLevel\")", "prefLabelByLang": { "sv": "Exkludera kommande publiceringar", "en": "Exclude upcoming publications" } },
+        { "alias": "excludePreliminary", "filter": "NOT recordType:VirtualRecord OR (NOT encodingLevel:(\"marc:PartialPreliminaryLevel\" OR \"marc:PrepublicationLevel\"))", "prefLabelByLang": { "sv": "Exkludera kommande publiceringar", "en": "Exclude upcoming publications" } },
         { "alias": "includePreliminary", "filter": "NOT excludePreliminary", "prefLabelByLang": { "sv": "Inkludera kommande publiceringar", "en": "Include upcoming publications" } },
         { "alias": "existsImage", "filter": "image:*", "prefLabelByLang": { "sv": "Har omslags-/miniatyrbild", "en": "Has cover/thumbnail" } },
         { "alias": "freeOnline", "filter": "instanceType:DigitalResource AND (usageAndAccessPolicy.label:gratis OR \"associatedMedia.marc:publicNote\":\"fritt tillgänglig\" OR usageAndAccessPolicy:(\"https://id.kb.se/policy/freely-available\" OR \"https://id.kb.se/policy/oa/gratis\"))", "prefLabelByLang": { "sv": "Fritt online", "en": "Free online material" } }
@@ -309,7 +309,7 @@
       "filterAliases": [
         { "alias": "excludeEplikt", "filter": "NOT (bibliography:\"sigel:EPLK\" AND itemHeldBy:\"sigel:APIS\" AND reverseLinks.totalItemsByRelation.itemOf.instanceOf=1)", "prefLabelByLang": { "sv": "Exkludera elektroniska pliktleveranser", "en": "Exclude electronic legal deposit" } },
         { "alias": "includeEplikt", "filter": "NOT excludeEplikt", "prefLabelByLang": { "sv": "Inkludera elektroniska pliktleveranser", "en": "Include electronic legal deposit"  } },
-        { "alias": "excludePreliminary", "filter": "NOT encodingLevel:(\"marc:PartialPreliminaryLevel\" OR \"marc:PrepublicationLevel\")", "prefLabelByLang": { "sv": "Exkludera kommande publiceringar", "en": "Exclude upcoming publications" } },
+        { "alias": "excludePreliminary", "filter": "NOT recordType:VirtualRecord OR (NOT encodingLevel:(\"marc:PartialPreliminaryLevel\" OR \"marc:PrepublicationLevel\"))", "prefLabelByLang": { "sv": "Exkludera kommande publiceringar", "en": "Exclude upcoming publications" } },
         { "alias": "includePreliminary", "filter": "NOT excludePreliminary", "prefLabelByLang": { "sv": "Inkludera kommande publiceringar", "en": "Include upcoming publications" } },
         { "alias": "existsImage", "filter": "image:*", "prefLabelByLang": { "sv": "Har omslags-/miniatyrbild", "en": "Has cover/thumbnail" } },
         { "alias": "freeOnline", "filter": "instanceType:DigitalResource AND (usageAndAccessPolicy.label:gratis OR \"associatedMedia.marc:publicNote\":\"fritt tillgänglig\" OR usageAndAccessPolicy:(\"https://id.kb.se/policy/freely-available\" OR \"https://id.kb.se/policy/oa/gratis\"))", "prefLabelByLang": { "sv": "Fritt online", "en": "Free online material" } }

--- a/source/vocab/agents.ttl
+++ b/source/vocab/agents.ttl
@@ -376,7 +376,6 @@
     rdfs:subClassOf :Agent .
 
 :bibliography a owl:ObjectProperty ;
-    :category :searchfilter, :impliedByObject ;
     rdfs:label "in bibliography"@en, "ingår i bibliografi"@sv ;
     rdfs:comment "Anger vilken bibliografisk förteckning som resursen är upptagen i. En bibliografi är en systematisk förteckning med en specifik urvalsprincip, t.ex. utgivningsland, ämne, språk eller materialtyp."@sv,
                  "Indicates which bibliography the resource is listed in. A bibliography is a systematic listing with a specific selection principle, e.g. country of publication, subject, language, or material type."@en ;

--- a/source/vocab/display.jsonld
+++ b/source/vocab/display.jsonld
@@ -1877,6 +1877,10 @@
             {
               "@type": "fresnel:fslselector",
               "@value": "meta/*/encodingLevel"
+            },
+            {
+              "@type": "fresnel:fslselector",
+              "@value": "relationship/*/entity/*/hasTitle"
             }
           ]
         },

--- a/source/vocab/libris-search-experimental.ttl
+++ b/source/vocab/libris-search-experimental.ttl
@@ -175,6 +175,10 @@ ls:encodingLevel a owl:ObjectProperty;
     rdfs:range marc:EncLevelType ;
     owl:propertyChainAxiom ( [ rdfs:subPropertyOf :meta ; rdfs:domain :Instance ] :encodingLevel ) .
 
+ls:recordType a owl:ObjectProperty;
+    :category :shorthand, :pending ;
+    owl:propertyChainAxiom ( :meta rdf:type ) .
+
 ls:isxn a owl:DatatypeProperty ;
     :category ls:composite, :pending, :searchfilter ;
     skos:notation "NUMM"^^ls:QueryCode ;

--- a/source/vocab/libris-search-experimental.ttl
+++ b/source/vocab/libris-search-experimental.ttl
@@ -407,7 +407,6 @@ ls:lccn rdfs:domain :Instance ;
     :category :searchfilter, :shorthand, :pending ;
     rdfs:label "LCCN";
     skos:notation "bath.lccn"^^ls:QueryCode ;
-    rdfs:subPropertyOf ls:isxn ;
     rdfs:domain :Instance ;
     owl:propertyChainAxiom ( [ rdfs:subPropertyOf :identifiedBy ; rdfs:domain :Instance ; rdfs:range :LCCN ] :value ) .
 

--- a/source/vocab/libris-search-experimental.ttl
+++ b/source/vocab/libris-search-experimental.ttl
@@ -143,7 +143,8 @@ ls:title a owl:ObjectProperty ;
     owl:propertyChainAxiom ( :translationOf :hasTitle ),
         ( :seriesMembership :inSeries :instanceOf :hasTitle ),
         ( :relationship :entity :hasTitle ),
-        ( :hasPart :hasTitle ) .
+        ( :hasPart :hasTitle ),
+        ( :hasPart :translationOf :hasTitle ) .
 
 ls:contributor a owl:ObjectProperty ;
     :category :searchfilter, :shorthand, ls:composite, :impliedByObject, ls:preferLike, :pending ;

--- a/source/vocab/libris-search-experimental.ttl
+++ b/source/vocab/libris-search-experimental.ttl
@@ -23,44 +23,6 @@
 
 :tableOfContents :category :searchfilter . # See ./details.ttl for full definition of :tableOfContents
 
-:contributor # See ./relations.ttl for full definition of :contributor
-    :category :searchfilter, :impliedByObject, ls:preferLike ;
-    skos:notation "dc.author"^^ls:QueryCode ;
-    skos:notation "dc.contributor"^^ls:QueryCode ;
-    skos:notation "dc.creator"^^ls:QueryCode ;
-    skos:notation "FÖRF"^^ls:QueryCode ;
-    skos:notation "FORF"^^ls:QueryCode ;
-    skos:notation "PERS"^^ls:QueryCode ;
-    skos:notation "WFRF"^^ls:QueryCode ;
-    skos:notation "WINS"^^ls:QueryCode .
-
-# NOTE: Old webbsök code 'author' was same as 'FÖRF'
-:author a owl:ObjectProperty ;
-    :category :searchfilter, ls:preferLike, :shorthand, :pending ;
-    rdfs:label "författare"@sv, "author"@en ;
-    owl:equivalentProperty <https://id.kb.se/relator/author> ;
-    rdfs:subPropertyOf :contributor ;
-    rdfs:range :Agent ;
-    owl:propertyChainAxiom (
-            [ rdfs:subPropertyOf :contribution ; rdfs:range [ rdfs:subClassOf [ a owl:Restriction ;
-                owl:onProperty :role ;
-                owl:hasValue <https://id.kb.se/relator/author> ] ] ]
-            :agent
-        ) .
-
-:translator a owl:ObjectProperty ;
-    :category :searchfilter, ls:preferLike, :shorthand, :pending ;
-    rdfs:label "översättare"@sv, "translator"@en ;
-    owl:equivalentProperty <https://id.kb.se/relator/translator> ;
-    rdfs:subPropertyOf :contributor ;
-    rdfs:range :Agent ;
-    owl:propertyChainAxiom (
-            [ rdfs:subPropertyOf :contribution ; rdfs:range [ rdfs:subClassOf [ a owl:Restriction ;
-                owl:onProperty :role ;
-                owl:hasValue <https://id.kb.se/relator/translator> ] ] ]
-            :agent
-        ) .
-
 :subject # See ./relations.ttl for full definition of :subject
     :category :searchfilter ;
     skos:notation "dc.subject"^^ls:QueryCode ;
@@ -171,14 +133,55 @@ ls:recordType a owl:ObjectProperty;
 ls:title a owl:ObjectProperty ;
     :category :searchfilter, ls:composite, :pending ;
     rdfs:label "titel"@sv, "title"@en ;
-    skos:notation "TIT"^^ls:QueryCode ;
-    skos:notation "bath.title"^^ls:QueryCode ;
-    skos:notation "dc.title"^^ls:QueryCode ; # TODO only hasTitle?
-    skos:notation "HTIT"^^ls:QueryCode ; # "Titel" - drop specificity
-    skos:notation "WUTI"^^ls:QueryCode ; # "Uniform titel (ordindex)" - drop specificity
+        "TIT"^^ls:QueryCode,
+        "bath.title"^^ls:QueryCode,
+        "dc.title"^^ls:QueryCode, # TODO only hasTitle?
+        "HTIT"^^ls:QueryCode, # "Titel" - drop specificity
+        "WUTI"^^ls:QueryCode, # "Uniform titel (ordindex)" - drop specificity
+    sdo:domainIncludes :Creation ;
     owl:propertyChainAxiom ( :translationOf :hasTitle ),
         ( :seriesMembership :inSeries :instanceOf :hasTitle ),
         ( :relationship :entity :hasTitle ) .
+
+ls:contributor a owl:ObjectProperty ;
+    :category :searchfilter, :shorthand, ls:composite, :impliedByObject, ls:preferLike ;
+    rdfs:label "Author/Contributor"@en, "Författare/upphov"@sv ;
+    skos:notation "dc.author"^^ls:QueryCode,
+        "dc.contributor"^^ls:QueryCode,
+        "dc.creator"^^ls:QueryCode,
+        "FÖRF"^^ls:QueryCode,
+        "FORF"^^ls:QueryCode,
+        "PERS"^^ls:QueryCode,
+        "WFRF"^^ls:QueryCode,
+        "WINS"^^ls:QueryCode ;
+    sdo:domainIncludes :Creation ;
+    sdo:rangeIncludes :BibliographicAgent ;
+    owl:propertyChainAxiom ( :contribution :agent ) .
+
+# NOTE: Old webbsök code 'author' was same as 'FÖRF'
+ls:author a owl:ObjectProperty ;
+    :category :searchfilter, ls:preferLike, :shorthand, :pending ;
+    rdfs:label "författare"@sv, "author"@en ;
+    sdo:domainIncludes :Work ;
+    sdo:rangeIncludes :BibliographicAgent ;
+    owl:propertyChainAxiom (
+            [ rdfs:subPropertyOf :contribution ; rdfs:range [ rdfs:subClassOf [ a owl:Restriction ;
+                owl:onProperty :role ;
+                owl:hasValue <https://id.kb.se/relator/author> ] ] ]
+            :agent
+        ) .
+
+ls:translator a owl:ObjectProperty ;
+    :category :searchfilter, ls:preferLike, :shorthand, :pending ;
+    rdfs:label "översättare"@sv, "translator"@en ;
+    sdo:domainIncludes :Work ;
+    sdo:rangeIncludes :BibliographicAgent ;
+    owl:propertyChainAxiom (
+            [ rdfs:subPropertyOf :contribution ; rdfs:range [ rdfs:subClassOf [ a owl:Restriction ;
+                owl:onProperty :role ;
+                owl:hasValue <https://id.kb.se/relator/translator> ] ] ]
+            :agent
+        ) .
 
 
 ## Work

--- a/source/vocab/libris-search-experimental.ttl
+++ b/source/vocab/libris-search-experimental.ttl
@@ -370,7 +370,7 @@ ls:instanceCategory a owl:ObjectProperty ;
     ls:indexKey "_categoryByCollection.@none" .
 
 ls:linkisxn a owl:DatatypeProperty ;
-    :category ls:composite, :pending, :searchfilter ;
+    :category ls:composite, :pending ;
     rdfs:label "LINKISXN" ;
     owl:propertyChainAxiom ( [ rdfs:subPropertyOf :identifiedBy ; rdfs:domain :Instance ] marc:incorrectIssn ),
         ( [ rdfs:subPropertyOf :identifiedBy ; rdfs:domain :Instance ] marc:canceledIssn ),

--- a/source/vocab/libris-search-experimental.ttl
+++ b/source/vocab/libris-search-experimental.ttl
@@ -10,29 +10,10 @@
 @prefix marc: <https://id.kb.se/marc/> .
 
 ### Extended definitions for Libris Search ###
+
 :identifier # See ./details.ttl for full definition of :identifier
     :category :searchfilter ;
     skos:notation "dc.identifier"^^ls:QueryCode .
-
-:isbn rdfs:domain :Instance ; # See ./details.ttl for full definition of :isbn
-    :category :searchfilter ;
-    skos:notation "bath.isbn"^^ls:QueryCode ;
-    rdfs:subPropertyOf ls:isxn .
-
-:ismn rdfs:domain :Instance ; # See ./details.ttl for full definition of :ismn
-    :category :searchfilter ;
-    rdfs:subPropertyOf ls:isxn .
-
-# TODO cataloging also searches identifiedBy / marc:canceledIssn, marc:incorrectIssn, marc:issnL, marc:canceledIssnL
-# webbsök has FELN / LINKISXN
-:issn rdfs:domain :Instance ; # See ./details.ttl for full definition of :issn
-    :category :searchfilter ;
-    skos:notation "bath.issn"^^ls:QueryCode ;
-    rdfs:subPropertyOf ls:isxn .
-
-:lccn rdfs:domain :Instance ; # See ./details.ttl for full definition of :lccn
-    :category :searchfilter ;
-    skos:notation "bath.lccn"^^ls:QueryCode .
 
 :seriesMembership :category :searchfilter . # See ./relations.ttl for full definition of :seriesMembership
 
@@ -101,6 +82,7 @@
 
 :textQuery skos:notation "cql.anywhere"^^ls:QueryCode . # See ./platform.ttl for full definition of :textQuery
 
+
 ### New definitions for Libris Search ###
 
 ## Auxiliary definitions
@@ -128,7 +110,11 @@ ls:merged a skos:Collection ;
 ls:merges a owl:ObjectProperty ;
     :category :pending .
 
-## Record search filters
+ls:indexKey a owl:DatatypeProperty ;
+    :category :pending .
+
+
+## Record
 
 ls:recordControlNumber a owl:DatatypeProperty ;
     :category :searchfilter, :shorthand, :pending ;
@@ -179,10 +165,247 @@ ls:recordType a owl:ObjectProperty;
     :category :shorthand, :pending ;
     owl:propertyChainAxiom ( :meta rdf:type ) .
 
+
+## Creation (Work/Instance)
+
+ls:title a owl:ObjectProperty ;
+    :category :searchfilter, ls:composite, :pending ;
+    rdfs:label "titel"@sv, "title"@en ;
+    skos:notation "TIT"^^ls:QueryCode ;
+    skos:notation "bath.title"^^ls:QueryCode ;
+    skos:notation "dc.title"^^ls:QueryCode ; # TODO only hasTitle?
+    skos:notation "HTIT"^^ls:QueryCode ; # "Titel" - drop specificity
+    skos:notation "WUTI"^^ls:QueryCode ; # "Uniform titel (ordindex)" - drop specificity
+    owl:propertyChainAxiom ( :translationOf :hasTitle ),
+        ( :seriesMembership :inSeries :instanceOf :hasTitle ),
+        ( :relationship :entity :hasTitle ) .
+
+
+## Work
+
+ls:workType a owl:ObjectProperty ;
+    :category :impliedByObject, :pending ;
+    rdfs:domain :Work ;
+    ls:indexKey "@type" .
+
+ls:originalLanguage a owl:ObjectProperty ;
+    rdfs:label "originalspråk"@sv, "original language"@en ;
+    rdfs:comment "Språk som resursen översatts från."@sv, "Language that resource was translated from."@en;
+    skos:notation "ÖVERS"^^ls:QueryCode ;
+    # skos:notation "ORIG"^^ls:QueryCode ; # TODO deprecate?
+    # skos:notation "TRANS"^^ls:QueryCode ; # TODO deprecate?
+    # skos:notation "TRANSLATION"^^ls:QueryCode ; # TODO deprecate?
+    :category :searchfilter, :shorthand, :pending ;
+    rdfs:domain :Work ;
+    rdfs:range :Language ;
+    owl:propertyChainAxiom ( :translationOf :language ) .
+
+ls:workCategory a owl:ObjectProperty ;
+    :category :searchfilter, :impliedByObject, :pending, ls:composite ;
+    rdfs:label "kategori"@sv, "category"@en ;
+    rdfs:domain :Work ;
+    rdfs:range :WorkCategory .
+
+ls:findCategory a owl:ObjectProperty ;
+    :category :pending, ls:coercing ;
+    rdfs:subPropertyOf ls:workCategory ;
+    rdfs:range [ rdfs:subClassOf [ a owl:Restriction ; owl:onProperty :inCollection ; owl:hasValue <https://id.kb.se/term/div/find> ] ] ;
+    ls:indexKey "_categoryByCollection.find" .
+
+ls:identifyCategory a owl:ObjectProperty ;
+    :category :pending, ls:coercing ;
+    rdfs:subPropertyOf ls:workCategory ;
+    rdfs:range [ rdfs:subClassOf [ a owl:Restriction ; owl:onProperty :inCollection ; owl:hasValue <https://id.kb.se/term/div/identify> ] ] ;
+    ls:indexKey "_categoryByCollection.identify" .
+
+ls:noneCategory a :ObjectProperty ;
+    :category :pending, ls:coercing ;
+    rdfs:subPropertyOf ls:workCategory ;
+    rdfs:range [ rdfs:subClassOf [ a owl:Restriction;
+            owl:onProperty :inCollection;
+            owl:allValuesFrom [ owl:complementOf [ owl:oneOf ( <https://id.kb.se/term/div/find> <https://id.kb.se/term/div/identify> ) ] ] ] ] ;
+    ls:indexKey "_categoryByCollection.@none" .
+
+ls:schemeCode a owl:DatatypeProperty ;
+    :category :shorthand, :pending ;
+    owl:propertyChainAxiom ( :inScheme :code ) .
+
+ls:sab a owl:DatatypeProperty ;
+    :category :shorthand, :pending, :searchfilter ;
+    rdfs:label "SAB-klassifikation"@sv, "SAB classification"@en ;
+    ls:indexKey "classification._sab" ;
+    sdo:domainIncludes :Work ;
+    owl:propertyChainAxiom (
+        [
+            rdfs:subPropertyOf :classification ;
+            rdfs:range [
+                rdfs:subClassOf [
+                    a owl:Restriction ;
+                    owl:onProperty ls:schemeCode ;
+                    owl:hasValue "kssb"
+                ]
+            ]
+        ]
+        :code
+    ) .
+
+ls:dewey a owl:DatatypeProperty ;
+    :category ls:merged, :pending, :searchfilter ;
+    rdfs:label "Dewey-klassifikation"@sv, "Dewey classification"@en ;
+    skos:notation "DDC"^^ls:QueryCode,
+        "DDC2"^^ls:QueryCode,
+        "DDK"^^ls:QueryCode ;
+    sdo:domainIncludes :Work ;
+    ls:merges [ owl:propertyChainAxiom ( :additionalClassificationDdc :code ) ],
+        [
+            owl:propertyChainAxiom (
+                [
+                    rdfs:subPropertyOf :classification ;
+                    rdfs:range :ClassificationDdc
+                ]
+                :code
+            )
+        ] .
+
+ls:udc a owl:DatatypeProperty ;
+    :category :shorthand, :pending, :searchfilter ;
+    rdfs:label "UDK-klassifikation"@sv, "UDC classification"@en ;
+    ls:indexKey "classification._udc" ;
+    sdo:domainIncludes :Work ;
+    owl:propertyChainAxiom (
+        [
+            rdfs:subPropertyOf :classification ;
+            rdfs:range :ClassificationUdc
+        ]
+        :code
+    ) .
+
+ls:nlm a owl:DatatypeProperty ;
+    :category :shorthand, :pending, :searchfilter ;
+    rdfs:label "NLM-klassifikation"@sv, "NLM classification"@en ;
+    ls:indexKey "classification._nlm" ;
+    sdo:domainIncludes :Work ;
+    owl:propertyChainAxiom (
+        [
+            rdfs:subPropertyOf :classification ;
+            rdfs:range :ClassificationNlm
+        ]
+        :code
+    ) .
+
+ls:lcc a owl:DatatypeProperty ;
+    :category :shorthand, :pending, :searchfilter ;
+    rdfs:label "LC-klassifikation"@sv, "LCC classification"@en ;
+    ls:indexKey "classification._lcc" ;
+    sdo:domainIncludes :Work ;
+    owl:propertyChainAxiom (
+        [
+            rdfs:subPropertyOf :classification ;
+            rdfs:range :ClassificationLcc
+        ]
+        :code
+    ) .
+
+
+## Instance
+
+ls:instanceType a owl:ObjectProperty ;
+    :category :impliedByObject, :pending ;
+    rdfs:domain :Instance ;
+    ls:indexKey "@type" .
+
+ls:instanceCategory a owl:ObjectProperty ;
+    :category :searchfilter, :impliedByObject, :pending ;
+    rdfs:label "format"@sv, "format"@en ;
+    rdfs:domain :Instance ;
+    rdfs:range :InstanceCategory ;
+    ls:indexKey "_categoryByCollection.@none" .
+
+ls:linkisxn a owl:DatatypeProperty ;
+    :category ls:composite, :pending, :searchfilter ;
+    rdfs:label "LINKISXN" ;
+    owl:propertyChainAxiom ( [ rdfs:subPropertyOf :identifiedBy ; rdfs:domain :Instance ] marc:incorrectIssn ),
+        ( [ rdfs:subPropertyOf :identifiedBy ; rdfs:domain :Instance ] marc:canceledIssn ),
+        ( [ rdfs:subPropertyOf :indirectlyIdentifiedBy ; rdfs:domain :Instance ] :value ) .
+
 ls:isxn a owl:DatatypeProperty ;
     :category ls:composite, :pending, :searchfilter ;
     skos:notation "NUMM"^^ls:QueryCode ;
-    rdfs:label "ISXN"@sv, "ISXN"@en .
+    rdfs:label "ISXN"@sv, "ISXN"@en ;
+    rdfs:subPropertyOf ls:linkisxn .
+
+ls:isbn a owl:DatatypeProperty ;
+    :category :searchfilter, :shorthand, :pending ;
+    rdfs:label "ISBN";
+    skos:notation "bath.isbn"^^ls:QueryCode ;
+    rdfs:subPropertyOf ls:isxn ;
+    rdfs:domain :Instance ;
+    owl:propertyChainAxiom ( [ rdfs:subPropertyOf :identifiedBy ; rdfs:domain :Instance ; rdfs:range :ISBN ] :value ) .
+
+ls:ismn a owl:DatatypeProperty ;
+    :category :searchfilter, :shorthand, :pending ;
+    rdfs:label "ISMN";
+    rdfs:subPropertyOf ls:isxn ;
+    rdfs:domain :Instance ;
+    owl:propertyChainAxiom ( [ rdfs:subPropertyOf :identifiedBy ; rdfs:domain :Instance ; rdfs:range :ISMN ] :value ) .
+
+# TODO cataloging also searches identifiedBy / marc:canceledIssn, marc:incorrectIssn, marc:issnL, marc:canceledIssnL
+ls:issn rdfs:domain :Instance ;
+    :category :searchfilter, :shorthand, :pending ;
+    rdfs:label "ISSN";
+    skos:notation "bath.issn"^^ls:QueryCode ;
+    rdfs:subPropertyOf ls:isxn ;
+    rdfs:domain :Instance ;
+    owl:propertyChainAxiom ( [ rdfs:subPropertyOf :identifiedBy ; rdfs:domain :Instance ; rdfs:range :ISSN ] :value ) .
+
+ls:lccn rdfs:domain :Instance ;
+    :category :searchfilter, :shorthand, :pending ;
+    rdfs:label "LCCN";
+    skos:notation "bath.lccn"^^ls:QueryCode ;
+    rdfs:subPropertyOf ls:isxn ;
+    rdfs:domain :Instance ;
+    owl:propertyChainAxiom ( [ rdfs:subPropertyOf :identifiedBy ; rdfs:domain :Instance ; rdfs:range :LCCN ] :value ) .
+
+ls:year a owl:DatatypeProperty ;
+    :category ls:merged, :pending ;
+    ls:merges :year, :startYear .
+
+ls:yearPublished a owl:DatatypeProperty ;
+    :category :searchfilter, :shorthand, :pending ;
+    rdfs:label "utgivningsår"@sv, "year of publication"@en ;
+    rdfs:domain :Instance ;
+    skos:notation "ÅR"^^ls:QueryCode,
+                  "dc.date"^^ls:QueryCode,
+                  "AR1"^^ls:QueryCode;
+    owl:propertyChainAxiom ( :publication ls:year ) .
+
+ls:publicationPlace a owl:ObjectProperty;
+    :category ls:composite, :searchfilter, :pending ;
+    rdfs:label "utgivningsort"@sv, "place of publication"@en ;
+    sdo:domainIncludes :Instance ;
+    rdfs:range :Place ;
+    owl:propertyChainAxiom ( :publication :place ), ( :publication :hasPart :place ) .
+
+ls:publicationCountry a owl:ObjectProperty;
+    :category :shorthand, :searchfilter, :impliedByObject, :pending ;
+    rdfs:label "utgivningsland"@sv, "country of publication"@en ;
+    skos:notation "LAND"^^ls:QueryCode ;
+    sdo:domainIncludes :Instance ;
+    rdfs:range :Country ;
+    owl:propertyChainAxiom ( :publication :country ) .
+
+ls:publisher a owl:ObjectProperty;
+    :category ls:composite, :searchfilter, :pending ;
+    rdfs:label "utgivare"@sv, "publisher"@en ;
+    sdo:domainIncludes :Instance ;
+    skos:notation "dc.publisher"^^ls:QueryCode,
+        "FÖRLAG"^^ls:QueryCode,
+        "FÖRL"^^ls:QueryCode,
+        "FORL"^^ls:QueryCode ;
+    owl:propertyChainAxiom ( :publication :agent ), ( :publication :hasPart :agent ) .
+
+
+## Item
 
 ls:library a owl:ObjectProperty ;
    :category :searchfilter, :impliedByObject, ls:composite, :pending ;
@@ -210,76 +433,6 @@ ls:itemHeldByOrg a owl:ObjectProperty ;
     rdfs:range bibdb:Organization ;
     ls:indexKey "@reverse.itemOf.heldBy.isPartOf" ; # FIXME: Implement support for ls:coercing + :shorthand in XL
     owl:propertyChainAxiom ( :hasItem :heldBy :isPartOf ) .
-
-ls:workType a owl:ObjectProperty ;
-    :category :impliedByObject, :pending ;
-    rdfs:domain :Work ;
-    ls:indexKey "@type" .
-
-ls:instanceType a owl:ObjectProperty ;
-    :category :impliedByObject, :pending ;
-    rdfs:domain :Instance ;
-    ls:indexKey "@type" .
-
-ls:originalLanguage a owl:ObjectProperty ;
-    rdfs:label "originalspråk"@sv, "original language"@en ;
-    rdfs:comment "Språk som resursen översatts från."@sv, "Language that resource was translated from."@en;
-    skos:notation "ÖVERS"^^ls:QueryCode ;
-    # skos:notation "ORIG"^^ls:QueryCode ; # TODO deprecate?
-    # skos:notation "TRANS"^^ls:QueryCode ; # TODO deprecate?
-    # skos:notation "TRANSLATION"^^ls:QueryCode ; # TODO deprecate?
-    :category :searchfilter, :shorthand, :pending ;
-    rdfs:domain :Work ;
-    rdfs:range :Language ;
-    owl:propertyChainAxiom ( :translationOf :language ) .
-
-ls:indexKey a owl:DatatypeProperty ;
-    :category :pending .
-
-ls:workCategory a owl:ObjectProperty ;
-    :category :searchfilter, :impliedByObject, :pending, ls:composite ;
-    rdfs:label "kategori"@sv, "category"@en ;
-    rdfs:domain :Work ;
-    rdfs:range :WorkCategory .
-
-ls:instanceCategory a owl:ObjectProperty ;
-    :category :searchfilter, :impliedByObject, :pending ;
-    rdfs:label "format"@sv, "format"@en ;
-    rdfs:domain :Instance ;
-    rdfs:range :InstanceCategory ;
-    ls:indexKey "_categoryByCollection.@none" .
-
-ls:findCategory a owl:ObjectProperty ;
-    :category :pending, ls:coercing ;
-    rdfs:subPropertyOf ls:workCategory ;
-    rdfs:range [ rdfs:subClassOf [ a owl:Restriction ; owl:onProperty :inCollection ; owl:hasValue <https://id.kb.se/term/div/find> ] ] ;
-    ls:indexKey "_categoryByCollection.find" .
-
-ls:identifyCategory a owl:ObjectProperty ;
-    :category :pending, ls:coercing ;
-    rdfs:subPropertyOf ls:workCategory ;
-    rdfs:range [ rdfs:subClassOf [ a owl:Restriction ; owl:onProperty :inCollection ; owl:hasValue <https://id.kb.se/term/div/identify> ] ] ;
-    ls:indexKey "_categoryByCollection.identify" .
-
-ls:noneCategory a :ObjectProperty ;
-    :category :pending, ls:coercing ;
-    rdfs:subPropertyOf ls:workCategory ;
-    rdfs:range [ rdfs:subClassOf [ a owl:Restriction;
-            owl:onProperty :inCollection;
-            owl:allValuesFrom [ owl:complementOf [ owl:oneOf ( <https://id.kb.se/term/div/find> <https://id.kb.se/term/div/identify> ) ] ] ] ] ;
-    ls:indexKey "_categoryByCollection.@none" .
-
-ls:title a owl:ObjectProperty ;
-    :category :searchfilter, ls:composite, :pending ;
-    rdfs:label "titel"@sv, "title"@en ;
-    skos:notation "TIT"^^ls:QueryCode ;
-    skos:notation "bath.title"^^ls:QueryCode ;
-    skos:notation "dc.title"^^ls:QueryCode ; # TODO only hasTitle?
-    skos:notation "HTIT"^^ls:QueryCode ; # "Titel" - drop specificity
-    skos:notation "WUTI"^^ls:QueryCode ; # "Uniform titel (ordindex)" - drop specificity
-    owl:propertyChainAxiom ( :translationOf :hasTitle ),
-        ( :seriesMembership :inSeries :instanceOf :hasTitle ),
-        ( :relationship :entity :hasTitle ) .
 
 ls:itemInformation a owl:DatatypeProperty ;
       :category :searchfilter, ls:composite, :pending ;
@@ -367,122 +520,3 @@ ls:itemSubject a owl:ObjectProperty ;
      rdfs:label "lokalt ämnesord"@sv, "item subject"@en ;
      rdfs:domain :Instance ;
      owl:propertyChainAxiom ( :hasItem :subject ) .
-
-ls:year a owl:DatatypeProperty ;
-    :category ls:merged, :pending ;
-    ls:merges :year, :startYear .
-
-ls:yearPublished a owl:DatatypeProperty ;
-    :category :searchfilter, :shorthand, :pending ;
-    rdfs:label "utgivningsår"@sv, "year of publication"@en ;
-    rdfs:domain :Instance ;
-    skos:notation "ÅR"^^ls:QueryCode,
-                  "dc.date"^^ls:QueryCode,
-                  "AR1"^^ls:QueryCode;
-    owl:propertyChainAxiom ( :publication ls:year ) .
-
-ls:publicationPlace a owl:ObjectProperty;
-    :category ls:composite, :searchfilter, :pending ;
-    rdfs:label "utgivningsort"@sv, "place of publication"@en ;
-    sdo:domainIncludes :Instance ;
-    rdfs:range :Place ;
-    owl:propertyChainAxiom ( :publication :place ), ( :publication :hasPart :place ) .
-
-ls:publicationCountry a owl:ObjectProperty;
-    :category :shorthand, :searchfilter, :impliedByObject, :pending ;
-    rdfs:label "utgivningsland"@sv, "country of publication"@en ;
-    skos:notation "LAND"^^ls:QueryCode ;
-    sdo:domainIncludes :Instance ;
-    rdfs:range :Country ;
-    owl:propertyChainAxiom ( :publication :country ) .
-
-ls:publisher a owl:ObjectProperty;
-    :category ls:composite, :searchfilter, :pending ;
-    rdfs:label "utgivare"@sv, "publisher"@en ;
-    sdo:domainIncludes :Instance ;
-    skos:notation "dc.publisher"^^ls:QueryCode,
-        "FÖRLAG"^^ls:QueryCode,
-        "FÖRL"^^ls:QueryCode,
-        "FORL"^^ls:QueryCode ;
-    owl:propertyChainAxiom ( :publication :agent ), ( :publication :hasPart :agent ) .
-
-# Auxiliary
-ls:schemeCode a owl:DatatypeProperty ;
-    :category :shorthand, :pending ;
-    owl:propertyChainAxiom ( :inScheme :code ) .
-
-ls:sab a owl:DatatypeProperty ;
-    :category :shorthand, :pending, :searchfilter ;
-    rdfs:label "SAB-klassifikation"@sv, "SAB classification"@en ;
-    ls:indexKey "classification._sab" ;
-    sdo:domainIncludes :Work ;
-    owl:propertyChainAxiom (
-        [
-            rdfs:subPropertyOf :classification ;
-            rdfs:range [
-                rdfs:subClassOf [
-                    a owl:Restriction ;
-                    owl:onProperty ls:schemeCode ;
-                    owl:hasValue "kssb"
-                ]
-            ]
-        ]
-        :code
-    ) .
-
-ls:dewey a owl:DatatypeProperty ;
-    :category ls:merged, :pending, :searchfilter ;
-    rdfs:label "Dewey-klassifikation"@sv, "Dewey classification"@en ;
-    skos:notation "DDC"^^ls:QueryCode,
-        "DDC2"^^ls:QueryCode,
-        "DDK"^^ls:QueryCode ;
-    sdo:domainIncludes :Work ;
-    ls:merges [ owl:propertyChainAxiom ( :additionalClassificationDdc :code ) ],
-        [
-            owl:propertyChainAxiom (
-                [
-                    rdfs:subPropertyOf :classification ;
-                    rdfs:range :ClassificationDdc
-                ]
-                :code
-            )
-        ] .
-
-ls:udc a owl:DatatypeProperty ;
-    :category :shorthand, :pending, :searchfilter ;
-    rdfs:label "UDK-klassifikation"@sv, "UDC classification"@en ;
-    ls:indexKey "classification._udc" ;
-    sdo:domainIncludes :Work ;
-    owl:propertyChainAxiom (
-        [
-            rdfs:subPropertyOf :classification ;
-            rdfs:range :ClassificationUdc
-        ]
-        :code
-    ) .
-
-ls:nlm a owl:DatatypeProperty ;
-    :category :shorthand, :pending, :searchfilter ;
-    rdfs:label "NLM-klassifikation"@sv, "NLM classification"@en ;
-    ls:indexKey "classification._nlm" ;
-    sdo:domainIncludes :Work ;
-    owl:propertyChainAxiom (
-        [
-            rdfs:subPropertyOf :classification ;
-            rdfs:range :ClassificationNlm
-        ]
-        :code
-    ) .
-
-ls:lcc a owl:DatatypeProperty ;
-    :category :shorthand, :pending, :searchfilter ;
-    rdfs:label "LC-klassifikation"@sv, "LCC classification"@en ;
-    ls:indexKey "classification._lcc" ;
-    sdo:domainIncludes :Work ;
-    owl:propertyChainAxiom (
-        [
-            rdfs:subPropertyOf :classification ;
-            rdfs:range :ClassificationLcc
-        ]
-        :code
-    ) .

--- a/source/vocab/libris-search-experimental.ttl
+++ b/source/vocab/libris-search-experimental.ttl
@@ -53,9 +53,6 @@
     skos:notation "WFRF"^^ls:QueryCode ;
     skos:notation "WINS"^^ls:QueryCode .
 
-:bibliography # See ./agents.ttl for full definition of :bibliography
-    skos:notation "DB"^^ls:QueryCode .
-
 # NOTE: Old webbsök code 'author' was same as 'FÖRF'
 :author a owl:ObjectProperty ;
     :category :searchfilter, ls:preferLike, :shorthand, :pending ;
@@ -100,21 +97,13 @@
     :category :searchfilter, :impliedByObject ;
     skos:notation "ART"^^ls:QueryCode .
 
-:controlNumber # See ./platform.ttl for full definition of :controlNumber
-    :category :searchfilter ;
-    skos:notation "ONR"^^ls:QueryCode ;
-    # rec.recordIdentifier is used A LOT in Libris SRU
-    # it looks like its part of "Record Metadata Context Set" based on the prefix. But it is not.
-    # https://web.archive.org/web/20130515105512/https://srw.cheshire3.org/contextSets/rec/1.1/
-    # Webbsök SRU does not support rec.id (from Bath profile) or rec.identifier
-    skos:notation "rec.recordIdentifier"^^ls:QueryCode ;
-    skos:notation "BIBID"^^ls:QueryCode .
-
 :hasTitle rdfs:subPropertyOf ls:title . # See ./details.ttl for full definition of :hasTitle
 
 :textQuery skos:notation "cql.anywhere"^^ls:QueryCode . # See ./platform.ttl for full definition of :textQuery
 
 ### New definitions for Libris Search ###
+
+## Auxiliary definitions
 
 ls:QueryCode a rdfs:Datatype ;
     :category :pending .
@@ -138,6 +127,53 @@ ls:merged a skos:Collection ;
 # TODO: add e.g. label, domain, comment
 ls:merges a owl:ObjectProperty ;
     :category :pending .
+
+## Record search filters
+
+ls:recordControlNumber a owl:DatatypeProperty ;
+    :category :searchfilter, :shorthand, :pending ;
+    rdfs:label "control number"@en, "kontrollnummer"@sv ;
+    skos:notation "ONR"^^ls:QueryCode,
+    # rec.recordIdentifier is used A LOT in Libris SRU
+    # it looks like its part of "Record Metadata Context Set" based on the prefix. But it is not.
+    # https://web.archive.org/web/20130515105512/https://srw.cheshire3.org/contextSets/rec/1.1/
+    # Webbsök SRU does not support rec.id (from Bath profile) or rec.identifier
+        "rec.recordIdentifier"^^ls:QueryCode,
+        "BIBID"^^ls:QueryCode ;
+    owl:propertyChainAxiom ( :meta :controlNumber ) .
+
+ls:instanceRecordModified a owl:DatatypeProperty ;
+     :category :searchfilter, :shorthand, :pending ;
+     rdfs:label "uppdateringsdatum (instans)"@sv, "modified date (instance)"@en ;
+     rdfs:comment "Datum när bibliografisk post uppdaterades."@sv, "Date when bibliographic record was updated."@en;
+     rdfs:domain :Instance ;
+     skos:notation "BDAT"^^ls:QueryCode ;
+     rdfs:range xsd:dateTime ;
+     owl:propertyChainAxiom ( [ rdfs:subPropertyOf :meta ; rdfs:domain :Instance ] :modified ) .
+
+ls:instanceRecordCreated a owl:DatatypeProperty ;
+     :category :searchfilter, :shorthand, :pending ;
+     rdfs:label "registreringsdatum (instans)"@sv, "created date (instance)"@en ;
+     rdfs:comment "Datum när bibliografisk post skapades."@sv, "Date when bibliographic record was created."@en;
+     rdfs:domain :Instance ;
+     skos:notation "DAT"^^ls:QueryCode ;
+     rdfs:range xsd:dateTime ;
+     owl:propertyChainAxiom ( [ rdfs:subPropertyOf :meta ; rdfs:domain :Instance ] :created ) .
+
+ls:bibliography a owl:ObjectProperty ;
+    :category :searchfilter, :shorthand, :impliedByObject, :pending ;
+    rdfs:label "in bibliography"@en, "ingår i bibliografi"@sv ;
+    skos:notation "DB"^^ls:QueryCode ;
+    rdfs:domain :Instance ;
+    rdfs:range :Bibliography ;
+    owl:propertyChainAxiom ( [ rdfs:subPropertyOf :meta ; rdfs:domain :Instance ] :bibliography ) .
+
+ls:encodingLevel a owl:ObjectProperty;
+    :category :shorthand, :pending ;
+    rdfs:label "Encoding level"@en, "Beskrivningsnivå"@sv ;
+    rdfs:domain :Instance ;
+    rdfs:range marc:EncLevelType ;
+    owl:propertyChainAxiom ( [ rdfs:subPropertyOf :meta ; rdfs:domain :Instance ] :encodingLevel ) .
 
 ls:isxn a owl:DatatypeProperty ;
     :category ls:composite, :pending, :searchfilter ;
@@ -320,24 +356,6 @@ ls:itemRecordCreated a owl:DatatypeProperty ;
      skos:notation "FORVDAT"^^ls:QueryCode ;
      rdfs:range xsd:dateTime ;
      owl:propertyChainAxiom ( :hasItem :meta :created ) .
-
-ls:instanceRecordModified a owl:DatatypeProperty ;
-     :category :searchfilter, :shorthand, :pending ;
-     rdfs:label "uppdateringsdatum (instans)"@sv, "modified date (instance)"@en ;
-     rdfs:comment "Datum när bibliografisk post uppdaterades."@sv, "Date when bibliographic record was updated."@en;
-     rdfs:domain :Instance ;
-     skos:notation "BDAT"^^ls:QueryCode ;
-     rdfs:range xsd:dateTime ;
-     owl:propertyChainAxiom ( [ rdfs:subPropertyOf :meta ; rdfs:domain :Instance ] :modified ) .
-
-ls:instanceRecordCreated a owl:DatatypeProperty ;
-     :category :searchfilter, :shorthand, :pending ;
-     rdfs:label "registreringsdatum (instans)"@sv, "created date (instance)"@en ;
-     rdfs:comment "Datum när bibliografisk post skapades."@sv, "Date when bibliographic record was created."@en;
-     rdfs:domain :Instance ;
-     skos:notation "DAT"^^ls:QueryCode ;
-     rdfs:range xsd:dateTime ;
-     owl:propertyChainAxiom ( [ rdfs:subPropertyOf :meta ; rdfs:domain :Instance ] :created ) .
 
 ls:itemSubject a owl:ObjectProperty ;
      :category :searchfilter, :shorthand, :pending ;

--- a/source/vocab/libris-search-experimental.ttl
+++ b/source/vocab/libris-search-experimental.ttl
@@ -563,4 +563,5 @@ ls:itemSubject a owl:ObjectProperty ;
      rdfs:subPropertyOf ls:itemInformation ;
      rdfs:label "lokalt ämnesord"@sv, "item subject"@en ;
      rdfs:domain :Instance ;
+     sdo:rangeIncludes :BibliographicAgent, :Subject, :Work ;
      owl:propertyChainAxiom ( :hasItem :subject ) .

--- a/source/vocab/libris-search-experimental.ttl
+++ b/source/vocab/libris-search-experimental.ttl
@@ -58,6 +58,7 @@ ls:composite a skos:Collection ;
     :code "composite" .
 
 ls:preferLike a skos:Collection ;
+    :category :pending ;
     :code "preferLike" .
 
 ls:coercing a skos:Collection ;
@@ -133,18 +134,19 @@ ls:recordType a owl:ObjectProperty;
 ls:title a owl:ObjectProperty ;
     :category :searchfilter, ls:composite, :pending ;
     rdfs:label "titel"@sv, "title"@en ;
-        "TIT"^^ls:QueryCode,
+    skos:notation "TIT"^^ls:QueryCode,
         "bath.title"^^ls:QueryCode,
         "dc.title"^^ls:QueryCode, # TODO only hasTitle?
         "HTIT"^^ls:QueryCode, # "Titel" - drop specificity
-        "WUTI"^^ls:QueryCode, # "Uniform titel (ordindex)" - drop specificity
+        "WUTI"^^ls:QueryCode ; # "Uniform titel (ordindex)" - drop specificity
     sdo:domainIncludes :Creation ;
     owl:propertyChainAxiom ( :translationOf :hasTitle ),
         ( :seriesMembership :inSeries :instanceOf :hasTitle ),
-        ( :relationship :entity :hasTitle ) .
+        ( :relationship :entity :hasTitle ),
+        ( :hasPart :hasTitle ) .
 
 ls:contributor a owl:ObjectProperty ;
-    :category :searchfilter, :shorthand, ls:composite, :impliedByObject, ls:preferLike ;
+    :category :searchfilter, :shorthand, ls:composite, :impliedByObject, ls:preferLike, :pending ;
     rdfs:label "Author/Contributor"@en, "Författare/upphov"@sv ;
     skos:notation "dc.author"^^ls:QueryCode,
         "dc.contributor"^^ls:QueryCode,
@@ -156,30 +158,70 @@ ls:contributor a owl:ObjectProperty ;
         "WINS"^^ls:QueryCode ;
     sdo:domainIncludes :Creation ;
     sdo:rangeIncludes :BibliographicAgent ;
-    owl:propertyChainAxiom ( :contribution :agent ) .
+    owl:propertyChainAxiom ( :contribution :agent ),
+        ( [ rdfs:subPropertyOf :hasPart ; rdfs:domain :Work ] :contribution :agent ),
+        ( [ rdfs:subPropertyOf :relationship ; rdfs:domain :Work ] :entity :contribution :agent ) .
+
+_:authorContribution rdfs:subPropertyOf :contribution ;
+    rdfs:domain :Work ;
+    rdfs:range [
+        rdfs:subClassOf [
+            a owl:Restriction ;
+            owl:onProperty :role ;
+            owl:hasValue <https://id.kb.se/relator/author>
+        ]
+    ] .
 
 # NOTE: Old webbsök code 'author' was same as 'FÖRF'
 ls:author a owl:ObjectProperty ;
-    :category :searchfilter, ls:preferLike, :shorthand, :pending ;
+    :category ls:preferLike, ls:composite, :pending ;
     rdfs:label "författare"@sv, "author"@en ;
-    sdo:domainIncludes :Work ;
+    rdfs:domain :Work ;
     sdo:rangeIncludes :BibliographicAgent ;
     owl:propertyChainAxiom (
-            [ rdfs:subPropertyOf :contribution ; rdfs:range [ rdfs:subClassOf [ a owl:Restriction ;
-                owl:onProperty :role ;
-                owl:hasValue <https://id.kb.se/relator/author> ] ] ]
+            _:authorContribution
+            :agent
+        ),
+        (
+            [ rdfs:subPropertyOf :hasPart ; rdfs:domain :Work ]
+            _:authorContribution
+            :agent
+        ),
+        (
+            [ rdfs:subPropertyOf :relationship ; rdfs:domain :Work ]
+            :entity
+            _:authorContribution
             :agent
         ) .
 
+_:translatorContribution rdfs:subPropertyOf :contribution ;
+    rdfs:domain :Work ;
+    rdfs:range [
+        rdfs:subClassOf [
+            a owl:Restriction ;
+            owl:onProperty :role ;
+            owl:hasValue <https://id.kb.se/relator/translator>
+        ]
+    ] .
+
 ls:translator a owl:ObjectProperty ;
-    :category :searchfilter, ls:preferLike, :shorthand, :pending ;
+    :category ls:preferLike, ls:composite, :pending ;
     rdfs:label "översättare"@sv, "translator"@en ;
     sdo:domainIncludes :Work ;
     sdo:rangeIncludes :BibliographicAgent ;
     owl:propertyChainAxiom (
-            [ rdfs:subPropertyOf :contribution ; rdfs:range [ rdfs:subClassOf [ a owl:Restriction ;
-                owl:onProperty :role ;
-                owl:hasValue <https://id.kb.se/relator/translator> ] ] ]
+            _:translatorContribution
+            :agent
+        ),
+        (
+            [ rdfs:subPropertyOf :hasPart ; rdfs:domain :Work ]
+            _:translatorContribution
+            :agent
+        ),
+        (
+            [ rdfs:subPropertyOf :relationship ; rdfs:domain :Work ]
+            :entity
+            _:translatorContribution
             :agent
         ) .
 

--- a/sys/context/kbv.jsonld
+++ b/sys/context/kbv.jsonld
@@ -242,6 +242,7 @@
     "librissearch:internalItemNote": {"@container": "@set"},
     "librissearch:itemStatement": {"@container": "@set"},
     "librissearch:shelf": {"@container": "@set"},
+    "librissearch:encodingLevel": {"@type": "@vocab"},
 
     "marc": "https://id.kb.se/marc/",
 


### PR DESCRIPTION
Then main features here are:
- Widened scope for `ls:title` (now includes `hasPart.hasTitle`, `hasPart.translationOf.hasTitle`)
- New terms `ls:contributor`/`ls:author`/`ls:translator` (to include  `hasPart.contribution` and `relationship.contribution`)
- New term `ls:linkisxn` for searching `marc:incorrectIssn` / `marc:canceledIssn` / `:indirectlyIdentifiedBy` in addition to `isxn`
- Adjusted `excludePreliminary` filter to always allow linked works through.
    - These were previously filtered out incorrectly: https://api.triplydb.com/s/iEhP8sk61
    - This case will now pass the filter but that seems acceptable :slightly_smiling_face: 
    https://api.triplydb.com/s/hr8KrnhMB

Also includes:
- Record search terms defined in the `librissearch:` namespace for better control over query expansion without having to mess with their `kbv:` counterparts.
- Restructuring of the `.ttl` file
- Minor fixes discovered while testing

Related changes:
- https://github.com/libris/lxl_api_tests/pull/50
- https://github.com/libris/librisxl/pull/1780
- https://github.com/libris/lxlviewer/tree/feature/locales

TODO/Questions (nothing urgent, just noted things):
- Should `indirectyIdentifiedBy` be included directly in `:isbn`? (and `marc:canceledIssn` / `marc:incorrectIssn`  in `:issn`). I think that would make sense, although it would mean `:isxn` == `:linkisixn`, which differs from webbsök.  
- Index `marc:canceledIssn` / `marc:incorrectIssn` as keyword in Elastic
- For uniformity, would it be better to define composite search filters for e.g. `seriesMembership` rather than relying on `_str`? That way we can display exactly which fields are being searched. 
