### PR TITLE
Make relation|relationship mappings explicit

### DIFF
--- a/source/vocab/bf-map.ttl
+++ b/source/vocab/bf-map.ttl
@@ -46,6 +46,12 @@ kbv:relatedTo owl:equivalentProperty bf2:relatedTo ;
     rdfs:domain kbv:Resource ; # NOTE: loosens implied bf2 domain
     rdfs:range kbv:Resource . # NOTE: loosens implied bf2 range
 
+# IMPORTANT: BF swapped these when incorporating from BFLC. We depend on the BFLC form!
+kbv:relationship owl:equivalentProperty bf2:relation .
+kbv:relation owl:equivalentProperty bf2:relationship .
+kbv:Relation owl:equivalentClass bf2:Relationship .
+kbv:Relationship owl:equivalentClass bf2:Relation .
+
 kbv:CODEN a rdfs:Datatype; owl:equivalentClass bf2:Coden .
 kbv:DOI a rdfs:Datatype; owl:equivalentClass bf2:Doi .
 kbv:EAN a rdfs:Datatype; owl:equivalentClass bf2:Ean .

--- a/source/vocab/relations.ttl
+++ b/source/vocab/relations.ttl
@@ -668,14 +668,14 @@
     rdfs:range :Relationship .
 
 :relation a owl:ObjectProperty;
-    rdfs:label "Relation"@sv;
+    rdfs:label "Relationstyp"@sv;
     rdfs:subPropertyOf :role;
     rdfs:domain :Relationship;
     rdfs:range :Relation ;
     owl:equivalentProperty prov:hadRole, bflc:relation .
 
 :Relation a owl:Class;
-    rdfs:label "Relation"@en, "Relation"@sv;
+    rdfs:label "Relation"@en, "Relationstyp"@sv;
     rdfs:subClassOf :ObjectProperty ;
     owl:equivalentClass bflc:Relation .
 


### PR DESCRIPTION
These were based on BFLC. Their eventual incorporation swapped the meaning of relation and relationship (both properties and classes). We keep the former meaning since we're in production with those.

This requires suppressing automatic mappings to BF.

(Note that the automatic mapping process needs to be replaced by a controlled update routine; but that's a separate change.)