### PR TITLE
Use proper IRIs for restricted contribution instead of blank nodes

### DIFF
--- a/source/vocab/libris-search-experimental.ttl
+++ b/source/vocab/libris-search-experimental.ttl
@@ -198,7 +198,9 @@ ls:contributor a owl:ObjectProperty ;
         ( [ rdfs:subPropertyOf :hasPart ; rdfs:domain :Work ] :contribution :agent ),
         ( [ rdfs:subPropertyOf :relationship ; rdfs:domain :Work ] :entity :contribution :agent ) .
 
-_:authorContribution rdfs:subPropertyOf :contribution ;
+ls:authorContribution a owl:ObjectProperty ;
+    :category :pending ;
+    rdfs:subPropertyOf :contribution ;
     rdfs:domain :Work ;
     rdfs:range [
         rdfs:subClassOf [
@@ -215,22 +217,24 @@ ls:author a owl:ObjectProperty ;
     rdfs:domain :Work ;
     sdo:rangeIncludes :BibliographicAgent ;
     owl:propertyChainAxiom (
-            _:authorContribution
+            ls:authorContribution
             :agent
         ),
         (
             [ rdfs:subPropertyOf :hasPart ; rdfs:domain :Work ]
-            _:authorContribution
+            ls:authorContribution
             :agent
         ),
         (
             [ rdfs:subPropertyOf :relationship ; rdfs:domain :Work ]
             :entity
-            _:authorContribution
+            ls:authorContribution
             :agent
         ) .
 
-_:translatorContribution rdfs:subPropertyOf :contribution ;
+ls:translatorContribution a owl:ObjectProperty ;
+    :category :pending ;
+    rdfs:subPropertyOf :contribution ;
     rdfs:domain :Work ;
     rdfs:range [
         rdfs:subClassOf [
@@ -246,18 +250,18 @@ ls:translator a owl:ObjectProperty ;
     sdo:domainIncludes :Work ;
     sdo:rangeIncludes :BibliographicAgent ;
     owl:propertyChainAxiom (
-            _:translatorContribution
+            ls:translatorContribution
             :agent
         ),
         (
             [ rdfs:subPropertyOf :hasPart ; rdfs:domain :Work ]
-            _:translatorContribution
+            ls:translatorContribution
             :agent
         ),
         (
             [ rdfs:subPropertyOf :relationship ; rdfs:domain :Work ]
             :entity
-            _:translatorContribution
+            ls:translatorContribution
             :agent
         ) .
 


### PR DESCRIPTION
FYI:
The XL dataset importer fails to handle these blank properties correctly, which causes test data reloads to fail (dev data is currently in a bad state). Instead of trying to fix it in XL we might as well define the terms with proper IRIs. Although these terms are not intended to be used as standalone terms, defining them is harmless since they are in the `librissearch:` namespace and set as `:pending`.