### PR TITLE
Add RDA term descriptions extracted from Box notes

### DIFF
--- a/scripts/oneoffs/rdabox2jsonld.py
+++ b/scripts/oneoffs/rdabox2jsonld.py
@@ -3,7 +3,7 @@ Convert RDA term lists in Box Notes to JSON-LD
 
 1. Download all lists from a given Box folder (here "Värdevokabulär") as a ZIP file.
 2. Run this script (pipe or redirect output as desired):
-        $ python scripts/rdabox2jsonld.py cache/Värdevokabulär.zip
+        $ python3 scripts/oneoffs/rdabox2jsonld.py cache/Värdevokabulär.zip | trld -ottl
 
 """
 from urllib.parse import quote
@@ -13,7 +13,8 @@ import re
 import sys
 
 
-def convert(doc, rtype):
+def convert(fname, doc):
+    folder_id, rtype = to_folder_and_type(fname)
     items = []
     for block in doc['content']:
         if block['type'] == 'table':
@@ -74,7 +75,7 @@ def convert(doc, rtype):
 
                 id_label = clean(label_en) or clean(label_sv)
 
-                r_id = label_to_slug(id_label)
+                r_id = folder_id + label_to_slug(id_label)
 
                 # NOTE: related_sv is probably superfluous
                 # (those labels *should* already be on the targets)
@@ -153,9 +154,18 @@ def find_with_content(items):
     return [item for item in items if 'content' in item]
 
 
-def to_type(fname):
-    fname = fname.rsplit('/')[-1].rsplit('.')[0]
-    return re.sub(r'\W', '', fname.title().replace(' ', ''))
+def to_folder_and_type(fname):
+    name = fname.rsplit('/')[-1].rsplit('.')[0].removesuffix('_')
+    name, paren, typenote = name.partition('(of an analog ')
+    if paren:
+        name = typenote.removesuffix(')') + ' ' + name
+    elif ' of ' in name:
+        kind, oftype = name.split(' of ', 1)
+        name = oftype.removesuffix('s') + ' ' + kind
+
+    rtype = re.sub(r'\W', '', name.title().replace(' ', ''))
+
+    return rtype.lower() + '/', rtype
 
 
 def label_to_slug(label):
@@ -180,7 +190,7 @@ def main():
         if not (doc := source.get('doc')) or 'content' not in doc:
             return
 
-        results = convert(doc, to_type(fname))
+        results = convert(fname, doc)
         for key, item in results.items():
             if dup := result_map.get(key):
                 print(
@@ -191,6 +201,7 @@ def main():
                     item['@type'],
                     file=sys.stderr
                 )
+                # item['@id'] += '_' + re.sub(r'[a-z]+', '', item['@type'])
         result_map.update(results)
 
     for fname in sys.argv[1:]:
@@ -205,6 +216,8 @@ def main():
                 source = json.load(f)
             convert_and_add_results(source, fname)
 
+    nodes = sorted(result_map.values(), key=lambda node: (node['@type'], node['@type']))
+
     doc = {
         "@context": {
             "@vocab": "https://id.kb.se/vocab/",
@@ -218,7 +231,7 @@ def main():
             "scopeNote_sv": {"@id": "scopeNote", "@language": "sv"},
             "scopeNote_en": {"@id": "scopeNote", "@language": "en"},
         },
-        "@graph": list(result_map.values())
+        "@graph": nodes
     }
 
     print(json.dumps(doc, indent=2, ensure_ascii=False))

--- a/source/rda/terms.ttl
+++ b/source/rda/terms.ttl
@@ -1,0 +1,4370 @@
+prefix : <https://id.kb.se/vocab/>
+base <https://id.kb.se/term/rda/>
+
+<aspectratiodesignation/FullScreen> a :AspectRatioDesignation ;
+  :prefLabel "Full screen"@en ;
+  :prefLabel "Normalbild"@sv ;
+  :altLabel "Full-screen"@en ;
+  :definition "An aspect ratio designation for an expression of a moving image work whose ratio is less than 1.5:1."@en ;
+  :definition "Bildförhållande för ett uttryck av ett verk bestående av rörlig bild vars mått är mindre än 1.5:1."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/AspectRatio/1001> ;
+  :note "345 #d (term)" ,
+    "(#d saknas i Formathandboken)" .
+
+<aspectratiodesignation/WideScreen> a :AspectRatioDesignation ;
+  :prefLabel "Wide screen"@en ;
+  :prefLabel "Bredbild"@sv ;
+  :altLabel "Wide-screen"@en ;
+  :definition "An aspect ratio designation for an expression of a moving image work whose ratio is equal to or greater than 1.5:1."@en ;
+  :definition "Bildförhållande för ett uttryck av ett verk bestående av rörlig bild vars mått 1.5:1 eller större"@sv ;
+  :exactMatch <http://rdaregistry.info/termList/AspectRatio/1002> ;
+  :note "345 #d (term)" .
+
+<aspectratiodesignation/MixedAspectRatio> a :AspectRatioDesignation ;
+  :prefLabel "Mixed aspect ratio"@en ;
+  :prefLabel "Blandade bildförhållanden"@sv ;
+  :definition "An aspect ratio designation for an expression of a moving image work that includes multiple aspect ratios within the same expression"@en ;
+  :definition "Bildförhållande för ett uttryck av ett verk bestående av rörlig bild som omfattar flera bildförhållanden i samma uttryck."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/AspectRatio/1003> ;
+  :note "345 #d (term)" .
+
+<bibliographicformat/128Mo> a :BibliographicFormat ;
+  :prefLabel "128mo"@en ;
+  :prefLabel "128:o"@sv ;
+  :altLabel "One hundred twenty-eightmo"@en ;
+  :definition "A bibliographic format that consists of one or more leaves that are 1/128 of the whole sheet."@en ;
+  :definition "Bokformat bestående av ett eller flera blad som utgör 1/128 av hela arket."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/bookFormat/1014> ;
+  :closeMatch <http://vocab.getty.edu/page/aat/300265731> ,
+    <https://www.wikidata.org/wiki/Q108650472> ;
+  :note "340 #m (term)" .
+
+<bibliographicformat/12Mo> a :BibliographicFormat ;
+  :prefLabel "12mo"@en ;
+  :prefLabel "12:o"@sv ;
+  :altLabel "Duodecimo"@en ;
+  :definition "A bibliographic format that consists of one or more leaves that are 1/12 of the whole sheet."@en ;
+  :definition "Bokformat bestående av ett eller flera blad som utgör 1/12 av hela arket."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/bookFormat/1004> ;
+  :closeMatch <http://vocab.getty.edu/page/aat/300265445> ,
+    <https://www.wikidata.org/wiki/Q1266414> ;
+  :note "340 #m (term)" .
+
+<bibliographicformat/16Mo> a :BibliographicFormat ;
+  :prefLabel "16mo"@en ;
+  :prefLabel "16:o"@sv ;
+  :altLabel "Decimo-sexto"@en ;
+  :definition "A bibliographic format that consists of one or more leaves that are 1/16 of the whole sheet."@en ;
+  :definition "Bokformat bestående av ett eller flera blad som utgör 1/16 av hela arket."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/bookFormat/1005> ;
+  :closeMatch <http://vocab.getty.edu/page/aat/300265441> ,
+    <https://www.wikidata.org/wiki/Q53345875> ;
+  :note "340 #m (term)" .
+
+<bibliographicformat/18Mo> a :BibliographicFormat ;
+  :prefLabel "18mo"@en ;
+  :prefLabel "18:o"@sv ;
+  :altLabel "Eighteenmo"@en ;
+  :definition "A bibliographic format that consists of one or more leaves that are 1/18 of the whole sheet."@en ;
+  :definition "Bokformat bestående av ett eller flera blad som utgör 1/18 av hela arket."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/bookFormat/1010> ;
+  :closeMatch <http://vocab.getty.edu/page/aat/300265446> ,
+    <https://www.wikidata.org/wiki/Q53346123> ;
+  :note "340 #m (term)" .
+
+<bibliographicformat/24Mo> a :BibliographicFormat ;
+  :prefLabel "24mo"@en ;
+  :prefLabel "24:o"@sv ;
+  :altLabel "Vigesimo-quarto"@en ;
+  :definition "A bibliographic format that consists of one or more leaves that are 1/24 of the whole sheet."@en ;
+  :definition "Bokformat bestående av ett eller flera blad som utgör 1/24 av hela arket."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/bookFormat/1006> ;
+  :closeMatch <http://vocab.getty.edu/page/aat/300265447> ;
+  :note "340 #m (term)" .
+
+<bibliographicformat/32Mo> a :BibliographicFormat ;
+  :prefLabel "32mo"@en ;
+  :prefLabel "32:o"@sv ;
+  :altLabel "Trigesimo-secundo"@en ;
+  :definition "A bibliographic format that consists of one or more leaves that are 1/32 of the whole sheet."@en ;
+  :definition "Bokformat bestående av ett eller flera blad som utgör 1/32 av hela arket."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/bookFormat/1007> ;
+  :closeMatch <http://vocab.getty.edu/page/aat/300265442> ,
+    <https://www.wikidata.org/wiki/Q108650412> ;
+  :note "340 #m (term)" .
+
+<bibliographicformat/36Mo> a :BibliographicFormat ;
+  :prefLabel "36mo"@en ;
+  :prefLabel "36:o"@sv ;
+  :altLabel "Thirty-sixmo"@en ;
+  :definition "A bibliographic format that consists of one or more leaves that are 1/36 of the whole sheet."@en ;
+  :definition "Bokformat bestående av ett eller flera blad som utgör 1/36 av hela arket."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/bookFormat/1011> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q108650469> ;
+  :note "340 #m (term)" .
+
+<bibliographicformat/48Mo> a :BibliographicFormat ;
+  :prefLabel "48mo"@en ;
+  :prefLabel "48:o"@sv ;
+  :altLabel "Forty-eightmo"@en ;
+  :definition "A bibliographic format that consists of one or more leaves that are 1/48 of the whole sheet."@en ;
+  :definition "Bokformat bestående av ett eller flera blad som utgör 1/48 av hela arket."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/bookFormat/1008> ;
+  :closeMatch <http://vocab.getty.edu/page/aat/300265448> ,
+    <https://www.wikidata.org/wiki/Q108650413> ;
+  :note "340 #m (term)" .
+
+<bibliographicformat/4To> a :BibliographicFormat ;
+  :prefLabel "4to"@en ;
+  :prefLabel "4:o"@sv ;
+  :altLabel "Quarto"@en ;
+  :definition "A bibliographic format that consists of one or more leaves that are 1/4 of the whole sheet."@en ;
+  :definition "Bokformat bestående av ett eller flera blad som utgör 1/4 av hela arket."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/bookFormat/1002> ;
+  :closeMatch <http://vocab.getty.edu/page/aat/300265439> ,
+    <https://www.wikidata.org/wiki/Q2122442> ;
+  :note "340 #m (term)" .
+
+<bibliographicformat/64Mo> a :BibliographicFormat ;
+  :prefLabel "64mo"@en ;
+  :prefLabel "64:o"@sv ;
+  :altLabel "Sixty-fourmo"@en ;
+  :definition "A bibliographic format that consists of one or more leaves that are 1/64 of the whole sheet."@en ;
+  :definition "Bokformat bestående av ett flera blad som utgör 1/64 av hela arket."@sv ;
+  :exactMatch <http://www.rdaregistry.info/termList/bookFormat/#1009> ;
+  :closeMatch <http://vocab.getty.edu/page/aat/300265443> ,
+    <https://www.wikidata.org/wiki/Q108650419> ;
+  :note "340 #m (term)" .
+
+<bibliographicformat/72Mo> a :BibliographicFormat ;
+  :prefLabel "72mo"@en ;
+  :prefLabel "72:o"@sv ;
+  :altLabel "Seventy-twomo"@en ;
+  :definition "A bibliographic format that consists of one or more leaves that are 1/72 of the whole sheet."@en ;
+  :definition "Bokformat bestående av ett eller flera blad som utgör 1/72 av hela arket."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/bookFormat/1012> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q108650470> ;
+  :note "340 #m (term)" .
+
+<bibliographicformat/8Vo> a :BibliographicFormat ;
+  :prefLabel "8vo"@en ;
+  :prefLabel "8:o"@sv ;
+  :altLabel "Octavo"@en ;
+  :definition "A bibliographic format that consists of one or more leaves that are 1/8 of the whole sheet."@en ;
+  :definition "Bokformat bestående av ett eller flera blad som utgör 1/8 av hela arket."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/bookFormat/1003> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q1307353> ;
+  :note "340 #m (term)" .
+
+<bibliographicformat/96Mo> a :BibliographicFormat ;
+  :prefLabel "96mo"@en ;
+  :prefLabel "96:o"@sv ;
+  :altLabel "Ninety-sixmo"@en ;
+  :definition "A bibliographic format that consists of one or more leaves that are 1/96 of the whole sheet."@en ;
+  :definition "Bokformat bestående av ett eller flera blad som utgör 1/96 av hela arket."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/bookFormat/1013> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q108650471> ;
+  :note "340 #m (term)" .
+
+<bibliographicformat/Folio> a :BibliographicFormat ;
+  :prefLabel "Folio"@en ;
+  :prefLabel "2:o"@sv ;
+  :altLabel "2o"@en ;
+  :definition "A bibliographic format that consists of one or more leaves that are 1/2 of the whole sheet."@en ;
+  :definition "Bokformat bestående av ett eller flera blad som utgör hälften av hela arket."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/bookFormat/1001> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q772267> ;
+  :note "340 #m (term)" .
+
+<bibliographicformat/FullSheet> a :BibliographicFormat ;
+  :prefLabel "Full-sheet"@en ;
+  :prefLabel "Helt ark"@sv ;
+  :altLabel "Full sheet"@en ;
+  :definition "A bibliographic format that consists of one or more sheets that have not been cut or folded."@en ;
+  :definition "Bokformat bestående av ett eller flera ark som inte beskurits eller vikts."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/bookFormat/1015> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q108650473> ;
+  :note "340 #m (term)" .
+
+<broadcaststandard/Hdtv> a :BroadcastStandard ;
+  :prefLabel "HDTV"@en ;
+  :prefLabel "HDTV"@sv ;
+  :definition "A broadcast standard that is an encoding system for digital broadcast television, named after high-definition television."@en ;
+  :definition "Sändningsstandard som är ett kodningssystem  för digitalt sänd tv, namngivet efter high definition tv."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/broadcastStand/1001> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q133454> ;
+  :note "346 #b (term)" ,
+    "538 #a (anmärkning)" .
+
+<broadcaststandard/Ntsc> a :BroadcastStandard ;
+  :prefLabel "NTSC"@en ;
+  :prefLabel "NTSC"@sv ;
+  :definition "A broadcast standard that is an analog broadcast television system that was used in most of the Americas and areas of the Far East, named after the National Television System Committee."@en ;
+  :definition "Sändningsstandard som är ett analogt sändningssystem för tv som användes i hela Amerika och Japan, namngivet efter National Television System Committee"@sv ;
+  :exactMatch <http://rdaregistry.info/termList/broadcastStand/1002> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q185796> ;
+  :note "346 #b (term)" ,
+    "538 #a (anmärkning)" .
+
+<broadcaststandard/Pal> a :BroadcastStandard ;
+  :prefLabel "PAL"@en ;
+  :prefLabel "PAL"@sv ;
+  :definition "A broadcast standard that is a colour encoding system for analog broadcast television used in most countries broadcasting at 625-line / 25 frame per second, named after Phase Alternating Line."@en ;
+  :definition "Sändningsstandard som är ett färgkodningssystem för analogt sänd tv som användes i stora delar av världen som hade en tv-standard med 625 linjer och 25 rutor per sekund, namngivet efter Phase Alternating Line."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/broadcastStand/1003> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q105973> ;
+  :note "346 #b (term)" ,
+    "538 #a (anmärkning)" .
+
+<broadcaststandard/Secam> a :BroadcastStandard ;
+  :prefLabel "SECAM"@en ;
+  :prefLabel "SECAM"@sv ;
+  :definition "A broadcast standard that is a colour encoding system for analog broadcast television first used in France, named after Séquentiel couleur à mémoire."@en ;
+  :definition "Sändningsstandard som är ett färgkodningssystem för analogt sänd tv, först använt i Frankrike, namngivet efter Séquentiel couleur à mémoire."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/broadcastStand/1004> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q223765> ;
+  :note "346 #b (term)" ,
+    "538 #a (anmärkning)" .
+
+<carrierextentunit/ActivityCard> a :CarrierExtentUnit ;
+  :prefLabel "Activity card"@en ;
+  :prefLabel "Aktivitetskort"@sv ;
+  :definition "A unit of extent that is a card printed with words, numerals, or pictures to be used by an individual or a group as a basis for performing a specific activity."@en ;
+  :definition "Kort med påtryckta ord, tal och/eller bilder som används av en person eller en grupp för att utföra en särskild aktivitet."@sv ;
+  :scopeNote "This term applies to still images. The cards are usually issued in sets."@en ;
+  :scopeNote "Termen används för stillbilder. Korten ges vanligtvis ut i  paket."@sv ;
+  :related <Toy> ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierEU/1001> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q105757830> ;
+  :note "300 #a" .
+
+<carrierextentunit/Atlas> a :CarrierExtentUnit ;
+  :prefLabel "Atlas"@en ;
+  :prefLabel "Atlas"@sv ;
+  :definition "A unit of extent that is a volume of maps or other cartographic content with or without descriptive text."@en ;
+  :definition "Volym med kartor eller annat kartografiskt innehåll med eller utan beskrivande text."@sv ;
+  :scopeNote "This term applies to cartographic resources."@en ;
+  :scopeNote "Termen används för kartografiska resurser."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierEU/1002> ;
+  :closeMatch <http://vocab.getty.edu/page/aat/300028053> ,
+    <https://www.wikidata.org/wiki/Q162827> ;
+  :note "300 #a" .
+
+<carrierextentunit/Case> a :CarrierExtentUnit ;
+  :prefLabel "Case"@en ;
+  :prefLabel "Fodral i nuvarande glossary."@sv ;
+  :definition "A unit of extent that consists of a box containing bound or unbound resources."@en ;
+  :definition "Låda innehållande bundna eller obundna resurser."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierEU/1003> ;
+  :closeMatch <http://vocab.getty.edu/page/aat/300045659> ;
+  :note "300 #a" .
+
+<carrierextentunit/Chart> a :CarrierExtentUnit ;
+  :prefLabel "Chart"@en ;
+  :prefLabel "Diagram"@sv ;
+  :definition "A unit of extent that consists of a two-dimensional representation of data in graphic or tabular form."@en ;
+  :definition "Tvådimensionell representation av data i grafisk form eller tabellform."@sv ;
+  :scopeNote "This term applies to still images."@en ;
+  :scopeNote "Termen används för stillbilder."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierEU/1004> ;
+  :closeMatch <http://vocab.getty.edu/page/aat/300026848> ,
+    <https://www.wikidata.org/wiki/Q28923> ;
+  :note "300 #a" .
+
+<carrierextentunit/Coin> a :CarrierExtentUnit ;
+  :prefLabel "Coin"@en ;
+  :prefLabel "Mynt"@sv ;
+  :definition "A unit of extent that consists of a piece of metal stamped by government authority for use as money."@en ;
+  :definition "Metallbit präglad av en statlig myndighet som används som betalningsmedel."@sv ;
+  :scopeNote "This term applies to three-dimensional forms."@en ;
+  :scopeNote "Termen används för tredimensionella former."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierEU/1005> ;
+  :closeMatch <http://vocab.getty.edu/page/aat/300037222> ,
+    <https://www.wikidata.org/wiki/Q41207> ;
+  :note "300 #a" .
+
+<carrierextentunit/Collage> a :CarrierExtentUnit ;
+  :prefLabel "Collage"@en ;
+  :prefLabel "Kollage"@sv ;
+  :definition "A unit of extent that consists of a work in two dimensions or very low relief that was made by affixing paper, fabrics, photographs, or other materials onto a flat surface."@en ;
+  :definition "Verk i två dimensioner eller med väldigt låg relief, tillverkat genom att papper, tyger, fotografier eller andra material fästs på en plan yta."@sv ;
+  :scopeNote "This term applies to still images."@en ;
+  :scopeNote "Termen används för stillbilder."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierEU/1006> ;
+  :closeMatch <http://vocab.getty.edu/page/aat/300033963> ,
+    <https://www.wikidata.org/wiki/Q22669857> ;
+  :note "300 #a" .
+
+<carrierextentunit/Column> a :CarrierExtentUnit ;
+  :prefLabel "Column"@en ;
+  :prefLabel "Kolumn"@sv ;
+  :definition "A unit of extent that consists of one of two or more vertical sections of text appearing on the same page or leaf."@en ;
+  :definition "En eller flera lodräta textstycken på samma sida eller blad."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierEU/1007> ;
+  :closeMatch <http://vocab.getty.edu/page/aat/300200012> ,
+    <https://www.wikidata.org/wiki/Property:P3903> ;
+  :note "300 #a" .
+
+<carrierextentunit/Diagram> a :CarrierExtentUnit ;
+  :prefLabel "Diagram"@en ;
+  :prefLabel "Diagram (se även chart)"@sv ;
+  :definition "A unit of extent that is a geographic representation of numeric data, or of the course or results of an action or process."@en ;
+  :definition "Geografisk representation av numeriska data, eller förloppet eller resultatet av en handling eller process."@sv ;
+  :scopeNote "This term applies to cartographic resources. The term is sometimes also applied to maps characterized by much simplified, or schematic, representation."@en ;
+  :scopeNote "Termen används för kartografiska resurser. Ibland används den även för kartor som är väldigt förenklade eller schematiska."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierEU/1008> ;
+  :note "300 #a" .
+
+<carrierextentunit/Diorama> a :CarrierExtentUnit ;
+  :prefLabel "Diorama"@en ;
+  :prefLabel "Diorama"@sv ;
+  :definition "A unit of extent that consists of a three-dimensional representation of a scene created by placing objects, figures, etc., in front of a two-dimensional painted background."@en ;
+  :definition "Tredimensionell representation som återger en scen arrangerad med hjälp av föremål, figurer o.sv.  framför en plan, målad bakgrund."@sv ;
+  :scopeNote "This term applies to three-dimensional forms."@en ;
+  :scopeNote "Termen används för tredimensionella former."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierEU/1009> ;
+  :closeMatch <http://vocab.getty.edu/page/aat/300047762> ,
+    <https://www.wikidata.org/wiki/Q207697> ;
+  :note "300 #a" .
+
+<carrierextentunit/Drawing> a :CarrierExtentUnit ;
+  :prefLabel "Drawing"@en ;
+  :prefLabel "Teckning"@sv ;
+  :definition "A unit of extent that consists of a visual work produced by drawing, which is the application of lines on a surface, often paper, by using a pencil, pen, chalk, or some other tracing instrument to focus on the delineation of form rather than the application of colour."@en ;
+  :definition "Visuellt verk framställt genom teckning, d.v.s. applicering av linjer på ett underlag, ofta papper, med hjälp av en penna?,  krita eller annat markerande verktyg med fokus på att avbilda form snarare än att applicera färg."@sv ;
+  :scopeNote "This term applies to still images. This term is often defined broadly to refer to computer-generated images as well."@en ;
+  :scopeNote "Termen används för stillbilder. Termen är ofta brett definierad och omfattar även datorgenererade bilder."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierEU/1010> ;
+  :closeMatch <http://vocab.getty.edu/page/aat/300033973> ,
+    <https://www.wikidata.org/wiki/Q93184> ;
+  :note "300 #a" .
+
+<carrierextentunit/Exhibit> a :CarrierExtentUnit ;
+  :prefLabel "Exhibit"@en ;
+  :prefLabel "Utställning"@sv ;
+  :definition "A unit of extent that consists of objects on display, along with the display environment of cases, labels, etc."@en ;
+  :definition "Utställda föremål i en utställningsmiljö med montrar och texter etc."@sv ;
+  :scopeNote "This term applies to three-dimensional forms."@en ;
+  :scopeNote "Termen används för tredimensionella former."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierEU/1011> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q9252000> ;
+  :note "300 #a" .
+
+<carrierextentunit/FlashCard> a :CarrierExtentUnit ;
+  :prefLabel "Flash card"@en ;
+  :prefLabel "Bildkort"@sv ;
+  :altLabel "Electronic flash card"@en ;
+  :altLabel "Elektroniskt bildkort"@sv ;
+  :definition "A unit of extent that consists of a card, or digital representation of a card, carrying words, numerals, pictures, etc., designed for rapid display as an aid to learning."@en ;
+  :definition "Kort eller en digital representation av ett kort, med påtryckt text, siffror, bilder etc., avsedd för snabb presentation som hjälp vid inlärning."@sv ;
+  :scopeNote "This term applies to still images."@en ;
+  :scopeNote "Termen används för stillbilder."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierEU/1012> ;
+  :closeMatch <http://vocab.getty.edu/page/aat/300425631> ,
+    <https://www.wikidata.org/wiki/Q1820374> ;
+  :note "300 #a" .
+
+<carrierextentunit/FoldedSheet> a :CarrierExtentUnit ;
+  :prefLabel "Folded sheet"@en ;
+  :prefLabel "Vikt ark"@sv ;
+  :definition "A unit of extent that consists of a sheet designed to be read in pages when folded."@en ;
+  :definition "Ark avsett att läsas som sidor när det är vikt."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierEU/1013> ;
+  :note "300 #a" .
+
+<carrierextentunit/Game> a :CarrierExtentUnit ;
+  :prefLabel "Game"@en ;
+  :prefLabel "Spel"@sv ;
+  :definition "A unit of extent that consists of a set of objects designed for manipulation according to prescribed or implicit rules for education, entertainment, or therapy."@en ;
+  :definition "Uppsättning föremål avsedda att manipuleras enligt föreskrivna eller outsagda regler för utbildning, underhållning eller som terapi."@sv ;
+  :scopeNote "This term applies to three-dimensional forms."@en ;
+  :scopeNote "Termen används för tredimensionella former."@sv ;
+  :related <Toy> ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierEU/1014> ;
+  :closeMatch <http://vocab.getty.edu/page/aat/300069657> ,
+    <https://www.wikidata.org/wiki/Q11410> ;
+  :note "300 #a" .
+
+<carrierextentunit/Globe> a :CarrierExtentUnit ;
+  :prefLabel "Globe"@en ;
+  :prefLabel "Glob"@sv ;
+  :definition "A unit of extent that is a depiction of the earth or other celestial body, real or imaginary, on the surface of a sphere."@en ;
+  :definition "Återgivning av jorden eller annan himlakropp, verklig eller påhittad, på ytan av ett klot."@sv ;
+  :scopeNote "This term applies to cartographic resources."@en ;
+  :scopeNote "Termen används för kartografiska resurser."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierEU/1015> ;
+  :closeMatch <http://vocab.getty.edu/page/aat/300028089> ,
+    <https://www.wikidata.org/wiki/Q133792> ;
+  :note "300 #a" .
+
+<carrierextentunit/Icon> a :CarrierExtentUnit ;
+  :prefLabel "Icon"@en ;
+  :prefLabel "Ikon"@sv ;
+  :definition "A unit of extent that consists of an image that portrays a sacred entity and that is itself regarded as sacred."@en ;
+  :definition "Bild som porträtterar  en helig entitet och som i sig själv betraktas som helig."@sv ;
+  :scopeNote "This term applies to still images. Most commonly it comprises tempera on panel, but it may be in any two-dimensional or relief medium, including fresco."@en ;
+  :scopeNote "Termen används för stillbilder. Vanligtvis består den av tempera på träpanel, men den kan vara i ett tvådimensionellt medium eller i relief, även al fresco."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierEU/1016> ;
+  :closeMatch <http://vocab.getty.edu/page/aat/300033945> ,
+    <https://www.wikidata.org/wiki/Q132137> ;
+  :note "300 #a" .
+
+<carrierextentunit/JigsawPuzzle> a :CarrierExtentUnit ;
+  :prefLabel "Jigsaw puzzle"@en ;
+  :prefLabel "Pussel"@sv ;
+  :definition "A unit of extent that consists of a picture, usually on pasteboard or wood, which has been cut into interlocking shapes intended to be reassembled."@en ;
+  :definition "Bild, vanligtvis på papp eller trä, som har skurits i bitar som passar ihop med varandra och är tänkta att sammanfogas igen."@sv ;
+  :scopeNote "This term applies to three-dimensional forms."@en ;
+  :scopeNote "Termen används för tredimensionella former."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierEU/1017> ;
+  :closeMatch <http://vocab.getty.edu/page/aat/300211322> ,
+    <https://www.wikidata.org/wiki/Q181008> ;
+  :note "300 #a" .
+
+<carrierextentunit/Leaf> a :CarrierExtentUnit ;
+  :prefLabel "Leaf"@en ;
+  :prefLabel "Blad"@sv ;
+  :definition "A unit of extent that consists of a single bound or fastened sheet as a subunit of a volume; each leaf consists of two pages, one on each side, either or both of which may be blank."@en ;
+  :definition "Ark som är bundet eller fäst som en underenhet till en volym; varje blad  har två sidor, där den ena eller båda kan vara tomma."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierEU/1018> ;
+  :closeMatch <http://vocab.getty.edu/page/aat/300115833> ,
+    <https://www.wikidata.org/wiki/Q107256474> ;
+  :note "300 #a" .
+
+<carrierextentunit/Map> a :CarrierExtentUnit ;
+  :prefLabel "Map"@en ;
+  :prefLabel "Karta"@sv ;
+  :definition "A unit of extent that consists of a representation, normally to scale and on a two-dimensional medium, of a selection of material or abstract features on, or in relation to, the surface of the earth, another celestial body, or an imaginary place."@en ;
+  :definition "Vanligtvis skalenlig och tvådimensionell framställning av ett urval fysiska eller abstrakta drag hos jordens, annan himlakropps eller påhittad plats yta."@sv ;
+  :scopeNote "This term applies to cartographic resources."@en ;
+  :scopeNote "Termen används för kartografiska resurser."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierEU/1019> ;
+  :closeMatch <http://vocab.getty.edu/page/aat/300028094> ,
+    <https://www.wikidata.org/wiki/Q4006> ;
+  :note "300 #a" .
+
+<carrierextentunit/Medal> a :CarrierExtentUnit ;
+  :prefLabel "Medal"@en ;
+  :prefLabel "Medalj"@sv ;
+  :definition "A unit of extent that consists of a small piece of metal, bearing a relief design on one or both sides and having a commemorative purpose; not used as a medium of exchange."@en ;
+  :definition "Liten metallbit med relief på ena eller båda sidorna och avsedd för jubileumsändamål; används inte som betalningsmedel."@sv ;
+  :scopeNote "This term applies to three-dimensional forms."@en ;
+  :scopeNote "Termen används för tredimensionella former."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierEU/1020> ;
+  :closeMatch <http://vocab.getty.edu/page/aat/300046025> ,
+    <https://www.wikidata.org/wiki/Q131647> ;
+  :note "300 #a" .
+
+<carrierextentunit/MockUp> a :CarrierExtentUnit ;
+  :prefLabel "Mock-up"@en ;
+  :prefLabel "Fullskalemodell (KRS)"@sv ;
+  :definition "A unit of extent that consists of a physical representation of a device or process that may be modified for training or analysis to emphasize a particular part or function."@en ;
+  :definition "Fysisk framställning av en anordning eller en process som kan ändras i övningssyfte eller för att analysera en viss del eller funktion."@sv ;
+  :scopeNote "This term applies to three-dimensional forms."@en ;
+  :scopeNote "Termen används för tredimensionella former."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierEU/1021> ;
+  :closeMatch <http://vocab.getty.edu/page/aat/300248774> ,
+    <https://www.wikidata.org/wiki/Q1933427> ;
+  :note "300 #a" .
+
+<carrierextentunit/Model> a :CarrierExtentUnit ;
+  :prefLabel "Model"@en ;
+  :prefLabel "Model"@sv ;
+  :definition "A unit of extent that consists of a three-dimensional representation of a real or imagined object."@en ;
+  :definition "Tredimensionell framställning av ett verkligt eller påhittat föremål."@sv ;
+  :scopeNote "This term applies to cartographic resources and three-dimensional forms."@en ;
+  :scopeNote "Termen används för kartografiska resurser och tredimensionella former."@sv ;
+  :related <Toy> ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierEU/1022> ;
+  :closeMatch <http://vocab.getty.edu/page/aat/300047753> ,
+    <https://www.wikidata.org/wiki/Q1979154> ;
+  :note "300 #a" .
+
+<carrierextentunit/Page> a :CarrierExtentUnit ;
+  :prefLabel "Page"@en ;
+  :prefLabel "Sida"@sv ;
+  :definition "A unit of extent that consists of a single side of a leaf."@en ;
+  :definition "Enskild sida av ett blad."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierEU/1023> ;
+  :closeMatch <http://vocab.getty.edu/page/aat/300194222> ,
+    <https://www.wikidata.org/wiki/Q1069725> ;
+  :note "300 #a" .
+
+<carrierextentunit/Painting> a :CarrierExtentUnit ;
+  :prefLabel "Painting"@en ;
+  :prefLabel "Målning"@sv ;
+  :definition "A unit of extent that consists of an item in which images are formed primarily by the direct application of pigment suspended in a medium, arranged in masses of colour onto a generally two-dimensional surface."@en ;
+  :definition "Föremål på vilket bilder framställts, främst genom direkt applicering av utspätt pigment, arrangerat i lager av färg, vanligtvis  på en på en plan yta."@sv ;
+  :scopeNote "This term applies to still images."@en ;
+  :scopeNote "Termen används för stillbilder."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierEU/1024> ;
+  :closeMatch <http://vocab.getty.edu/page/aat/300033618> ,
+    <https://www.wikidata.org/wiki/Q3305213> ;
+  :note "300 #a" .
+
+<carrierextentunit/Photograph> a :CarrierExtentUnit ;
+  :prefLabel "Photograph"@en ;
+  :prefLabel "Fotografi"@sv ;
+  :definition "A unit of extent that consists of an image captured by a lens and carried on the surface of a sheet."@en ;
+  :definition "Bild fångad av en lins och överförd till ytan av ett ark."@sv ;
+  :scopeNote "This term applies to still images."@en ;
+  :scopeNote "Termen används för stillbilder."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierEU/1025> ;
+  :closeMatch <http://vocab.getty.edu/page/aat/300046300> ,
+    <https://www.wikidata.org/wiki/Q125191> ;
+  :note "300 #a" .
+
+<carrierextentunit/Picture> a :CarrierExtentUnit ;
+  :prefLabel "Picture"@en ;
+  :prefLabel "Bild"@sv ;
+  :definition "A unit of extent that consists of two-dimensional representations."@en ;
+  :definition "Tvådimensionella representationer."@sv ;
+  :scopeNote "This term applies to still images."@en ;
+  :scopeNote "Termen används för stillbilder."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierEU/1026> ;
+  :closeMatch <http://vocab.getty.edu/page/aat/300264388> ;
+  :note "300 #a" .
+
+<carrierextentunit/Portfolio> a :CarrierExtentUnit ;
+  :prefLabel "Portfolio"@en ;
+  :prefLabel "Portfölj (KRS)"@sv ;
+  :definition "A unit of extent that is a container for holding loose materials, that usually consists of two covers joined together at the back."@en ;
+  :definition "Mapp som samlar löst material; består vanligtvis av två omslag som är förenade i ryggen."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierEU/1027> ;
+  :closeMatch <http://vocab.getty.edu/page/aat/300198929> ,
+    <https://www.wikidata.org/wiki/Q79509036> ;
+  :note "300 #a" .
+
+<carrierextentunit/Postcard> a :CarrierExtentUnit ;
+  :prefLabel "Postcard"@en ;
+  :prefLabel "Vykort"@sv ;
+  :definition "A unit of extent that consists of a card on which a message may be written or printed for mailing without an envelope."@en ;
+  :definition "Kort på vilket ett meddelande kan vara skrivet eller tryckt och som kan skickas utan kuvert."@sv ;
+  :scopeNote "This term applies to still images."@en ;
+  :scopeNote "Termen används för stillbilder."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierEU/1028> ;
+  :closeMatch <http://vocab.getty.edu/page/aat/300026816> ,
+    <https://www.wikidata.org/wiki/Q192425> ;
+  :note "300 #a" .
+
+<carrierextentunit/Poster> a :CarrierExtentUnit ;
+  :prefLabel "Poster"@en ;
+  :prefLabel "Poster eller affisch"@sv ;
+  :definition "A unit of extent that consists of a notice, usually decorative or pictorial, intended to be posted to advertise, promote, or publicize an activity, cause, product, or service; also, a decorative, mass-produced print intended for hanging."@en ;
+  :definition "Meddelande, vanligtvis dekorativt eller illustrerat, avsett att sättas upp för att annonsera, marknadsföra eller offentliggöra en aktivitet, en sak, en vara eller tjänst; även ett dekorativt, massproducerat tryck avsett att hängas upp."@sv ;
+  :scopeNote "This term applies to still images."@en ;
+  :scopeNote "Termen används för stillbilder."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierEU/1029> ;
+  :closeMatch <http://vocab.getty.edu/page/aat/300027221> ,
+    <https://www.wikidata.org/wiki/Q429785> ;
+  :note "300 #a" .
+
+<carrierextentunit/Print> a :CarrierExtentUnit ;
+  :prefLabel "Print"@en ;
+  :prefLabel "Tryckt bild"@sv ;
+  :definition "A unit of extent that consists of a pictorial work produced by transferring an image by means of a matrix such as a plate, block, or screen, using any of various printing processes."@en ;
+  :definition "Bildverk framställt genom att överföra en bild med en matris, till exempel en platta, ett block eller ram med olika tryckprocesser."@sv ;
+  :scopeNote "This term applies to still images."@en ;
+  :scopeNote "Termen används för stillbilder."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierEU/1030> ;
+  :closeMatch <http://vocab.getty.edu/page/aat/300041273> ,
+    <https://www.wikidata.org/wiki/Q11060274> ;
+  :note "300 #a" .
+
+<carrierextentunit/Profile> a :CarrierExtentUnit ;
+  :prefLabel "Profile"@en ;
+  :prefLabel "Profil"@sv ;
+  :definition "A unit of extent that is a scale representation of the intersection of a vertical surface, which may or may not be a plane, with the surface of the ground, or of the intersection of such a vertical surface with that of a conceptual three-dimensional model representing phenomena having a continuous distribution."@en ;
+  :definition "Skalenlig framställning av skärningen mellan en vertikal yta (som inte behöver vara ett plan) och markytan, eller skärningen mellan en sådan vertikal yta och ytan hos en tredimensionell modell, som återger fenomen med kontinuerlig utbredning."@sv ;
+  :scopeNote "This term applies to cartographic resources."@en ;
+  :scopeNote "Termen används för kartografiska resurser."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierEU/1031> ;
+  :note "300 #a" .
+
+<carrierextentunit/Radiograph> a :CarrierExtentUnit ;
+  :prefLabel "Radiograph"@en ;
+  :prefLabel "Röntgenbild"@sv ;
+  :definition "A unit of extent that is a photograph produced by the passage of radiation, such as X rays, gamma rays, or neutrons, through an opaque object."@en ;
+  :definition "Fotografi framställt genom strålning, till exempel genom att röntgenstrålar, gammastrålar eller neutroner, passerat ett ogenomskinligt föremål."@sv ;
+  :scopeNote "This term applies to still images."@en ;
+  :scopeNote "Termen används för stillbilder."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierEU/1032> ;
+  :closeMatch <http://vocab.getty.edu/page/aat/300134722> ,
+    <https://www.wikidata.org/wiki/Q108990163> ;
+  :note "300 #a" .
+
+<carrierextentunit/RemoteSensingImage> a :CarrierExtentUnit ;
+  :prefLabel "Remote-sensing image"@en ;
+  :prefLabel "Fjärranalysbild"@sv ;
+  :definition "A unit of extent that is a pictorial product of any remote-sensing instrument that detects and measures reflected and/or emitted electromagnetic radiation from a distance and reflected underwater sound waves in the case of sonar."@en ;
+  :definition "Bildprodukt framställd med hjälp av sensor som på avstånd känner av och mäter  reflekterad och/eller utsänd elektromagnetisk strålning, och i fallet ekolod, reflekterande undervattensljudvågor."@sv ;
+  :scopeNote "This term applies to cartographic resources."@en ;
+  :scopeNote "Termen används för kartografiska resurser."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierEU/1033> ;
+  :note "300 #a" .
+
+<carrierextentunit/Sculpture> a :CarrierExtentUnit ;
+  :prefLabel "Sculpture"@en ;
+  :prefLabel "Skulptur"@sv ;
+  :definition "A unit of extent that consists of a physical representation, usually of art, in which an image or form is produced in relief, in intaglio, or in the round."@en ;
+  :definition "Fysisk representation, vanligen konst, i vilken en bild eller figur framställs i relief, i djuptryck eller i fri form."@sv ;
+  :scopeNote "This term applies to three-dimensional forms."@en ;
+  :scopeNote "Termen används för tredimensionella former."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierEU/1034> ;
+  :closeMatch <http://vocab.getty.edu/page/aat/300047090> ,
+    <https://www.wikidata.org/wiki/Q860861> ;
+  :note "300 #a" .
+
+<carrierextentunit/Section> a :CarrierExtentUnit ;
+  :prefLabel "Section"@en ;
+  :prefLabel "Kartsektion"@sv ;
+  :altLabel "Map section"@en ;
+  :altLabel "Kartsnitt"@sv ;
+  :definition "A unit of extent that is a scale representation of a vertical surface, commonly a plane, displaying both the profile where it intersects the surface of a celestial body, or some conceptual model, and the underlying structures along the plane of intersection."@en ;
+  :definition "Skalenlig framställning av en lodrät yta, vanligen ett plan, som visar både den profil där den skär markytan, eller någon tänkt modell, och de strukturer som ligger under ytan längs skärningsplanet."@sv ;
+  :scopeNote "This term applies to cartographic resources."@en ;
+  :scopeNote "Termen används för kartografiska resurser."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierEU/1035> ;
+  :note "300 #a" .
+
+<carrierextentunit/Specimen> a :CarrierExtentUnit ;
+  :prefLabel "Specimen"@en ;
+  :prefLabel "Provexemplar"@sv ;
+  :definition "A unit of extent that consists of an individual unit or sample chosen to represent a larger population or aggregation."@en ;
+  :definition "Individuell enhet eller prov som representerar en större population eller samling."@sv ;
+  :scopeNote "This term applies to three-dimensional forms."@en ;
+  :scopeNote "Termen används för tredimensionella former."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierEU/1036> ;
+  :closeMatch <http://vocab.getty.edu/page/aat/300235576> ;
+  :note "300 #a" .
+
+<carrierextentunit/StudyPrint> a :CarrierExtentUnit ;
+  :prefLabel "Study print"@en ;
+  :prefLabel "?"@sv ;
+  :definition "A unit of extent that consists of an image sometimes accompanied by text and used for education."@en ;
+  :definition "Bild, ibland med text, som används för undervisning."@sv ;
+  :scopeNote "This term applies to still images."@en ;
+  :scopeNote "Termen används för stillbilder."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierEU/1037> ;
+  :note "300 #a" .
+
+<carrierextentunit/TechnicalDrawing> a :CarrierExtentUnit ;
+  :prefLabel "Technical drawing"@en ;
+  :prefLabel "Teknisk ritning"@sv ;
+  :definition "A unit of extent that consists of a cross section, detail, diagram, elevation, perspective, plan, working plan, etc., made for use in an engineering or other technical context."@en ;
+  :definition "Tvärprojektion, detalj, diagram, vertikalprojektion, perspektiv, planritning, arbetsritning etc., avsedd för bruk  i ett tekniskt sammanhang."@sv ;
+  :scopeNote "This term applies to still images."@en ;
+  :scopeNote "Termen används för stillbilder."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierEU/1038> ;
+  :closeMatch <http://vocab.getty.edu/page/aat/300034789> ,
+    <https://www.wikidata.org/wiki/Q109772972> ;
+  :note "300 #a" .
+
+<carrierextentunit/Toy> a :CarrierExtentUnit ;
+  :prefLabel "Toy"@en ;
+  :prefLabel "Leksak"@sv ;
+  :definition "A unit of extent that consists of an object designed for education, entertainment, or stimulation through play."@en ;
+  :definition "Föremål avsett för undervisning, underhållning eller stimulering genom lek."@sv ;
+  :scopeNote "This term applies to three-dimensional forms."@en ;
+  :scopeNote "Termen används för tredimensionella former."@sv ;
+  :related <Game> ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierEU/1039> ;
+  :closeMatch <http://vocab.getty.edu/page/aat/300211037> ,
+    <https://www.wikidata.org/wiki/Q11422> ;
+  :note "300 #a" .
+
+<carrierextentunit/View> a :CarrierExtentUnit ;
+  :prefLabel "View"@en ;
+  :prefLabel "Perspektivbild"@sv ;
+  :definition "A unit of extent that is a perspective representation of the landscape in which detail is shown as if projected on an oblique plane."@en ;
+  :definition "Perspektivisk framställning av landskapet, i vilken detaljerna återges som om de var projicerade på ett lutande plan."@sv ;
+  :scopeNote "This term applies to cartographic resources. A bird's-eye view, panorama, panoramic drawing, worm's-eye view, etc., are included."@en ;
+  :scopeNote "Termen används för kartografiska resurser. Omfattar fågelperspektiv, panorama, grodperspektiv, etc.."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierEU/1040> ;
+  :closeMatch <http://vocab.getty.edu/page/aat/300015424> ;
+  :note "300 #a" .
+
+<carrierextentunit/WallChart> a :CarrierExtentUnit ;
+  :prefLabel "Wall chart"@en ;
+  :prefLabel "Väggplansch"@sv ;
+  :definition "A unit of extent that consists of a tabular or graphic representation of data appropriate for display on a wall."@en ;
+  :definition "Data framställd i grafisk- eller tabellform, avsedd att visas på en vägg."@sv ;
+  :scopeNote "This term applies to still images."@en ;
+  :scopeNote "Termen används för stillbilder."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierEU/1041> ;
+  :note "300 #a" .
+
+<carriertype/AudioCartridge> a :CarrierType ;
+  :prefLabel "Audio cartridge"@en ;
+  :prefLabel "Ljudmagasin (sg)"@sv ;
+  :definition "A carrier type that consists of a cartridge containing an audio tape."@en ;
+  :definition "Magasin innehållande ett ljudband."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierType/1002> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q105761455> ;
+  :note "007 (Ljudupptagningar: s)" ,
+    "01 (Särskild bärarbeteckning): g Ljudmagasin" ,
+    "Kommer ut i 338 #a Ljudmagasin #b g #2 rdacarrier vid MARC-export" ,
+    "Medietyp: ljud" .
+
+<carriertype/AudioCylinder> a :CarrierType ;
+  :prefLabel "Audio cylinder"@en ;
+  :prefLabel "Ljudcylinder (se)"@sv ;
+  :definition "A carrier type that consists of a roller-shaped object on which sound waves are incised or indented in a continuous circular groove."@en ;
+  :definition "Rullformat objekt på vilket ljudvågor är inskrivna eller intryckta i ett sammanhängande cirkelspår."@sv ;
+  :scopeNote "Wax cylinders, wire cylinders, etc., are included."@en ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierType/1003> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q60533116> ;
+  :note "007 (Ljudupptagningar: s)" ,
+    "01 (Särskild bärarbeteckning): e" ,
+    "Kommer ut i 338 #a Ljudcylinder #b e #2 rdacarrier vid MARC-export" ,
+    "Medietyp: ljud" .
+
+<carriertype/AudioDisc> a :CarrierType ;
+  :prefLabel "Audio disc"@en ;
+  :prefLabel "Ljudskiva (sd)"@sv ;
+  :altLabel "Sound disc"@en ;
+  :definition "A carrier type that consists of a disc on which sound waves, recorded as modulations, pulses, etc., are incised or indented in a continuous spiral groove."@en ;
+  :definition "Skiva på vilken ljudvågor, inspelade som moduleringar, vibrationer osv. är inskrivna eller intryckta i ett sammanhängande cirkelspår."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierType/1004> ;
+  :closeMatch <https://libris.kb.se/katalogisering/ksq9jfbvm1jz6lj6> ,
+    <https://www.wikidata.org/wiki/Q60533116> .
+
+<carriertype/SoundTrackReel> a :CarrierType ;
+  :prefLabel "Sound-track reel"@en ;
+  :prefLabel "Filmljudspole (si)"@sv ;
+  :definition "A carrier type that consists of an open reel holding a length of film on which sound is recorded."@en ;
+  :definition "Öppen spole med film på vilken ljud är inspelat."@sv ;
+  :scopeNote "Use for sound-track films, whether or not they are intended to accompany visual images on film."@en ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierType/1005> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q105821505> ;
+  :note "007 (Ljudupptagningar: s)" ,
+    "01 (Särskild bärarbeteckning): i" ,
+    "Kommer ut i 338 #a Filmljudspole #b i #2 rdacarrier vid MARC-export" ,
+    "Medietyp: ljud" .
+
+<carriertype/AudioRoll> a :CarrierType ;
+  :prefLabel "Audio roll"@en ;
+  :prefLabel "Ljudrulle (sq)"@sv ;
+  :altLabel "Piano roll"@en ;
+  :definition "A carrier type that consists of a roll of paper on which musical notes are represented by perforations, designed to mechanically reproduce the music when used in a player piano, player organ, etc."@en ;
+  :definition "Pappersrulle på vilken musiknoter representeras av perforeringar avsedda att mekaniskt återge musiken när den används i ett självspelande piano, en självspelande orgel osv."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierType/1006> ;
+  :closeMatch <https://libris.kb.se/katalogisering/qcj2v39ts5cbp7nr> .
+
+<carriertype/Audiocassette> a :CarrierType ;
+  :prefLabel "Audiocassette"@en ;
+  :prefLabel "Ljudkassett (ss)"@sv ;
+  :definition "A carrier type that consists of a cassette containing an audiotape."@en ;
+  :definition "Kassett innehållande ett ljudband."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierType/1007> ;
+  :closeMatch <https://libris.kb.se/katalogisering/7rzpdlsb905jq6sp> ,
+    <http://vocab.getty.edu/page/aat/300028661> .
+
+<carriertype/AudiotapeReel> a :CarrierType ;
+  :prefLabel "Audiotape reel"@en ;
+  :prefLabel "Ljudspole"@sv ;
+  :definition "A carrier type that consists of an open reel holding a length of audiotape to be used with reel-to-reel audio equipment."@en ;
+  :definition "Öppen spole med ljudband för användning i rullbandspelare med öppna spolar."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierType/1008> ;
+  :note "007 (Ljudupptagningar: s)" ,
+    """01 (Särskild bärarbeteckning): t Ljudspole
+Öppen spole, som kräver tomspole i utrustningen.""" ,
+    "Kommer ut i 338 #a Ljudspole #b t #2 rdacarrier vid MARC-export" ,
+    "Medietyp: ljud" .
+
+<carriertype/ComputerCard> a :CarrierType ;
+  :prefLabel "Computer card"@en ;
+  :prefLabel "Datorkort"@sv ;
+  :definition "A carrier type that consists of a card containing digitally encoded data designed for use with a computer."@en ;
+  :definition "Kort innehållande digitalt kodade data avsett för användning i en dator."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierType/1011> ;
+  :closeMatch <https://libris.kb.se/katalogisering/ttw406dxw5m50rc7> .
+
+<carriertype/ComputerChipCartridge> a :CarrierType ;
+  :prefLabel "Computer chip cartridge"@en ;
+  :prefLabel "Datorminnesmodul"@sv ;
+  :definition "A carrier type that consists of a cartridge containing a miniaturized electronic circuit on a small wafer of semiconductor silicon, designed to provide additional processing, memory, or storage capacity."@en ;
+  :definition "Magasin innehållande elektronisk miniatyrkrets på en lövtunn skiva av halvledande silikon."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierType/1012> ;
+  :closeMatch <https://libris.kb.se/katalogisering/ttw406dxw5m50rc7> ,
+    <https://www.wikidata.org/wiki/Q105762876> .
+
+<carriertype/ComputerDisc> a :CarrierType ;
+  :prefLabel "Computer disc"@en ;
+  :prefLabel "Datorskiva"@sv ;
+  :definition "A carrier type that consists of a disc containing digitally encoded data that are magnetically or optically recorded."@en ;
+  :definition "Skiva innehållande digitalt kodade data som är magnetiskt eller optiskt inspelade."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierType/1013> ;
+  :closeMatch <https://libris.kb.se/katalogisering/ps30v28sr55tqz2g> .
+
+<carriertype/ComputerDiscCartridge> a :CarrierType ;
+  :prefLabel "Computer disc cartridge"@en ;
+  :prefLabel "Datorskivmagasin"@sv ;
+  :definition "A carrier type that consists of a cartridge containing one or more computer discs."@en ;
+  :definition "Magasin innehållande en eller fler datorskivor."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierType/1014> ;
+  :closeMatch <https://libris.kb.se/katalogisering/7h66hlsb93qwbsnt> .
+
+<carriertype/C> a :CarrierType ;
+  :prefLabel "C"@en ;
+  :prefLabel "Datorbandmagasin"@sv ;
+  :definition "A carrier type that consists of a cartridge containing a computer tape."@en ;
+  :definition "Magasin innehållande ett datorband."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierType/1015> ;
+  :closeMatch <https://libris.kb.se/katalogisering/j53zpw3ml06hxz78> ,
+    <https://www.wikidata.org/wiki/Q105821643> .
+
+<carriertype/ComputerTapeCassette> a :CarrierType ;
+  :prefLabel "Computer tape cassette"@en ;
+  :prefLabel "Datorkassett"@sv ;
+  :definition "A carrier type that consists of a cassette containing a computer tape."@en ;
+  :definition "Kassett innehållande ett datorband."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierType/1016> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q105821647> ;
+  :note "007 (Digitalt lagrade resurser : c)" ,
+    "01 (Särskild bärarbeteckning): f" ,
+    "Datorkassett" ,
+    "Flyttbar modul med skriv- och läsbart magnetband." ,
+    "Kommer ut i 338 #a Datorkassett #b f #2 rdacarrier vid MARC-export" ,
+    "Medietyp: dator" .
+
+<carriertype/ComputerTapeReel> a :CarrierType ;
+  :prefLabel "Computer tape reel"@en ;
+  :prefLabel "Datorbandspole"@sv ;
+  :definition "A carrier type that consists of an open reel holding a length of computer tape to be used with a computer tape drive."@en ;
+  :definition "Öppen spole med datorband avsedd för en datorbandstation."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierType/1017> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q105821648> ;
+  :note "007 (Digitalt lagrade resurser: c)" ,
+    "01 (Särskild bärarbeteckning): h" ,
+    """Datorbandspole
+Flyttbar spole med skriv- och läsbart magnetband.""" ,
+    "Kommer ut i 338 #a Datorbandspole #b h #2 rdacarrier vid MARC-export" ,
+    "Medietyp: dator" .
+
+<carriertype/OnlineResource> a :CarrierType ;
+  :prefLabel "Online resource"@en ;
+  :prefLabel "Onlineresurs"@sv ;
+  :definition "A carrier type that consists of a digital resource accessed by means of hardware and software connections to a communications network."@en ;
+  :definition "Digital resurs tillgängliggjord via hårdvara och mjukvara genom uppkoppling till ett kommunikationsnät."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierType/1018> ;
+  :closeMatch <https://libris.kb.se/katalogisering/gf53mt1kj0wd1ck3> ,
+    <https://libris.kb.se/katalogisering/hk21mv2lk0vb8sgq> .
+
+<carriertype/ApertureCard> a :CarrierType ;
+  :prefLabel "Aperture card"@en ;
+  :prefLabel "Maskhålkort"@sv ;
+  :definition "A carrier type that consists of a card with one or more rectangular openings or apertures holding frames of microfilm."@en ;
+  :definition "Kort med en eller flera rektangulära öppningar eller maskhål som rymmer bildrutor av mikrofilm."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierType/1021> ;
+  :closeMatch <http://vocab.getty.edu/page/aat/300028594> ,
+    <https://www.wikidata.org/wiki/Q4779389> ;
+  :note "007 (Mikroformer: h)" ,
+    "01 (Särskild bärarkategori): a" ,
+    "Fönsterkort" ,
+    "Kommer ut i 338 #a Fönsterkort #b a" ,
+    "Vid MARC-export" ,
+    "Medietyp: mikroform" .
+
+<carriertype/Microfiche> a :CarrierType ;
+  :prefLabel "Microfiche"@en ;
+  :prefLabel "Mikrofiche (he)"@sv ;
+  :definition "A carrier type that consists of a sheet of film bearing a number of micro-images in a two-dimensional array."@en ;
+  :definition "Filmblad med ett antal mikrobilder i tvådimensionell presentation."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierType/1022> ;
+  :closeMatch <https://libris.kb.se/katalogisering/mh72v06qp1hc7dx3> ,
+    <https://libris.kb.se/katalogisering/dczdkrzhg443cg0k> ,
+    <http://vocab.getty.edu/page/aat/300028591> ,
+    <https://www.wikidata.org/wiki/Q2368076> .
+
+<carriertype/MicroficheCassette> a :CarrierType ;
+  :prefLabel "Microfiche cassette"@en ;
+  :prefLabel "Mikrofichekassett (hf)"@sv ;
+  :definition "A carrier type that consists of a cassette containing uncut microfiches."@en ;
+  :definition "Kassett innehållande oförminskade mikrofichekort."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierType/1023> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q105952901> ;
+  :note "007 (Mikroformer: h)" ,
+    "01 (Särskild bärarkategori): f" ,
+    "Kommer ut i 338 #a Mikrofichekassett #b f #2 rdacarrier vid MARC-export" ,
+    "Medietyp: mikroform" .
+
+<carriertype/MicrofilmCartridge> a :CarrierType ;
+  :prefLabel "Microfilm cartridge"@en ;
+  :prefLabel "Mikrofilmsmagasin (hb)"@sv ;
+  :definition "A carrier type that consists of a cartridge containing a microfilm."@en ;
+  :definition "Magasin innehållande en mikrofilm."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierType/1024> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q105763705> ;
+  :note "007 (Mikroformer: h)" ,
+    "01 (Särskild bärarkategori): b" ,
+    "Kommer ut i 338 #a Mikrofilmsmagasin #b b #2 rdacarrier vid MARC-export" ,
+    "Medietyp: mikroform" .
+
+<carriertype/MicrofilmCassette> a :CarrierType ;
+  :prefLabel "Microfilm cassette"@en ;
+  :prefLabel "Mikrofilmskassett (hc)"@sv ;
+  :definition "A carrier type that consists of a cassette containing a microfilm."@en ;
+  :definition "Kassett innehållande en mikrofilm."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierType/1025> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q105763706> ;
+  :note "007 (Mikroformer: h)" ,
+    "01 (Särskild bärarkategori): c" ,
+    "Kommer ut i 338 #a Mikrofilmskassett #b c #2 rdacarrier vid MARC-export" ,
+    "Medietyp: mikroform" .
+
+<carriertype/MicrofilmReel> a :CarrierType ;
+  :prefLabel "Microfilm reel"@en ;
+  :prefLabel "Mikrofilmsspole (hd)"@sv ;
+  :definition "A carrier type that consists of an open reel holding a microfilm, to be threaded into a microfilm reader."@en ;
+  :definition "Öppen spole med en mikrofilm avsedd att matas in i en mikrofilmsläsare."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierType/1026> ;
+  :closeMatch <https://libris.kb.se/katalogisering/6ttmckr983s5bk4c> ,
+    <https://www.wikidata.org/wiki/Q105763579> .
+
+<carriertype/MicrofilmSlip> a :CarrierType ;
+  :prefLabel "Microfilm slip"@en ;
+  :prefLabel "Mikrofilmsr"@sv ;
+  :definition "A carrier type that consists of a short strip of microfilm cut from a roll."@en ;
+  :definition "Kort remsa mikrofilm klippt från en rulle."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierType/1027> ;
+  :closeMatch <https://libris.kb.se/katalogisering/wp6c28g0z3wv3zxb> ,
+    <https://www.wikidata.org/wiki/Q105763708> .
+
+<carriertype/Microopaque> a :CarrierType ;
+  :prefLabel "Microopaque"@en ;
+  :prefLabel "Mikrokort (hg)"@sv ;
+  :definition "A carrier type that consists of a card or sheet of opaque material bearing a number of micro-images in a two-dimensional array."@en ;
+  :definition "Kort eller ark i ogenomskinligt material med ett antal mikrobilder i tvådimensionell presentation."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierType/1028> ;
+  :closeMatch <https://libris.kb.se/katalogisering/m0d2v06qp419h3jw> ,
+    <https://libris.kb.se/katalogisering/kxkrqx4nm0lg9w6n> ,
+    <http://vocab.getty.edu/page/aat/300028607> ,
+    <https://www.wikidata.org/wiki/Q105763709> .
+
+<carriertype/MicroscopeSlide> a :CarrierType ;
+  :prefLabel "Microscope slide"@en ;
+  :prefLabel "Mikroskoperingspreparat (pp)"@sv ;
+  :definition "A carrier type that consists of a small sheet of transparent material, with or without a protective mount, bearing a minute object designed for use with a device such as a microscope."@en ;
+  :definition "Tunn platta av genomskinligt material, med eller utan skyddande montering, som kan hysa minimala föremål, avsett för användning i en apparat som ett mikroskop."@sv ;
+  :related <Slide> ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierType/1030> ;
+  :closeMatch <http://vocab.getty.edu/page/aat/300380440> ,
+    <https://www.wikidata.org/wiki/Q900183> ;
+  :note "Motsvarande MARC-kod saknas." ,
+    "008  (Grafisk resurs)" ,
+    "33 (Typ av grafisk resurs): p Mikroskoperingspreparat." ,
+    "(även 006/16)" .
+
+<carriertype/FilmCartridge> a :CarrierType ;
+  :prefLabel "Film cartridge"@en ;
+  :prefLabel "Filmmagasin (mc)"@sv ;
+  :definition "A carrier type that consists of a cartridge containing a motion picture film."@en ;
+  :definition "Magasin innehållande en film med rörliga bilder."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierType/1032> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q105821739> ;
+  :note """007 (Spelfilmer: m)
+01 (Särskild bärarbeteckning): c""" ,
+    """Filmmagasin
+Filmen är en ändlös slinga innesluten i ett magasin så att den kan upprepas utan återspolning.""" ,
+    "007 (Projicerbara stillbilder: g)" ,
+    "01 (Särskild bärarbeteckning): c" ,
+    """Film- eller bildbandsmagasin
+Magasin med film-/bildband, där bandet har sammanfogade ändar som medger playback utan återspolning.""" ,
+    "Kommer ut  i 338 #a Film- eller bildbandsmagasin #b c #2 rdacarrier vid MARC-export" ,
+    "Medietyp: projicerad" .
+
+<carriertype/FilmCassette> a :CarrierType ;
+  :prefLabel "Film cassette"@en ;
+  :prefLabel "Filmkassett (mf)"@sv ;
+  :definition "A carrier type that consists of a cassette containing a motion picture film."@en ;
+  :definition "Kassett innehållande en film med rörliga bilder."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierType/1033> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q105821740> ;
+  :note """007 (Spelfilmer: m)
+01 (Särskild bärarbeteckning): f""" ,
+    "MARC-koden saknas i Libris format." ,
+    "Medietyp: projicerad" .
+
+<carriertype/FilmReel> a :CarrierType ;
+  :prefLabel "Film reel"@en ;
+  :prefLabel "Filmspole (mr)"@sv ;
+  :definition "A carrier type that consists of an open reel holding a motion picture film to be used with a motion picture film projector."@en ;
+  :definition "Öppen spole med film med rörliga bilder avsedd för användning i en filmprojektor."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierType/1034> ;
+  :closeMatch <http://vocab.getty.edu/page/aat/300400779> ,
+    <https://www.wikidata.org/wiki/Q105759907> ,
+    <https://www.wikidata.org/wiki/Q45871375> ;
+  :note """007 (Spelfilmer: m)
+01 (Särskild bärarbeteckning): r""" ,
+    "MARC-koden saknas i Libris format." ,
+    "Medietyp: projicerad" .
+
+<carriertype/Filmslip> a :CarrierType ;
+  :prefLabel "Filmslip"@en ;
+  :prefLabel "Filmremsa (gd)"@sv ;
+  :definition "A carrier type that consists of a short strip of film, usually in rigid format rather than rolled."@en ;
+  :definition "Kort remsa film, vanligen i styvt format snarare än rullad."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierType/1035> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q105953346> ;
+  :note "007 (Projicerbara stillbilder: g)" ,
+    "01 (Särskild bärarbeteckning): d" ,
+    "Kommer ut i 338 #a Filmremsa #b d #2 rdacarrier vid MARC-export" ,
+    "Medietyp: projicerad" .
+
+<carriertype/Filmstrip> a :CarrierType ;
+  :prefLabel "Filmstrip"@en ;
+  :prefLabel "Bildband (gf)"@sv ;
+  :definition "A carrier type that consists of a roll of film, with or without recorded sound, containing a succession of images intended for projection one at a time."@en ;
+  :definition "Filmrulle, med eller utan inspelat ljud, innehållande en följd av bilder avsedda att projiceras en och en."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierType/1036> ;
+  :note "007 (Projicerbara stillbilder: g)" ,
+    "01 (Särskild bärarbeteckning): f" ,
+    "(ospecificerad typ)" ,
+    "Kommer ut i 338 #a Bildband (ospecificerad typ) #b f #2 rdacarrier" ,
+    "Medietyp: projicerad" .
+
+<carriertype/FilmstripCartridge> a :CarrierType ;
+  :prefLabel "Filmstrip cartridge"@en ;
+  :prefLabel "Bildbandsmagasin (gc)"@sv ;
+  :definition "A carrier type that consists of a cartridge containing a filmstrip."@en ;
+  :definition "Magasin innehållande ett bildband."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierType/1037> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q105821808> ;
+  :note "007 (Projicerbara stillbilder: g)" ,
+    "01 (Särskild bärarbeteckning): c" ,
+    """Film- eller bildbandsmagasin
+Magasin med film-/bildband, där bandet har sammanfogade ändar som medger playback utan återspolning.""" ,
+    "Kommer ut i 338 #a Film- eller bildbandsmagasin #b c #2 rdacarrier vid MARC-export" ,
+    "Medietyp: projicerad" .
+
+<carriertype/OverheadTransparency> a :CarrierType ;
+  :prefLabel "Overhead transparency"@en ;
+  :prefLabel "OH-bild"@sv ;
+  :altLabel "Overhead projectural"@en ;
+  :definition "A carrier type that consists of a sheet of transparent material, with or without a protective mount, bearing an image designed for use with an overhead projector."@en ;
+  :definition "Ark av genomskinligt material, med eller utan skyddande montering, som kan rymma en bild, avsedd för användning i en overheadprojektor."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierType/1039> ;
+  :closeMatch <https://libris.kb.se/katalogisering/fl8rls0jh2zj9tvm> ,
+    <https://www.wikidata.org/wiki/Q1751645> .
+
+<carriertype/Slide> a :CarrierType ;
+  :prefLabel "Slide"@en ;
+  :prefLabel "Diabild (gs)"@sv ;
+  :definition "A carrier type that consists of a small sheet of transparent material, usually in a protective mount, bearing an image designed for use with a slide projector or viewer."@en ;
+  :definition "Litet ark av genomskinligt material, vanligen i en skyddande montering, med en bild avsedd för användning i en diabildsprojektor."@sv ;
+  :related <MicroscopeSlide> ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierType/1040> ;
+  :closeMatch <https://libris.kb.se/katalogisering/9bjqfnvdc50pqp5c> ,
+    <http://vocab.getty.edu/page/aat/300128371> ,
+    <https://www.wikidata.org/wiki/Q3026325> .
+
+<carriertype/StereographCard> a :CarrierType ;
+  :prefLabel "Stereograph card"@en ;
+  :prefLabel "Stereo"@sv ;
+  :definition "A carrier type that consists of a card bearing stereographic images."@en ;
+  :definition "Kort med stereoskopiska bilder."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierType/1042> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q105821864> ;
+  :note "007 (Bilder: k)" ,
+    "01 (Särskild bärarbeteckning): h" ,
+    "Fotografi, positiv" ,
+    """En positiv fototekniskt framställd bild. Fotografiet återger en positiv bild direkt eller indirekt på ett material som kemiskt eller fysikaliskt påverkas av ljus. Termen inkluderar stereografier.
+Se även kod r (röntgenfoto).
+Diabilder, se projicerbara stillbilder""" ,
+    "Medietyp: stereografisk" .
+
+<carriertype/StereographDisc> a :CarrierType ;
+  :prefLabel "Stereograph disc"@en ;
+  :prefLabel "Stereo"@sv ;
+  :altLabel "Stereograph reel"@en ;
+  :definition "A carrier type that consists of a disc with openings around the perimeter holding pairs of still images designed for use with a stereograph viewer."@en ;
+  :definition "Skiva med öppningar runt omkretsen innehållande par av stillbilder avsedd för användning i ett stereoskop."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierType/1043> ;
+  :closeMatch <https://libris.kb.se/katalogisering/9bjqfnvdc50pqp5c> ,
+    <https://www.wikidata.org/wiki/Q105821863> .
+
+<carriertype/Card> a :CarrierType ;
+  :prefLabel "Card"@en ;
+  :prefLabel "Kort (no)"@sv ;
+  :definition "A carrier type that consists of a small sheet of opaque material."@en ;
+  :definition "Litet ark i ogenomskinligt material."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierType/1045> ;
+  :note "Motsvarande MARC-kod saknas." ,
+    "Medietyp: oförmedlad" .
+
+<carriertype/Flipchart> a :CarrierType ;
+  :prefLabel "Flipchart"@en ;
+  :prefLabel "Blädderblock (n"@sv ;
+  :definition "A carrier type that consists of a hinging device holding two or more sheets designed for use on an easel."@en ;
+  :definition "Upphängd anordning med två eller flera ark avsedd för användning på ett staffli."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierType/1046> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q1428941> ;
+  :note "Motsvarande MARC-kod saknas." ,
+    "Medietyp: oförmedlad" .
+
+<carriertype/Roll> a :CarrierType ;
+  :prefLabel "Roll"@en ;
+  :prefLabel "Rulle (na)"@sv ;
+  :definition "A carrier type that consists of a wound length of paper, film, tape, etc."@en ;
+  :definition "Lindad bit papper, film, band osv."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierType/1047> ;
+  :note "Motsvarande MARC-kod saknas." ,
+    "Medietyp: oförmedlad" .
+
+<carriertype/Sheet> a :CarrierType ;
+  :prefLabel "Sheet"@en ;
+  :prefLabel "Ark (nb)"@sv ;
+  :definition "A carrier type that consists of a flat, thin piece of paper, plastic, etc."@en ;
+  :definition "Platt, tunn bit papper, plast osv."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierType/1048> ;
+  :closeMatch <http://vocab.getty.edu/page/aat/300014671> ;
+  :note "Motsvarande MARC-kod saknas." ,
+    "Medietyp: oförmedlad" .
+
+<carriertype/Volume> a :CarrierType ;
+  :prefLabel "Volume"@en ;
+  :prefLabel "Volym (nc)"@sv ;
+  :definition "A carrier type that consists of one or more sheets bound or fastened together to form a single unit."@en ;
+  :definition "Ett eller flera ark som är bundna eller fästa tillsammans och utgör en enstaka enhet."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierType/1049> ;
+  :closeMatch <http://vocab.getty.edu/page/aat/300265632> ;
+  :note "Motsvarande MARC-kod saknas." ,
+    "Medietyp: oförmedlad" .
+
+<carriertype/VideoCartridge> a :CarrierType ;
+  :prefLabel "Video cartridge"@en ;
+  :prefLabel "Videomagasin"@sv ;
+  :definition "A carrier type that consists of a cartridge containing a video tape."@en ;
+  :definition "Magasin innehållande ett videoband."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierType/1051> ;
+  :closeMatch <https://libris.kb.se/katalogisering/b5wzhpwfd1n5h50x> ,
+    <https://www.wikidata.org/wiki/Q105063216> .
+
+<carriertype/Videocassette> a :CarrierType ;
+  :prefLabel "Videocassette"@en ;
+  :prefLabel "Videokassett"@sv ;
+  :definition "A carrier type that consists of a cassette containing a video tape."@en ;
+  :definition "Kassett innehållande ett videoband."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierType/1052> ;
+  :closeMatch <https://libris.kb.se/katalogisering/j6s1pw3ml0hm2rv1> ,
+    <http://vocab.getty.edu/page/aat/300028692> .
+
+<carriertype/VideotapeReel> a :CarrierType ;
+  :prefLabel "Videotape reel"@en ;
+  :prefLabel "Videospole"@sv ;
+  :definition "A carrier type that consists of an open reel holding a video tape for use with reel-to-reel video equipment."@en ;
+  :definition "Öppen spole med ett videoband för användning i videobandspelare med öppna spolar."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierType/1053> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q60533098> ;
+  :note "007 (Videoupptagning: v)" ,
+    """01 (Särskild bärarbeteckning): r
+Videospole""" ,
+    "Kommer ut i 338 #a Videokassett #b r #2 rdacarrier" ,
+    "Medietyp: video" .
+
+<carriertype/MicrofilmRoll> a :CarrierType ;
+  :prefLabel "Microfilm roll"@en ;
+  :prefLabel "Mikrofilmsrulle"@sv ;
+  :definition "A carrier type that consists of a wound length of microfilm."@en ;
+  :definition "Rullad mikrofilm."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierType/1056> ;
+  :closeMatch <https://libris.kb.se/katalogisering/xm8d39h102rnhwh2> ,
+    <https://www.wikidata.org/wiki/Q105763578> .
+
+<carriertype/Object> a :CarrierType ;
+  :prefLabel "Object"@en ;
+  :prefLabel "Föremål (nr)"@sv ;
+  :definition "A carrier type that consists of a three-dimensional artifact, a replica of an artifact, or a naturally-occurring object."@en ;
+  :definition "Tredimensionell konstprodukt, en replik av en konstprodukt eller ett naturligt förekommande föremål."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierType/1059> ;
+  :closeMatch <http://vocab.getty.edu/page/aat/300311889> ;
+  :note "Motsvarande MARC-kod saknas." ,
+    "Leader 06: r (Resurs i form av tredimensionellt föremål, tillverkat eller hämtat från naturen)" ,
+    "Medietyp: oförmedlad" .
+
+<carriertype/Videodisc> a :CarrierType ;
+  :prefLabel "Videodisc"@en ;
+  :prefLabel "Videoskiva"@sv ;
+  :definition "A carrier type that consists of a disc on which video signals, with or without sound, are recorded."@en ;
+  :definition "Skiva på vilken videosignaler, med eller utan ljud, är inspelade."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierType/1060> ;
+  :closeMatch <https://libris.kb.se/katalogisering/n044v17rq237f8xm> ,
+    <https://libris.kb.se/katalogisering/n044v17rq237f8xm> ,
+    <https://libris.kb.se/katalogisering/n044v17rq237f8xm> ,
+    <http://vocab.getty.edu/page/aat/300028685> ,
+    <https://www.wikidata.org/wiki/Q764322> .
+
+<carriertype/FilmRoll> a :CarrierType ;
+  :prefLabel "Film roll"@en ;
+  :prefLabel "Filmrulle (mo)"@sv ;
+  :definition "A carrier type that consists of a wound length of film."@en ;
+  :definition "Rullad film."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierType/1069> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q105763494> ;
+  :note "007 (Spelfilmer: m)" ,
+    """01 (Särskild bärarbeteckning): o
+film roll (saknas i Formathandboken)""" ,
+    "Saknas som MARC-kod i Libris" ,
+    "Medietyp: projicerad" .
+
+<carriertype/AudioBelt> a :CarrierType ;
+  :prefLabel "Audio belt"@en ;
+  :prefLabel "Ljudslinga (sb)"@sv ;
+  :definition "A carrier type that consists of a loop of flexible plastic or magnetic film on which audio signals are mechanically recorded, commonly known under the trade name Dictabelt."@en ;
+  :definition "Slinga av böjlig plast- eller magnetfilm på vilken ljudsignaler är mekaniskt inspelade, vanligen av märket Dictabelt."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierType/1070> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q105822022> ;
+  :note "007 (Ljudupptagning: s)" ,
+    """01 (Särskild bärarbeteckning): b
+audio belt (saknas i Formathandboken)""" ,
+    "Saknas helt i Libris" ,
+    "Medietyp: ljud" .
+
+<carriertype/AudioWireReel> a :CarrierType ;
+  :prefLabel "Audio wire reel"@en ;
+  :prefLabel "Ljudtråd (sw)"@sv ;
+  :definition "A carrier type that consists of a reel or spool of steel or stainless steel wire upon which audio signals are magnetically recorded."@en ;
+  :definition "Rulle eller spole med ståltråd av vanligt eller rostfritt stål, på vilken ljudsignaler är magnetiskt inspelade."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACarrierType/1071> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q105822335> ;
+  :note "007 (Ljudupptagning: s)" ,
+    """01 (Särskild bärarbeteckning): w
+Ljudtråd""" ,
+    "Kommer ut i 338 #a Ljudtråd  #b w #2 rdacarrier" ,
+    "Medietyp: ljud" .
+
+<cartographicdatatype/Raster> a :CartographicDataType ;
+  :prefLabel "Raster"@en ;
+  :prefLabel "Raster"@sv ;
+  :definition "A cartographic data type that uses a dot matrix data structure to represent geospatial features in a usually rectangular grid of pixels."@en ;
+  :definition "En kartografisk datatyp som använder punktmatrisdata för att framställa geospatiala kännetecken i ett vanligen rektangulärt rutnät av pixlar."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACartoDT/1001> ;
+  :note "352 #a (term)" .
+
+<cartographicdatatype/Vector> a :CartographicDataType ;
+  :prefLabel "Vector"@en ;
+  :prefLabel "Vektor"@sv ;
+  :definition "A cartographic data type that uses polygons specified by vectors to represent geospatial features."@en ;
+  :definition "En kartografisk datatyp som använder månghörningar bestämda av vektorer för att framställa geospatiala kännetecken."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACartoDT/1002> ;
+  :note "352 #a (term)" .
+
+<cartographicdatatype/Point> a :CartographicDataType ;
+  :prefLabel "Point"@en ;
+  :prefLabel "Punkt"@sv ;
+  :definition "A cartographic data type that uses points to represent geospatial features."@en ;
+  :definition "En kartografisk datatyp som använder punkter för att framställa geospatiala kännetecken."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDACartoDT/1003> ;
+  :note "352 #a (term)" .
+
+<collectionaccrualmethod/Loan> a :CollectionAccrualMethod ;
+  :prefLabel "Loan"@en ;
+  :prefLabel "Lån"@sv ;
+  :definition "A collection accrual method that adds items to a collection for a fixed or open-ended timespan with no transfer of ownership or financial transaction."@en ;
+  :exactMatch <http://rdaregistry.info/termList/RDACollectionAccrualMethod/1001> ;
+  :closeMatch <http://purl.org/cld/accmeth/loan> .
+
+<collectionaccrualmethod/Deposit> a :CollectionAccrualMethod ;
+  :prefLabel "Deposit"@en ;
+  :prefLabel "Deposition"@sv ;
+  :definition "A collection accrual method that adds items to a collection permanently with no transfer of ownership or financial transaction."@en ;
+  :exactMatch <http://rdaregistry.info/termList/RDACollectionAccrualMethod/1002> ;
+  :closeMatch <http://purl.org/cld/accmeth/deposit> .
+
+<collectionaccrualmethod/Donation> a :CollectionAccrualMethod ;
+  :prefLabel "Donation"@en ;
+  :prefLabel "Donation"@sv ;
+  :definition "A collection accrual method that adds items to a collection permanently with a transfer of ownership but no financial transaction."@en ;
+  :exactMatch <http://rdaregistry.info/termList/RDACollectionAccrualMethod/1003> ;
+  :closeMatch <http://purl.org/cld/accmeth/donation> .
+
+<collectionaccrualmethod/License> a :CollectionAccrualMethod ;
+  :prefLabel "License"@en ;
+  :prefLabel "Licens"@sv ;
+  :definition "A collection accrual method that adds items to a collection for a fixed or open-ended timespan with no transfer of ownership but with a financial transaction."@en ;
+  :exactMatch <http://rdaregistry.info/termList/RDACollectionAccrualMethod/1004> ;
+  :closeMatch <http://purl.org/cld/accmeth/license> .
+
+<collectionaccrualmethod/Purchase> a :CollectionAccrualMethod ;
+  :prefLabel "Purchase"@en ;
+  :prefLabel "Köp"@sv ;
+  :definition "A collection accrual method that adds items to a collection permanently with a transfer of ownership and a financial transaction."@en ;
+  :exactMatch <http://rdaregistry.info/termList/RDACollectionAccrualMethod/1005> ;
+  :closeMatch <http://purl.org/cld/accmeth/purchase> .
+
+<collectionaccrualpolicy/Closed> a :CollectionAccrualPolicy ;
+  :prefLabel "Closed"@en ;
+  :prefLabel "Stängd"@sv ;
+  :definition "A collection accrual policy that does not add items to a collection."@en ;
+  :exactMatch <http://rdaregistry.info/termList/RDACollectionAccrualPolicy/1001> ;
+  :closeMatch <http://purl.org/cld/accpol/closed> .
+
+<collectionaccrualpolicy/Passive> a :CollectionAccrualPolicy ;
+  :prefLabel "Passive"@en ;
+  :prefLabel "Passiv"@sv ;
+  :definition "A collection accrual policy that adds items to a collection when the items are in scope for the collection but have been acquired for other reasons."@en ;
+  :exactMatch <http://rdaregistry.info/termList/RDACollectionAccrualPolicy/1002> ;
+  :closeMatch <http://purl.org/cld/accpol/passive> .
+
+<collectionaccrualpolicy/Active> a :CollectionAccrualPolicy ;
+  :prefLabel "Active"@en ;
+  :prefLabel "Aktiv"@sv ;
+  :definition "A collection accrual policy that seeks, acquires, and adds items to a collection."@en ;
+  :exactMatch <http://rdaregistry.info/termList/RDACollectionAccrualPolicy/1003> ;
+  :closeMatch <http://purl.org/cld/accpol/active> .
+
+<collectionaccrualpolicy/Selective> a :CollectionAccrualPolicy ;
+  :prefLabel "Selective"@en ;
+  :prefLabel "Selektiv"@sv ;
+  :definition "A collection accrual policy that adds items to one or more subcollections of a collection."@en ;
+  :exactMatch <http://rdaregistry.info/termList/RDACollectionAccrualPolicy/1004> .
+
+<colourcontent/Monochrome> a :ColourContent ;
+  :prefLabel "Monochrome"@en ;
+  :prefLabel "Monokrom"@sv ;
+  :definition "A colour content that consists of tones of one colour, or black and white, or black or white and another colour."@en ;
+  :definition "Ett färginnehåll som består av toner av en färg, eller svartvit eller svart, vit och en annan färg."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAColourContent/1002> ;
+  :closeMatch <http://vocab.getty.edu/page/aat/300137660> ;
+  :note "007/03" ,
+    "Kartor: a" ,
+    "Digitalt lagrade resurser: a, b, g" ,
+    "Glober: a" ,
+    "Projicerbara stillbilder: a, b" ,
+    "Stillbilder: a, b" ,
+    "Videoupptagningar: (a), b" ,
+    "007/09" ,
+    "Mikroformer: b" ,
+    "340 #g (term)" .
+
+<colourcontent/Polychrome> a :ColourContent ;
+  :prefLabel "Polychrome"@en ;
+  :prefLabel "Polykrom"@sv ;
+  :definition "A colour content that consists of two colours, neither of which is black or white, or more than two colours."@en ;
+  :definition "Ett färginnehåll som består av två färger, varav ingen är svart eller vit, eller fler än två färger."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAColourContent/1003> ;
+  :closeMatch <http://vocab.getty.edu/page/aat/300252261> ;
+  :note "007/03" ,
+    "Kartor: c" ,
+    "Digitalt lagrade resurser: c, (m)" ,
+    "Glober: c" ,
+    "Projicerbara stillbilder: c, (m)" ,
+    "Stillbilder: c, (m)" ,
+    "Videoupptagningar: c, (m)" ,
+    "007/09" ,
+    "Mikroformer: c, (m)" ,
+    "340 #g (term)" .
+
+<contenttype/CartographicDataset> a :ContentType ;
+  :prefLabel "Cartographic dataset"@en ;
+  :prefLabel "Kartografiskt dataset"@sv ;
+  :definition "A content type that consists of cartographic content expressed through a digitally encoded dataset intended to be processed by a computer."@en ;
+  :definition "Innehållstyp som betecknar kartografiskt innehåll uttryckt med ett digitalt kodat dataset avsett att processas av en dator."@sv ;
+  :scopeNote "A cartographic dataset excludes cartographic data intended to be perceived in the form of an image or three-dimensional form."@en ;
+  :scopeNote "Omfattar inte kartografiska data avsedda att uppfattas i form av en bild eller en tredimensionell form."@sv ;
+  :related <CartographicMovingImage> ,
+    <CartographicTactileImage> ,
+    <CartographicTactileThreeDimensionalForm> ,
+    <CartographicThreeDimensionalForm> ,
+    <CartographicImage> ,
+    <ComputerDataset> ;
+  :exactMatch <http://rdaregistry.info/termList/RDAContentType/1001> ;
+  :note "336 #a (term)" .
+
+<contenttype/CartographicImage> a :ContentType ;
+  :prefLabel "Cartographic image"@en ;
+  :prefLabel "Kartografisk bild"@sv ;
+  :definition "A content type that consists of cartographic content expressed through line, shape, shading, etc., intended to be perceived visually as a still image or images in two dimensions."@en ;
+  :definition "Innehållstyp som betecknar kartografiskt innehåll uttryckt med linjer, former, skuggor, etc., avsett att uppfattas visuellt som stillbild eller stillbilder i två dimensioner."@sv ;
+  :scopeNote "Maps, views, atlases, remote-sensing images, etc., are included."@en ;
+  :scopeNote "Related Terms:"@sv ;
+  :related <StillImage> ,
+    <CartographicDataset> ;
+  :exactMatch <http://rdaregistry.info/termList/RDAContentType/1002> ;
+  :note "336 #a (term)" .
+
+<contenttype/CartographicMovingImage> a :ContentType ;
+  :prefLabel "Cartographic moving image"@en ;
+  :prefLabel "Kartografisk rörlig bild"@sv ;
+  :definition "A content type that consists of cartographic content expressed through images intended to be perceived as moving, in two dimensions."@en ;
+  :definition "Innehållstyp som betecknar kartografiskt innehåll uttryckt med bilder avsett att uppfattas som rörliga, i två dimensioner."@sv ;
+  :scopeNote "Satellite images of the earth or other celestial bodies in motion are included."@en ;
+  :scopeNote "Related Terms:"@sv ;
+  :related <TwoDimensionalMovingImage> ,
+    <CartographicDataset> ;
+  :exactMatch <http://rdaregistry.info/termList/RDAContentType/1003> ;
+  :note "336 #a (term)" .
+
+<contenttype/CartographicTactileImage> a :ContentType ;
+  :prefLabel "Cartographic tactile image"@en ;
+  :prefLabel "Kartografisk taktil bild"@sv ;
+  :definition "A content type that consists of cartographic content expressed through line, shape, and/or other forms, intended to be perceived through touch as a still image in two dimensions."@en ;
+  :definition "Innehållstyp som betecknar kartografiskt innehåll uttryckt med linjer, former och/eller andra former avsett att uppfattas genom beröring som stillbild i två dimensioner."@sv ;
+  :related <CartographicDataset> ;
+  :exactMatch <http://rdaregistry.info/termList/RDAContentType/1004> ;
+  :note "336 #a (term)" .
+
+<contenttype/CartographicTactileThreeDimensionalForm> a :ContentType ;
+  :prefLabel "Cartographic tactile three-dimensional form"@en ;
+  :prefLabel "Kartografisk taktil tredimensionell form"@sv ;
+  :definition "A content type that consists of cartographic content expressed through a form or forms intended to be perceived through touch as a three-dimensional form or forms."@en ;
+  :definition "Innehållstyp som betecknar kartografiskt innehåll uttryckt med form eller former avsett att uppfattas genom beröring som tredimensionell/a form/former."@sv ;
+  :related <CartographicDataset> ;
+  :exactMatch <http://rdaregistry.info/termList/RDAContentType/1005> ;
+  :note "336 #a (term)" .
+
+<contenttype/CartographicThreeDimensionalForm> a :ContentType ;
+  :prefLabel "Cartographic three-dimensional form"@en ;
+  :definition "A content type that consists of cartographic content expressed through a form or forms intended to be perceived visually in three-dimensions."@en ;
+  :definition "Innehållstyp som betecknar kartografiskt innehåll uttryckt med form eller former avsett att uppfattas visuellt i tre dimensioner."@sv ;
+  :scopeNote "Globes, relief models, etc., are included."@en ;
+  :scopeNote "Related Terms:"@sv ;
+  :related <TactileThreeDimensionalForm> ,
+    <ThreeDimensionalForm> ,
+    <CartographicDataset> ;
+  :exactMatch <http://rdaregistry.info/termList/RDAContentType/1006> ;
+  :note "336 #a (term)" .
+
+<contenttype/ComputerDataset> a :ContentType ;
+  :prefLabel "Computer dataset"@en ;
+  :prefLabel "Dataset"@sv ;
+  :definition "A content type that consists of content expressed through a digitally encoded dataset intended to be processed by a computer."@en ;
+  :definition "Innehållstyp som betecknar innehåll uttryckt med ett digitalt kodat dataset avsett att processas av en dator."@sv ;
+  :scopeNote "Numeric data, environmental data, etc., used by applications software to calculate averages, correlations, etc., or to produce models, etc., but not normally displayed in its raw form, are included. Excludes data intended to be perceived visually in the form of notation, image, or three-dimensional form."@en ;
+  :scopeNote "Omfattar inte data avsedda att uppfattas visuellt i notationsform, bild eller tredimonesionell form."@sv ;
+  :related <CartographicDataset> ,
+    <NotatedMovement> ,
+    <NotatedMusic> ,
+    <StillImage> ,
+    <Text> ,
+    <TwoDimensionalMovingImage> ,
+    <ThreeDimensionalMovingImage> ,
+    <ThreeDimensionalForm> ,
+    <SpokenWord> ,
+    <Sounds> ,
+    <PerformedMusic> ;
+  :exactMatch <http://rdaregistry.info/termList/RDAContentType/1007> ;
+  :note "336 #a (term)" .
+
+<contenttype/ComputerProgram> a :ContentType ;
+  :prefLabel "Computer program"@en ;
+  :prefLabel "Datorprogram"@sv ;
+  :definition "A content type that consists of content expressed through digitally encoded instructions intended to be processed and performed by a computer."@en ;
+  :definition "Innehållstyp som betecknar innehåll uttryckt med digitalt kodade instruktioner avsett att processas av en dator."@sv ;
+  :scopeNote "Operating systems, applications software, etc., are included."@en ;
+  :scopeNote "Omfattar operativsystem, mjukvaruapplikationer etc."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAContentType/1008> ;
+  :note "336 #a (term)" .
+
+<contenttype/NotatedMovement> a :ContentType ;
+  :prefLabel "Notated movement"@en ;
+  :prefLabel "Noterad rörelse"@sv ;
+  :definition "A content type that consists of content expressed through a form of notation for movement intended to be perceived visually."@en ;
+  :definition "Innehållstyp som betecknar innehåll uttryckt med notation för rörelse avsett att uppfattas visuellt."@sv ;
+  :scopeNote "All forms of movement notation other than those intended to be perceived through touch are included."@en ;
+  :scopeNote "Related Terms:"@sv ;
+  :related <ComputerDataset> ,
+    <TactileNotatedMovement> ;
+  :exactMatch <http://rdaregistry.info/termList/RDAContentType/1009> ;
+  :note "336 #a (term)" .
+
+<contenttype/NotatedMusic> a :ContentType ;
+  :prefLabel "Notated music"@en ;
+  :prefLabel "Noterad musik"@sv ;
+  :definition "A content type that consists of content expressed through a form of musical notation intended to be perceived visually."@en ;
+  :definition "Innehållstyp som betecknar innehåll uttryckt med musiknotation avsett att uppfattas visuellt."@sv ;
+  :scopeNote "All forms of music notation other than those intended to be perceived through touch are included."@en ;
+  :scopeNote "Omfattar alla typer av musiknotation förutom sådan som är avsedd att uppfattas genom beröring."@sv ;
+  :related <ComputerDataset> ,
+    <TactileNotatedMusic> ;
+  :exactMatch <http://rdaregistry.info/termList/RDAContentType/1010> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q109274999> ;
+  :note "336 #a (term)" ,
+    "007/00 = q" .
+
+<contenttype/PerformedMovement> a :ContentType ;
+  :prefLabel "Performed movement"@en ;
+  :prefLabel "Framförd rörelse"@sv ;
+  :definition "A content type that consists of content expressed through choreography in a visual form."@en ;
+  :definition "Innehållstyp som betecknar innehåll uttryckt med koreografi i visuell form."@sv ;
+  :scopeNote "Includes performed dance and mime, and animated choreography."@en ;
+  :scopeNote "Omfattar framförd dans och pantomim samt animerad koreografi."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAContentType/1024> ;
+  :note "336 #a (term)" .
+
+<contenttype/PerformedMusic> a :ContentType ;
+  :prefLabel "Performed music"@en ;
+  :prefLabel "Framförd musik"@sv ;
+  :definition "A content type that consists of content expressed through music in an audible form."@en ;
+  :definition "Innehållstyp som betecknar innehåll uttryckt med hörbar musik."@sv ;
+  :scopeNote "Recorded performances of music, computer-generated music, etc., are included."@en ;
+  :scopeNote "Omfattar inspelade musikframföranden, datorgenererad musik etc."@sv ;
+  :related <ComputerDataset> ;
+  :exactMatch <http://rdaregistry.info/termList/RDAContentType/1011> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q106805967> ;
+  :note "336 #a (term)" .
+
+<contenttype/Sounds> a :ContentType ;
+  :prefLabel "Sounds"@en ;
+  :prefLabel "Ljud (utom tal och musik)"@sv ;
+  :definition "A content type that consists of content other than language or music, expressed in an audible form."@en ;
+  :definition "Innehållstyp som betecknar annat innehåll än språk eller musik, uttryckt i hörbar form."@sv ;
+  :scopeNote "Natural sounds, artificially produced sounds, etc., are included."@en ;
+  :scopeNote "Omfattar naturligt förekommande ljud, artificiellt framställda ljud etc."@sv ;
+  :related <ComputerDataset> ;
+  :exactMatch <http://rdaregistry.info/termList/RDAContentType/1012> ;
+  :note "336 #a (term)" .
+
+<contenttype/SpokenWord> a :ContentType ;
+  :prefLabel "Spoken word"@en ;
+  :prefLabel "Tal"@sv ;
+  :definition "A content type that consists of content expressed through language in an audible form."@en ;
+  :definition "Innehållstyp som betecknar innehåll uttryckt med hörbart språk."@sv ;
+  :scopeNote "Recorded readings, recitations, speeches, interviews, oral histories, etc., computer-generated speech, etc., are included."@en ;
+  :scopeNote "Omfattar inspelade uppläsningar, tal, intervjuer, muntliga historier, etc., datorgenererat tal, etc."@sv ;
+  :related <ComputerDataset> ;
+  :exactMatch <http://rdaregistry.info/termList/RDAContentType/1013> ;
+  :note "336 #a (term)" .
+
+<contenttype/StillImage> a :ContentType ;
+  :prefLabel "Still image"@en ;
+  :prefLabel "Stillbild"@sv ;
+  :definition "A content type that consists of content expressed through line, shape, shading, etc., intended to be perceived visually as a still image or images in two dimensions."@en ;
+  :definition "Innehållstyp som betecknar innehåll uttryckt med linjer, former, etc., avsett att uppfattas visuellt som stillbild eller stillbilder i två dimensioner."@sv ;
+  :scopeNote "Drawings, paintings, diagrams, photographic images known as stills, etc., are included."@en ;
+  :scopeNote "Omfattar teckningar, målningar, diagram, fotografiska bilder, etc.."@sv ;
+  :related <ComputerDataset> ,
+    <CartographicImage> ,
+    <TactileImage> ;
+  :exactMatch <http://rdaregistry.info/termList/RDAContentType/1014> ;
+  :note "336 #a (term)" .
+
+<contenttype/TactileImage> a :ContentType ;
+  :prefLabel "Tactile image"@en ;
+  :prefLabel "Taktil bild"@sv ;
+  :definition "A content type that consists of content expressed through line, shape, and/or other forms, intended to be perceived through touch as a still image in two dimensions."@en ;
+  :definition "Innehållstyp som betecknar innehåll uttryckt med linjer och/eller former, avsett att uppfattas genom beröring som stillbild i en dimension."@sv ;
+  :related <StillImage> ;
+  :exactMatch <http://rdaregistry.info/termList/RDAContentType/1015> ;
+  :note "336 #a (term)" .
+
+<contenttype/TactileNotatedMovement> a :ContentType ;
+  :prefLabel "Tactile notated movement"@en ;
+  :prefLabel "Taktil noterad rörelse"@sv ;
+  :definition "A content type that consists of content expressed through a form of notation for movement intended to be perceived through touch."@en ;
+  :definition "Innehållstyp som betecknar innehåll uttryckt med rörelsenotation avsett att uppfattas genom beröring."@sv ;
+  :related <NotatedMovement> ;
+  :exactMatch <http://rdaregistry.info/termList/RDAContentType/1017> ;
+  :note "336 #a (term)" .
+
+<contenttype/TactileNotatedMusic> a :ContentType ;
+  :prefLabel "Tactile notated music"@en ;
+  :prefLabel "Taktil noterad musik"@sv ;
+  :definition "A content type that consists of content expressed through a form of musical notation intended to be perceived through touch."@en ;
+  :definition "Innehållstyp som betecknar innehåll uttryckt med musiknotation avsett att uppfattas genom beröring."@sv ;
+  :scopeNote "Braille music and other tactile forms of musical notation are included."@en ;
+  :scopeNote "Omfattar puntskiftsmusik och andra former av musiknotation."@sv ;
+  :related <NotatedMusic> ;
+  :exactMatch <http://rdaregistry.info/termList/RDAContentType/1016> ;
+  :note "336 #a (term)" .
+
+<contenttype/TactileText> a :ContentType ;
+  :prefLabel "Tactile text"@en ;
+  :prefLabel "Taktil text"@sv ;
+  :definition "A content type that consists of content expressed through a form of notation for language intended to be perceived through touch."@en ;
+  :definition "Innehållstyp som betecknar innehåll uttryckt med språknotation avsett att uppfattas genom beröring."@sv ;
+  :scopeNote "Braille text and other tactile forms of language notation are included."@en ;
+  :scopeNote "Omfattar punktskrift och andra taktila språknotationer."@sv ;
+  :related <Text> ;
+  :exactMatch <http://rdaregistry.info/termList/RDAContentType/1018> ;
+  :note "336 #a (term)" .
+
+<contenttype/TactileThreeDimensionalForm> a :ContentType ;
+  :prefLabel "Tactile three-dimensional form"@en ;
+  :prefLabel "Taktil tredimensionell form"@sv ;
+  :definition "A content type that consists of content expressed through a form or forms intended to be perceived through touch as a three-dimensional form or forms."@en ;
+  :definition "Innehållstyp som betecknar innehåll uttryckt i form eller former avsedda att uppfattas genom beröring som tredimensionell/a form/fomer."@sv ;
+  :related <ThreeDimensionalForm> ,
+    <CartographicThreeDimensionalForm> ;
+  :exactMatch <http://rdaregistry.info/termList/RDAContentType/1019> ;
+  :note "336 #a (term)" .
+
+<contenttype/Text> a :ContentType ;
+  :prefLabel "Text"@en ;
+  :prefLabel "Text"@sv ;
+  :definition "A content type that consists of content expressed through a form of notation for language intended to be perceived visually."@en ;
+  :definition "Innehållstyp som betecknar innehåll uttryckt med språknotation avsett att uppfatttas visuellt."@sv ;
+  :scopeNote "All forms of language notation other than those intended to be perceived through touch are included."@en ;
+  :scopeNote "Omfattar alla former av språknotation förutom sådana avsedda att uppfattad genom beröring."@sv ;
+  :related <ComputerDataset> ,
+    <TactileText> ;
+  :exactMatch <http://rdaregistry.info/termList/RDAContentType/1020> ;
+  :note "336 #a (term)" ,
+    "007/00 = t" .
+
+<contenttype/ThreeDimensionalForm> a :ContentType ;
+  :prefLabel "Three-dimensional form"@en ;
+  :prefLabel "Tredimensionell form"@sv ;
+  :definition "A content type that consists of content expressed through a form or forms intended to be perceived visually in three-dimensions."@en ;
+  :definition "Innehållstyp som betecknar innehåll uttryckt genom form eller former avsedda att uppfattas visuellt i tre dimensioner."@sv ;
+  :scopeNote "Sculptures, models, naturally occurring objects and specimens, holograms, etc., are included. Excludes cartographic content intended to be perceived as a three-dimensional form. Excludes three-dimensional forms intended to be perceived through touch."@en ;
+  :scopeNote "Omfattar skulpturer, modeller, naturligt förekommande föremål, provexemplar?, hologram etc."@sv ;
+  :related <TactileThreeDimensionalForm> ,
+    <ComputerDataset> ,
+    <CartographicThreeDimensionalForm> ;
+  :exactMatch <http://rdaregistry.info/termList/RDAContentType/1021> ;
+  :note "336 #a (term)" .
+
+<contenttype/ThreeDimensionalMovingImage> a :ContentType ;
+  :prefLabel "Three-dimensional moving image"@en ;
+  :prefLabel "Tredimensionell rörlig bild"@sv ;
+  :definition "A content type that consists of content expressed through images intended to be perceived to be moving, and in three dimensions."@en ;
+  :definition "Innehållstyp som betecknar innehåll uttryckt med bilder avsedda att uppfattas som rörliga och i tre dimensioner."@sv ;
+  :scopeNote "Three-dimensional motion pictures using live action or animation, and stereoscopic, known as S-3D, video games, etc., are included. Three-dimensional moving images may or may not be accompanied by sound."@en ;
+  :scopeNote "Omfattar tredimensionell film som använder spel?eller animation och stereoskopi, även känd som S-3D, datorspel, etc. Tredimensionell rörlig bild, kan vara med eller utan ljud."@sv ;
+  :related <ComputerDataset> ,
+    <CartographicMovingImage> ,
+    <TwoDimensionalMovingImage> ;
+  :exactMatch <http://rdaregistry.info/termList/RDAContentType/1022> ;
+  :note "336 #a (term)" .
+
+<contenttype/TwoDimensionalMovingImage> a :ContentType ;
+  :prefLabel "Two-dimensional moving image"@en ;
+  :prefLabel "Tvådimensionell rörlig bild"@sv ;
+  :definition "A content type that consists of content expressed through images intended to be perceived to be moving, and in two dimensions."@en ;
+  :definition "Innehållstyp som betecknar innehåll uttryckt genom bilder avsedda att uppfattas som rörliga och i två dimensioner."@sv ;
+  :scopeNote "Motion pictures using live action and/or animation, film and video recordings of performances, events, etc., other than those intended to be perceived in three dimensions, are included. Moving images may or may not be accompanied by sound."@en ;
+  :scopeNote "Omfattar film som använder spel? och/eller animation, film- eller videoupptagningar av framföranden, händelser etc. förutom sådana som är avsedda att uppfattas i tre dimensioner. Rörlig bild kan vara med eller utan ljud."@sv ;
+  :related <ComputerDataset> ,
+    <CartographicMovingImage> ,
+    <ThreeDimensionalMovingImage> ;
+  :exactMatch <http://rdaregistry.info/termList/RDAContentType/1023> ;
+  :note "336 #a (term)" .
+
+<cylindergroovepitch/Fine> a :CylinderGroovePitch ;
+  :prefLabel "Fine"@en ;
+  :prefLabel "[svensk term saknas]"@sv ;
+  :definition "A groove pitch for an analog cylinder in the range of 60-64 turns per cm, or 150 or 160 turns per inch, for 6 1/8 inch dictation format cylinders, or 200 turns per inch for 4-minute cylinders."@en ;
+  :definition "Spårstorlek för en analog cylinder med  60-64 varv per cm (150 eller 160 varv per tum) för"@sv ;
+  :exactMatch <http://rdaregistry.info/termList/groovePitch/1005> ;
+  :note "007 (ljudupptagningar)" ,
+    "/05 (spår):" ,
+    "344 #d (term)" .
+
+<cylindergroovepitch/Standard> a :CylinderGroovePitch ;
+  :prefLabel "Standard"@en ;
+  :prefLabel "[svensk term saknas]"@sv ;
+  :definition "A groove pitch for an analog cylinder of 40 turns per cm or 100 turns per inch."@en ;
+  :definition "Spåregenskap för analoga cylindrar"@sv ;
+  :exactMatch <http://rdaregistry.info/termList/groovePitch/1006> ;
+  :note "007 (ljudupptagningar)" ,
+    "/05 (spår):" ,
+    "344 #d (term)" .
+
+<discgroovewidth/CoarseGroove> a :DiscGrooveWidth ;
+  :prefLabel "Coarse groove"@en ;
+  :prefLabel "Grovspår"@sv ;
+  :definition "A groove width for an analog disc typically around 40 grooves per cm or 100 grooves per inch."@en ;
+  :definition "Spårbredd för en analog skiva vanligtvis omkring 40 spår per centimeter eller 100 spår per tum."@sv ;
+  :scopeNote "Coarse groove is generally found in early acoustic and electric recordings that are mostly on shellac carriers."@en ;
+  :exactMatch <http://rdaregistry.info/termList/grooveWidth/1001> ;
+  :note "007 (ljudupptagningar)" ,
+    "/05 (spår):" ,
+    "344 #d (term)" .
+
+<discgroovewidth/Microgroove> a :DiscGrooveWidth ;
+  :prefLabel "Microgroove"@en ;
+  :prefLabel "Mikrospår"@sv ;
+  :definition "A groove width for an analog disc typically in the range 120 to 160 or more per cm or 300 to 400 or more grooves per inch, generally pressed into vinyl and in use post 1945."@en ;
+  :definition "Spårbredd för en analog skiva vanligtvis i området 120 till 160 eller mer per centimeter eller 300 till 400 spår per tum, i allmänhet pressade på vinyl och i bruk efter 1945."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/grooveWidth/1002> ;
+  :note "007 (ljudupptagningar)" ,
+    "/05 (spår): m" ,
+    "344 #d (term)" .
+
+<extensionplan/StaticPlan> a :ExtensionPlan ;
+  :prefLabel "Static plan"@en ;
+  :prefLabel "Statisk plan"@sv ;
+  :definition "An extension plan for a work that is intended to be realized by one or more distinct expressions that are all embodied simultaneously."@en ;
+  :definition "En utgivningsplan för ett verk som är tänkt att förverkligas av ett eller flera distinkta uttryck som alla förverkligas samtidigt."@sv ;
+  :scopeNote "Includes poems, photographs, and completed novels."@en ;
+  :scopeNote "Inkluderar dikter, fotografier och färdiga romaner."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAExtensionPlan/1001> ;
+  :note "335 #a (term)" .
+
+<extensionplan/IntegratingDeterminatePlan> a :ExtensionPlan ;
+  :prefLabel "Integrating determinate plan"@en ;
+  :prefLabel "Integrerande bestämd plan"@sv ;
+  :definition "An extension plan for a work that is intended to be realized by one distinct expression that is embodied during a closed timespan."@en ;
+  :definition "En utgivningsplan för ett verk som är tänkt att förverkligas av ett distinkt uttryck som förverkligas under en bestämd tidsperiod."@sv ;
+  :scopeNote "Includes project wikis, and conference websites."@en ;
+  :scopeNote "Inkluderar projektwikis och konferenswebbplatser."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAExtensionPlan/1002> ;
+  :note "335 #a (term)" .
+
+<extensionplan/IntegratingIndeterminatePlan> a :ExtensionPlan ;
+  :prefLabel "Integrating indeterminate plan"@en ;
+  :prefLabel "Integrerande obestämd plan"@sv ;
+  :definition "An extension plan for a work that is intended to be realized by one distinct expression that is embodied during an open timespan."@en ;
+  :definition "En utgivningsplan för ett verk som är tänkt att förverkligas av ett distinkt uttryck som förverkligas under en obestämd tidsperiod."@sv ;
+  :scopeNote "Includes updated standards, laws, and wikis."@en ;
+  :scopeNote "Inkluderar uppdaterade standarder, lagar och wikis."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAExtensionPlan/1003> ;
+  :note "335 #a (term)" .
+
+<extensionplan/SuccessiveDeterminatePlan> a :ExtensionPlan ;
+  :prefLabel "Successive determinate plan"@en ;
+  :prefLabel "Succesiv bestämd plan"@sv ;
+  :definition "An extension plan for a work that is intended to be realized by multiple distinct expressions that are embodied during a closed timespan."@en ;
+  :definition "En utgivningsplan för ett verk som är tänkt att förverkligas av flera distinkta uttryck som förverkligas under en bestämd tidsperiod."@sv ;
+  :scopeNote "Includes serialized versions of novels, dictionaries, and reference works."@en ;
+  :scopeNote "Inkluderar serialiserade versioner av romaner, ordböcker och uppslagsverk."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAExtensionPlan/1004> ;
+  :note "335 #a (term)" .
+
+<extensionplan/SuccessiveIndeterminatePlan> a :ExtensionPlan ;
+  :prefLabel "Successive indeterminate plan"@en ;
+  :prefLabel "Succesiv obestämd plan"@sv ;
+  :altLabel "Serial work plan"@en ;
+  :definition "An extension plan for a work that is intended to be realized by multiple distinct expressions that are embodied during an open timespan."@en ;
+  :definition "En utgivningsplan för ett verk som är tänkt att förverkligas av flera distinkta uttryck som förverkligas under en obestämd tidsperiod."@sv ;
+  :scopeNote "Includes periodicals, newspapers, series, newsletters, conference proceedings, annual reports, and archived copies of webpages."@en ;
+  :scopeNote "Inkluderar idskrifter, tidningar, serier, nyhetsbrev, konferenshandlingar, årsrapporter och arkiverade kopior av webbsidor."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAExtensionPlan/1005> ;
+  :note "335 #a (term)" .
+
+<filetype/AudioFile> a :FileType ;
+  :prefLabel "Audio file"@en ;
+  :prefLabel "Ljudfil"@sv ;
+  :definition "A file type for storing electronically recorded audio content."@en ;
+  :definition "En filtyp för lagring av elektroniskt inspelat ljudinnehåll."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/fileType/1001> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q26987229> ;
+  :note "008 (Elektronisk resurs)" ,
+    "26 (Typ av elektronisk resurs): h Ljuddokument" ,
+    """Används ej.
+Digitalt lagrat ljud skall betraktas som ljudupptagning (000/06=i/j) med 007/00=c.""" .
+
+<filetype/TextFile> a :FileType ;
+  :prefLabel "Text file"@en ;
+  :prefLabel "Textfil"@sv ;
+  :definition "A file type for storing electronically recorded textual content."@en ;
+  :definition "En filtyp för lagring av elektroniskt inspelat textinnehåll."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/fileType/1002> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q86920> ;
+  :note "008 (Elektronisk resurs)" ,
+    "26 (Typ av elektronisk resurs): d textdokument" ,
+    """Används ej.
+Skall betraktas som språklig resurs (000/06 = a) med fält 007/00 = c.""" .
+
+<filetype/ProgramFile> a :FileType ;
+  :prefLabel "Program file"@en ;
+  :prefLabel "Programfil"@sv ;
+  :definition "A file type for storing electronically recorded programs consisting of organized lists of instructions to be executed by computer software."@en ;
+  :definition "En filtyp för lagring av elektroniskt inspelade program bestående av organiserade listor med instruktioner avsedda att utföras av datorprogram."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/fileType/1003> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q56822593> .
+
+<filetype/ImageFile> a :FileType ;
+  :prefLabel "Image file"@en ;
+  :prefLabel "Bildfil"@sv ;
+  :definition "A file type for storing electronically recorded content representing still images."@en ;
+  :definition "En filtyp för lagring av elektroniskt inspelat innehåll som utgörs av stillbilder."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/fileType/1004> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q860625> .
+
+<filetype/DataFile> a :FileType ;
+  :prefLabel "Data file"@en ;
+  :prefLabel "Datafil"@sv ;
+  :definition "A file type for storing electronically recorded content representing data values."@en ;
+  :definition "En filtyp för lagring av elektroniskt inspelat innehåll som utgörs av datavärden."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/fileType/1005> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q5227290> .
+
+<filetype/VideoFile> a :FileType ;
+  :prefLabel "Video file"@en ;
+  :prefLabel "Videofil"@sv ;
+  :definition "A file type for storing electronically recorded content representing moving images."@en ;
+  :definition "En filtyp för lagring av elektroniskt inspelat innehåll som utgörs av rörliga bilder."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/fileType/1006> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q98405806> .
+
+<fontsize/GiantPrint> a :FontSize ;
+  :prefLabel "Giant print"@en ;
+  :prefLabel "Giant print"@sv ;
+  :altLabel "Super large print"@en ;
+  :definition "A font size that is very large, designed to aid readers who experience difficulty reading large print."@en ;
+  :definition "En teckengrad som är väldigt stor, framtagen för att hjälpa läsare som har svårt att läsa vanlig stil."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/fontSize/1001> ;
+  :note "340 #n (term)" .
+
+<fontsize/LargePrint> a :FontSize ;
+  :prefLabel "Large print"@en ;
+  :prefLabel "Stor stil"@sv ;
+  :definition "A font size designed to aid readers who experience difficulty reading regular print."@en ;
+  :definition "En teckengrad framtagen för att hjälpa läsare som har svårt att läsa vanlig stil."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/fontSize/1002> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q1548123> ;
+  :note "340 #n (term)" .
+
+<fontsize/JumboBraille> a :FontSize ;
+  :prefLabel "Jumbo braille"@en ;
+  :prefLabel "Storstilspunktskrift"@sv ;
+  :definition "A font size of braille text where the individual cells are expanded to give wider spacing between standard size dots or between dots larger than standard size."@en ;
+  :definition "En teckengrad för punktskrift där de individuella cellerna är utökade för att ge större mellanrum mellan punkter av standardstorlek eller mellan punkter som är större än standardstorlek."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/fontSize/1003> ;
+  :note "340 #n (term)" .
+
+<frequency/Daily> a :Frequency ;
+  :prefLabel "Daily"@en ;
+  :prefLabel "Daglig"@sv ;
+  :definition "A frequency for a diachronic work that is issued or updated once every day, usually exclusive of nonworking days."@en ;
+  :definition "Frekvens för en manifestation utgiven eller uppdaterad en gång varje dag, icke arbetsdagar undantagna."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/frequency/1001> ;
+  :note "D" ,
+    "Varje dag" .
+
+<frequency/ThreeTimesAWeek> a :Frequency ;
+  :prefLabel "Three times a week"@en ;
+  :prefLabel "3 nr/vecka"@sv ;
+  :definition "A frequency for a diachronic work that is issued or updated three times every week."@en ;
+  :definition "Frekvens för en manifestation utgiven eller uppdaterad tre gånger varje vecka."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/frequency/1002> ;
+  :note "I" ,
+    "Tre gånger i veckan" .
+
+<frequency/Biweekly> a :Frequency ;
+  :prefLabel "Biweekly"@en ;
+  :prefLabel "Varannan vecka"@sv ;
+  :altLabel "Fortnightly"@en ;
+  :definition "A frequency for a diachronic work that is issued or updated once every two weeks."@en ;
+  :definition "Frekvens för en manifestation utgiven eller uppdaterad en gång varannan vecka."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/frequency/1003> ;
+  :note "E" ,
+    "Varannan vecka" ,
+    "Var fjortonde dag. Se kod s med nästan samma innebörd." .
+
+<frequency/Weekly> a :Frequency ;
+  :prefLabel "Weekly"@en ;
+  :prefLabel "1 nr/vecka"@sv ;
+  :definition "A frequency for a diachronic work that is issued or updated once every week."@en ;
+  :definition "Frekvens för en manifestation utgiven eller uppdaterad en gång varje vecka."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/frequency/1004> ;
+  :note "W" ,
+    "En gång per vecka" .
+
+<frequency/Semiweekly> a :Frequency ;
+  :prefLabel "Semiweekly"@en ;
+  :prefLabel "2 nr/vecka"@sv ;
+  :definition "A frequency for a diachronic work that is issued or updated twice every week."@en ;
+  :definition "Frekvens för en manifestation utgiven eller uppdaterad två gånger varje vecka."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/frequency/1005> ;
+  :note "C" ,
+    "Två gånger per vecka" .
+
+<frequency/ThreeTimesAMonth> a :Frequency ;
+  :prefLabel "Three times a month"@en ;
+  :prefLabel "3 nr/månad"@sv ;
+  :definition "A frequency for a diachronic work that is issued or updated three times every month."@en ;
+  :definition "Frekvens för en manifestation utgiven eller uppdaterad tre gånger gång varje månad."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/frequency/1006> ;
+  :note "J" ,
+    "Tre gånger i månaden" .
+
+<frequency/Bimonthly> a :Frequency ;
+  :prefLabel "Bimonthly"@en ;
+  :prefLabel "Varannan månad"@sv ;
+  :definition "A frequency for a diachronic work that is issued or updated once every two months."@en ;
+  :definition "Frekvens för en manifestation utgiven eller uppdaterad en gång varannan månad."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/frequency/1007> ;
+  :note "B" ,
+    "Varannan månad" ,
+    "Även sex, sju eller åtta gånger per år." .
+
+<frequency/Monthly> a :Frequency ;
+  :prefLabel "Monthly"@en ;
+  :prefLabel "1 nr/månad"@sv ;
+  :definition "A frequency for a diachronic work that is issued or updated once every month."@en ;
+  :definition "Frekvens för en manifestation utgiven eller uppdaterad en gång varje månad."@sv ;
+  :note "M" ,
+    "Varje månad" .
+
+<frequency/Semimonthly> a :Frequency ;
+  :prefLabel "Semimonthly"@en ;
+  :prefLabel "2 nr/månad"@sv ;
+  :definition "A frequency for a diachronic work that is issued or updated twice every month."@en ;
+  :definition "Frekvens för en manifestation utgiven eller uppdaterad två gånger varje månad."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/frequency/1009> ;
+  :note "S" ,
+    "Två  gånger i månaden" ,
+    "Kod e har nästan samma innebörd. Publikationens egen beteckning avgör." .
+
+<frequency/Quarterly> a :Frequency ;
+  :prefLabel "Quarterly"@en ;
+  :prefLabel "1 nr/kvartal"@sv ;
+  :definition "A frequency for a diachronic work that is issued or updated once every three months."@en ;
+  :definition "Frekvens för en manifestation utgiven eller uppdaterad en gång varje kvartal."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/frequency/1010> ;
+  :note "Q" ,
+    "Varje kvartal" .
+
+<frequency/ThreeTimesAYear> a :Frequency ;
+  :prefLabel "Three times a year"@en ;
+  :prefLabel "3 nr/år"@sv ;
+  :definition "A frequency for a diachronic work that is issued or updated three times every year."@en ;
+  :definition "Frekvens för en manifestation utgiven eller uppdaterad tre gånger gång varje år."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/frequency/1011> ;
+  :note "T" ,
+    "Tre gånger per år" .
+
+<frequency/Semiannual> a :Frequency ;
+  :prefLabel "Semiannual"@en ;
+  :prefLabel "2 nr/år"@sv ;
+  :definition "A frequency for a diachronic work that is issued or updated twice every year."@en ;
+  :definition "Frekvens för en manifestation utgiven eller uppdaterad två gånger varje år."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/frequency/1012> ;
+  :note "F" ,
+    "Varje halvår" ,
+    "Även då frekvens/uppdatering uttrycks som två gånger per år." .
+
+<frequency/Annual> a :Frequency ;
+  :prefLabel "Annual"@en ;
+  :prefLabel "1 nr/år"@sv ;
+  :definition "A frequency for a diachronic work that is issued or updated once every year."@en ;
+  :definition "Frekvens för en manifestation utgiven eller uppdaterad en gång varje år."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/frequency/1013> ;
+  :note "A" ,
+    "En gång per år" .
+
+<frequency/Biennial> a :Frequency ;
+  :prefLabel "Biennial"@en ;
+  :prefLabel "Vartannat år"@sv ;
+  :definition "A frequency for a diachronic work that is issued or updated once every two years."@en ;
+  :definition "Frekvens för en manifestation utgiven eller uppdaterad en gång vartannat år."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/frequency/1014> ;
+  :note "G" ,
+    "Vartannat år" ,
+    "En gång på två år" .
+
+<frequency/Triennial> a :Frequency ;
+  :prefLabel "Triennial"@en ;
+  :prefLabel "Var"@sv ;
+  :definition "A frequency for a diachronic work that is issued or updated once every three years."@en ;
+  :definition "Frekvens för en manifestation utgiven eller uppdaterad en gång vart tredje år."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/frequency/1015> ;
+  :note "H" ,
+    "Vart tredje år" ,
+    "En gång på tre år." .
+
+<frequency/Irregular> a :Frequency ;
+  :prefLabel "Irregular"@en ;
+  :prefLabel "Oregelbunden"@sv ;
+  :definition "A frequency for a diachronic work that is issued or updated with no consistent interval between issues or updates."@en ;
+  :definition "Frekvens för en manifestation utgiven utan konsekvent intervall mellan utgåvorna."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/frequency/1016> ;
+  :note "_" ,
+    "Frekvens kan ej fastställas (helt oregelbunden)." ,
+    "Används tillsammans med 008/19: x vid avsiktligt oregelbunden frekvens/uppdatering." .
+
+<generation/DerivativeMaster> a :Generation ;
+  :prefLabel "Derivative master"@en ;
+  :prefLabel "Härledd master"@sv ;
+  :definition "A generation that is derived from the master."@en ;
+  :definition "Generation som härletts från mastern."@sv ;
+  :scopeNote "This term applies to digital resources."@en ;
+  :scopeNote "Termen gäller för digitala resurser."@sv ;
+  :related <Master> ;
+  :exactMatch <http://rdaregistry.info/termList/RDAGeneration/1001> ;
+  :note "340 #j (term)" .
+
+<generation/DiscMaster> a :Generation ;
+  :prefLabel "Disc master"@en ;
+  :prefLabel "Negativ modermatris"@sv ;
+  :definition "A generation that is a negative metal copy of a recording cut typically onto a lacquer-coated disc by means of a disc lathe; the lacquer original is destroyed in the process."@en ;
+  :definition "Generation som är en negativ metallkopia av en inspelning som vanligtvis skärs in på en lackbelagd skiva med hjälp av en skivsvarv; lackoriginalet förstörs i processen."@sv ;
+  :scopeNote "This term applies to audio resources."@en ;
+  :scopeNote "Termen gäller för ljudresurser."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAGeneration/1002> ;
+  :note "340 #j (term)" .
+
+<generation/FirstGeneration> a :Generation ;
+  :prefLabel "First generation"@en ;
+  :prefLabel "Första generation"@sv ;
+  :altLabel "First-generation master"@en ;
+  :definition "A generation that is the original camera film or videotape used to record the production."@en ;
+  :definition "Generation som är den ursprungliga kamerafilmen eller videobandet som använts för att spela in produktionen."@sv ;
+  :scopeNote "This term applies to microform and video resources."@en ;
+  :scopeNote "Termen gäller för mikroforms- och videoresurser."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAGeneration/1004> ;
+  :note "340 #j (term)" .
+
+<generation/Master> a :Generation ;
+  :prefLabel "Master"@en ;
+  :prefLabel "Master"@sv ;
+  :definition "A generation that is created from the process of digitization at the highest resolution and often used to make derivative copies."@en ;
+  :definition "Generation som skapas från digitiseringsprocessen i högsta upplösning och ofta används för att göra härledda kopior."@sv ;
+  :scopeNote "This term applies to digital resources."@en ;
+  :scopeNote "Termen gäller för digitala resurser."@sv ;
+  :related <DerivativeMaster> ;
+  :note "340 #j (term)" .
+
+<generation/MasterTape> a :Generation ;
+  :prefLabel "Master tape"@en ;
+  :prefLabel "Masterband"@sv ;
+  :definition "A generation that is the original recorded version of a tape from which copies can be made."@en ;
+  :definition "Generation som är den originalinspelade versionen av ett band från vilket kopior kan göras."@sv ;
+  :scopeNote "This term applies to audio resources."@en ;
+  :scopeNote "Termen gäller för ljudresurser."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAGeneration/1006> ;
+  :note "340 #j (term)" .
+
+<generation/MixedGeneration> a :Generation ;
+  :prefLabel "Mixed generation"@en ;
+  :prefLabel "Blandad generation"@sv ;
+  :definition "A generation that is a combination of generations for which it is not possible to assign more precise terms."@en ;
+  :definition "Generation som är en kombination av generationer för vilka det inte går att tilldela mer exakta termer."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAGeneration/1007> ;
+  :note "340 #j (term)" .
+
+<generation/Mother> a :Generation ;
+  :prefLabel "Mother"@en ;
+  :prefLabel "Positiv modermatris"@sv ;
+  :definition "A generation that is a positive metal copy of a disc master used to create one or more stampers."@en ;
+  :definition "Generation som är en positiv metallkopia av en skivmaster som används för att skapa en eller flera fadermatriser."@sv ;
+  :scopeNote "This term applies to audio resources."@en ;
+  :scopeNote "Termen gäller för ljudresurser."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAGeneration/1008> ;
+  :note "340 #j (term)" .
+
+<generation/Original> a :Generation ;
+  :prefLabel "Original"@en ;
+  :prefLabel "Original"@sv ;
+  :definition "A generation that is the first of a resource created digitally."@en ;
+  :definition "Generation som är den första av en digitalt skapad resurs."@sv ;
+  :scopeNote "This term applies to digital resources."@en ;
+  :scopeNote "Termen gäller för digitala resurser."@sv ;
+  :related <Master> ;
+  :exactMatch <http://rdaregistry.info/termList/RDAGeneration/1009> ;
+  :note "340 #j (term)" .
+
+<generation/PrintingMaster> a :Generation ;
+  :prefLabel "Printing master"@en ;
+  :prefLabel "Kopieringsmaster"@sv ;
+  :altLabel "Copying master"@en ;
+  :definition "A generation that is used to produce subsequent generations of microforms."@en ;
+  :definition "Generation som används för att producera efterföljande generationer av mikroformer."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAGeneration/1010> ;
+  :note "340 #j (term)" .
+
+<generation/ReferencePrint> a :Generation ;
+  :prefLabel "Reference print"@en ;
+  :prefLabel "??"@sv ;
+  :definition "A generation that is a release print approved by the producer and director of a film."@en ;
+  :definition "Generation som är ett releasetryck som godkänts av producenten och regissören av en film."@sv ;
+  :scopeNote "This term applies to motion picture resources."@en ;
+  :scopeNote "Termen gäller för filmresurser."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAGeneration/1011> ;
+  :note "340 #j (term)" .
+
+<generation/MasterPositive> a :Generation ;
+  :prefLabel "Master positive"@en ;
+  :prefLabel "Positiv master?"@sv ;
+  :altLabel "Intermediate positive"@en ;
+  :definition "A generation that is a positive print made from an earlier generation negative film and used for the preparation of duplicate negatives rather than projection."@en ;
+  :definition "Generation som är ett positivt tryck gjord av en tidigare generations negativfilm och används för att förbereda dubbletter av negativ snarare än projicering."@sv ;
+  :scopeNote "This term applies to motion picture resources."@en ;
+  :scopeNote "Termen gäller för filmresurser."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAGeneration/1012> ;
+  :note "340 #j (term)" .
+
+<generation/OriginalNegative> a :Generation ;
+  :prefLabel "Original negative"@en ;
+  :prefLabel "Originalnegativ?"@sv ;
+  :definition "A generation that is a negative film originally exposed in a camera and thus of better quality than any subsequent generation or derivative."@en ;
+  :definition "Generation som är en negativfilm som ursprungligen exponerats i en kamera och därmed av bättre kvalitet än någon efterföljande generation eller derivat."@sv ;
+  :scopeNote "This term applies to motion picture resources."@en ;
+  :scopeNote "Termen gäller för filmresurser."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAGeneration/1013> ;
+  :note "340 #j (term)" .
+
+<generation/ServiceCopy> a :Generation ;
+  :prefLabel "Service copy"@en ;
+  :prefLabel "??"@sv ;
+  :altLabel "Reference copy"@en ;
+  :definition "A generation that is intended primarily for use."@en ;
+  :definition "Generation som i första hand är avsedd att användas."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAGeneration/1014> ;
+  :note "340 #j (term)" .
+
+<generation/Stamper> a :Generation ;
+  :prefLabel "Stamper"@en ;
+  :prefLabel "Fadermatris"@sv ;
+  :definition "A generation that is a hard metal negative copy of a disc master that can be mounted within a press and used to impress the groove pattern in a production run of discs."@en ;
+  :definition "Generation som är en negativ kopia av hårdmetall av en skivmaster som kan monteras i en press och användas för att pressa spårmönstret i en produktionskörning av skivor."@sv ;
+  :scopeNote "This term applies to audio resources."@en ;
+  :scopeNote "Termen gäller för ljudresurser."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAGeneration/1015> ;
+  :note "340 #j (term)" .
+
+<generation/TapeDuplicationMaster> a :Generation ;
+  :prefLabel "Tape duplication master"@en ;
+  :prefLabel "Masterkopia"@sv ;
+  :definition "A generation that is a tape copy, usually a first generation copy of the master, used for creating multiple copies of the content."@en ;
+  :definition "Generation som är en bandkopia, vanligtvis en första generationens kopia av mastern, som används för att skapa flera kopior av innehållet."@sv ;
+  :scopeNote "This term applies to audio resources."@en ;
+  :scopeNote "Termen gäller för ljudresurser."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAGeneration/1016> ;
+  :note "340 #j (term)" .
+
+<generation/TestPressing> a :Generation ;
+  :prefLabel "Test pressing"@en ;
+  :prefLabel "Testpressning"@sv ;
+  :definition "A generation that is one of a short run of pressings used to check for any flaws before running a full pressing."@en ;
+  :definition "Generation som är en av en kort serie pressningar som används för att kontrollera eventuella brister innan man kör en full pressning."@sv ;
+  :scopeNote "This term applies to audio resources. Initial pressings sent out to reviewers, DJs, etc., are excluded."@en ;
+  :scopeNote "Termen gäller för ljudresurser. Första tryckningar som skickas ut till kritiker, DJ:s etc. är exkluderade."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAGeneration/1017> ;
+  :note "340 #j (term)" .
+
+<generation/ViewingCopy> a :Generation ;
+  :prefLabel "Viewing copy"@en ;
+  :prefLabel "??"@sv ;
+  :definition "A generation that is a copy that may be viewed by researchers."@en ;
+  :definition "Generation som är en kopia som kan ses av forskare."@sv ;
+  :scopeNote "This term applies to motion picture resources."@en ;
+  :scopeNote "Termen gäller för filmresurser."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAGeneration/1018> ;
+  :note "340 #j (term)" .
+
+<generation/DuplicateNegative> a :Generation ;
+  :prefLabel "Duplicate negative"@en ;
+  :prefLabel "??"@sv ;
+  :altLabel "Duplicate"@en ;
+  :definition "A generation that is a negative film made from a master positive or other positive film or from an original negative, used to make positive prints."@en ;
+  :definition "Generation som är en negativfilm gjord från en masterpositiv eller annan positiv film eller från ett originalnegativ, som används för att göra positiva tryckningar."@sv ;
+  :scopeNote "This term applies to motion picture resources."@en ;
+  :scopeNote "Termen gäller för filmresurser."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAGeneration/1019> ;
+  :note "340 #j (term)" .
+
+<identificationstatus/FullyEstablished> a :IdentificationStatus ;
+  :prefLabel "Fully established"@en ;
+  :prefLabel "Helt fastställd"@sv ;
+  :definition "A status of identification for an authorized access point when the data is complete."@en ;
+  :definition "Status för identifikation av en auktoriserad sökingång när data är komplett."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/statIdentification/1001> ;
+  :note "008/33 (auktoritetsformatet): a" .
+
+<identificationstatus/Provisional> a :IdentificationStatus ;
+  :prefLabel "Provisional"@en ;
+  :prefLabel "Preliminär"@sv ;
+  :definition "A status of identification for an authorized access point when the data is insufficient to satisfactorily identify the entity."@en ;
+  :definition "Status för identifikation av en auktoriserad sökingång när data är otillräcklig för att på ett tillfredsställande sätt identifiera entiteten."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/statIdentification/1002> ;
+  :note "008/33 (auktoritetsformatet): c" .
+
+<identificationstatus/Preliminary> a :IdentificationStatus ;
+  :prefLabel "Preliminary"@en ;
+  :prefLabel "Ej kontrollerad"@sv ;
+  :definition "A status of identification for an authorized access point when the data is taken from a description without the resource described in hand."@en ;
+  :definition "Status för identifikation av en auktoriserad sökingång när data tas från en beskrivning utan att ha tillgång till den beskrivna resursen."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/statIdentification/1003> ;
+  :note "008/33 (auktoritetsformatet): d" .
+
+<illustrativecontent/CoatOfArms> a :IllustrativeContent ;
+  :prefLabel "Coat of arms"@en ;
+  :prefLabel "Vapensköld"@sv ;
+  :definition "An illustrative content that includes a full display of armorial bearings that consists of the escutcheon plus its adjuncts."@en ;
+  :definition "Illustrativt innehåll som visar fullständigt adelsvapen som består av skölden och dess komplement."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/IllusContent/1001> ;
+  :closeMatch <http://vocab.getty.edu/page/aat/300126352> ,
+    <https://www.wikidata.org/wiki/Q14659> ,
+    <http://id.loc.gov/vocabulary/millus/coa> .
+
+<illustrativecontent/Facsimile> a :IllustrativeContent ;
+  :prefLabel "Facsimile"@en ;
+  :prefLabel "Faksimil"@sv ;
+  :definition "An illustrative content that consists of an exact copy of an original, usually in the same dimensions as the original, especially of books, documents, prints, and drawings."@en ;
+  :definition "Illustrativt innehåll som består av en exakt kopia av ett original, vanligen med samma mått som originalet, särskilt av böcker, dokument, tryck, och teckningar."@sv ;
+  :scopeNote "Today the original is often reproduced photographically or digitally; in the past, it was reproduced by engraving or other printmaking process."@en ;
+  :exactMatch <http://rdaregistry.info/termList/IllusContent/1002> ;
+  :closeMatch <http://vocab.getty.edu/page/aat/300121391> ,
+    <https://www.wikidata.org/wiki/Q194070> ,
+    <http://id.loc.gov/vocabulary/millus/fac> .
+
+<illustrativecontent/Form> a :IllustrativeContent ;
+  :prefLabel "Form"@en ;
+  :prefLabel "Formulär"@sv ;
+  :definition "An illustrative content that consists of labeled areas for recording structured data to be input by specified persons for specific purposes, usually accompanied by prompts and guidance."@en ;
+  :definition "Illustrativt innehåll som består av utmärkta områden för angivande av strukturerade data att föras in av särskilda personer för särskilda ändamål, vanligen åtföljda av inmatningsmarkörer och vägledning."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/IllusContent/1003> ;
+  :closeMatch <http://vocab.getty.edu/page/aat/300049060> ,
+    <https://www.wikidata.org/wiki/Q1335296> ,
+    <http://id.loc.gov/vocabulary/millus/for> .
+
+<illustrativecontent/GenealogicalTable> a :IllustrativeContent ;
+  :prefLabel "Genealogical table"@en ;
+  :prefLabel "Genealogisk tabell"@sv ;
+  :definition "An illustrative content that consists of a table or diagram representing the lineage of a person or family."@en ;
+  :definition "Illustrativt innehåll som består av en tabell eller ett diagram som representerar härstamning för en person eller släkt."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/IllusContent/1004> ;
+  :closeMatch <http://vocab.getty.edu/page/aat/300027016> ,
+    <https://www.wikidata.org/wiki/Q9353932> ,
+    <http://id.loc.gov/vocabulary/millus/gnt> .
+
+<illustrativecontent/Graph> a :IllustrativeContent ;
+  :prefLabel "Graph"@en ;
+  :prefLabel "Grafiskt diagram"@sv ;
+  :definition "An illustrative content that consists of a diagram showing relative quantitative and qualitative aspects of a data set."@en ;
+  :definition "Illustrativt innehåll som består av ett diagram som visar relativa kvantitativa och kvalitativa aspekter av ett dataset."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/IllusContent/1005> ;
+  :closeMatch <http://vocab.getty.edu/page/aat/300027020> ,
+    <https://www.wikidata.org/wiki/Q141488> ,
+    <http://id.loc.gov/vocabulary/millus/chr> .
+
+<illustrativecontent/Illumination> a :IllustrativeContent ;
+  :prefLabel "Illumination"@en ;
+  :prefLabel "Illumination"@sv ;
+  :definition "An illustrative content that consists of adornments, usually in one or more colours and applied by hand to an item using paint, ink, or metal foil."@en ;
+  :definition "Illustrativt innehåll som består av utsmyckningar, vanligen i en eller flera färger, applicerade för hand på ett objekt med användande av färg, bläck eller metallfolie."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/IllusContent/1006> ;
+  :closeMatch <http://vocab.getty.edu/page/aat/300264522> ,
+    <https://www.wikidata.org/wiki/Q48498> ,
+    <http://id.loc.gov/vocabulary/millus/ilm> .
+
+<illustrativecontent/Map> a :IllustrativeContent ;
+  :prefLabel "Map"@en ;
+  :prefLabel "Karta"@sv ;
+  :definition "An illustrative content that consists of a representation, normally to scale and on a two-dimensional medium, of a selection of material or abstract features on, or in relation to, the surface of the earth, another celestial body, or an imaginary place."@en ;
+  :definition "Illustrativt innehåll som består av en framställning, normalt skalenlig och på ett tvådimensionellt medium, av ett urval av material eller abstrakta kännetecken på, eller i relation till, jordens yta, en annan himlakropp eller en inbillad plats."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/IllusContent/1008> ;
+  :closeMatch <http://vocab.getty.edu/page/aat/300028094> ,
+    <https://www.wikidata.org/wiki/Q4006> ,
+    <http://id.loc.gov/vocabulary/millus/map> .
+
+<illustrativecontent/Photograph> a :IllustrativeContent ;
+  :prefLabel "Photograph"@en ;
+  :prefLabel "Fotografi"@sv ;
+  :definition "An illustrative content that consists of an image created by light falling on a light-sensitive surface, usually photographic film or an electronic medium."@en ;
+  :definition "Illustrativt innehåll som består av en bild skapad av ljus som träffar en ljuskänslig yta, vanligen fotografisk film eller ett elektroniskt medium."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/IllusContent/1010> ;
+  :closeMatch <http://vocab.getty.edu/page/aat/300046300> ,
+    <https://www.wikidata.org/wiki/Q125191> ,
+    <http://id.loc.gov/vocabulary/millus/pht> .
+
+<illustrativecontent/Plan> a :IllustrativeContent ;
+  :prefLabel "Plan"@en ;
+  :prefLabel "Planritning"@sv ;
+  :definition "An illustrative content that consists of a detailed drawing or diagram."@en ;
+  :definition "Illustrativt innehåll som består av en detaljerad teckning eller diagram."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/IllusContent/1011> ;
+  :closeMatch <http://vocab.getty.edu/page/aat/300263886> ,
+    <http://vocab.getty.edu/page/aat/300034104> ,
+    <https://www.wikidata.org/wiki/Q611203> ,
+    <http://id.loc.gov/vocabulary/millus/pln> .
+
+<illustrativecontent/Portrait> a :IllustrativeContent ;
+  :prefLabel "Portrait"@en ;
+  :prefLabel "Porträtt"@sv ;
+  :definition "An illustrative content that consists of a representation of an individual or group of persons or animals that is intended to capture a known or supposed likeness, especially the face of the individual."@en ;
+  :definition "Illustrativt innehåll som består av en representation av en individ eller en grupp personer eller djur som är avsett att fånga en känd eller förmodad likhet, särskilt individens ansikte."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/IllusContent/1012> ;
+  :closeMatch <http://vocab.getty.edu/page/aat/300015637> ,
+    <https://www.wikidata.org/wiki/Q134307> ,
+    <http://id.loc.gov/vocabulary/millus/por> .
+
+<illustrativecontent/Sample> a :IllustrativeContent ;
+  :prefLabel "Sample"@en ;
+  :prefLabel "Prov"@sv ;
+  :definition "An illustrative content that consists of an individual unit, segment, or small quantity taken as evidence of the quality or character of the entire group or lot."@en ;
+  :definition "Illustrativt innehåll som består av en individuell enhet, segment eller smärre kvantitet tagen som bevis på kvaliteten på eller karaktären för hela gruppen eller mängden."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/IllusContent/1013> ;
+  :closeMatch <http://vocab.getty.edu/page/aat/300028875> ,
+    <https://www.wikidata.org/wiki/Q485146> ,
+    <http://id.loc.gov/vocabulary/millus/sam> .
+
+<illustrativecontent/Illustration> a :IllustrativeContent ;
+  :prefLabel "Illustration"@en ;
+  :prefLabel "Illustration"@sv ;
+  :definition "An illustrative content that consists of a still image."@en ;
+  :definition "Illustrativt innehåll som består av en stillbild."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/IllusContent/1014> ;
+  :closeMatch <http://vocab.getty.edu/page/aat/300015578> ,
+    <https://www.wikidata.org/wiki/Q178659> ,
+    <http://id.loc.gov/vocabulary/millus/ill> .
+
+<interactivitymode/Interactive> a :InteractivityMode ;
+  :prefLabel "Interactive"@en ;
+  :prefLabel "Interaktiv"@sv ;
+  :definition "An interactivity mode that indicates that the content of an expression responds to actions performed by the user."@en ;
+  :definition "Interaktivitetsläge som indikerar att innehållet i ett uttryck svarar på handlingar som utförs av användaren."@sv ;
+  :scopeNote "Actions include searching, using commands, and making selections."@en ;
+  :scopeNote "Åtgärder inkluderar att söka, använda kommandon och göra val."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAInteractivityMode/1001> .
+
+<interactivitymode/NonInteractive> a :InteractivityMode ;
+  :prefLabel "Non-interactive"@en ;
+  :prefLabel "Ej interaktiv"@sv ;
+  :definition "An interactivity mode that indicates that the content of an expression does not respond to actions performed by the user."@en ;
+  :definition "Interaktivitetsläge som indikerar att innehållet i ett uttryck inte svarar på handlingar som utförs av användaren."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAInteractivityMode/1002> .
+
+<material/Acetate> a :Material ;
+  :prefLabel "Acetate"@en ;
+  :prefLabel "Acetat"@sv ;
+  :altLabel "Cellulose acetate"@en ;
+  :definition "A material that is composed of the acetate ester of cellulose."@en ;
+  :definition "Material framställt genom acetylering av cellulosa."@sv ;
+  :related <Plastic> ;
+  :exactMatch <http://rdaregistry.info/termList/RDAMaterial/1001> ;
+  :closeMatch <http://vocab.getty.edu/aat/300014439> ,
+    <https://www.wikidata.org/wiki/Q124686> ;
+  :note "340 #a bärande material" ,
+    "340 #c applicerat material" .
+
+<material/AcrylicPaint> a :Material ;
+  :prefLabel "Acrylic paint"@en ;
+  :prefLabel "Akrylfärg"@sv ;
+  :definition "A material that consists of pigment or dye bound in an emulsion of acrylic resin."@en ;
+  :definition "Material bestående av pigment eller färgämnen blandade med akrylharts som bindemedel."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAMaterial/1002> ;
+  :closeMatch <http://vocab.getty.edu/aat/300015058> ,
+    <https://www.wikidata.org/wiki/Q207849> .
+
+<material/Aluminium> a :Material ;
+  :prefLabel "Aluminium"@en ;
+  :prefLabel "Aluminium"@sv ;
+  :altLabel "Aluminum"@en ;
+  :definition "A material that is a non-magnetic metal, usually alloyed, that is ductile and malleable with a lustre that ranges from grey to silver."@en ;
+  :definition "Formbart, lättarbetat material bestående av icke-magnetisk metall, vanligtvis legerad, med en glans som varierar från grå till silverfärgad."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAMaterial/1003> ;
+  :closeMatch <http://vocab.getty.edu/aat/300011015> ,
+    <https://www.wikidata.org/wiki/Q663> .
+
+<material/BristolBoard> a :Material ;
+  :prefLabel "Bristol board"@en ;
+  :prefLabel "Bristol board"@sv ;
+  :definition "A material that consists of a high-grade white cardboard, most commonly made by pasting together sheets of heavy ledger paper."@en ;
+  :definition "Material bestående av vit papp/kartong av hög kvalitet, vanligtvis tillverkat genom att ark av kraftigt ledger-papper limmats samman."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAMaterial/1004> ;
+  :closeMatch <http://vocab.getty.edu/aat/300014228> ,
+    <https://www.wikidata.org/wiki/Q2916879> .
+
+<material/Canvas> a :Material ;
+  :prefLabel "Canvas"@en ;
+  :prefLabel "Duk"@sv ;
+  :definition "A material that consists of a closely woven textile made in various weights, usually of flax, hemp, jute, or cotton, used as a support for painting or printing; or a loosely woven, lattice-like mesh, usually of flax, hemp, jute, or cotton, used as a needlepoint foundation."@en ;
+  :definition "Material bestående av tättvävd textil i olika viktklasser, vanligtvis av lin, hampa, jute eller bomull, som används som underlag för måleri eller tryck. Termen används även för stramalj, en löst vävd textil, vanligtvis av lin, hampa, jute eller bomull som används som underlag för broderi."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAMaterial/1005> ;
+  :closeMatch <http://vocab.getty.edu/aat/300014078> ,
+    <https://www.wikidata.org/wiki/Q12321255> ,
+    <https://libris.kb.se/katalogisering/vcbd07fzx0nctx3q> .
+
+<material/Cardboard> a :Material ;
+  :prefLabel "Cardboard"@en ;
+  :prefLabel "Papp"@sv ;
+  :definition "A material that consists of a type of stiff sheet typically made of good-quality chemical pulp or rag pulp, varying greatly in type and strength, and that is thicker than 0.1524 mm."@en ;
+  :definition "Material bestående av en sorts styvt ark, vanligtvis framställt av sulfatmassa av god kvalitet eller lumpmassa, med stor variation avseende typ och styrka, och med en tjocklek på minst 0,15 mm."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAMaterial/1006> ;
+  :closeMatch <http://vocab.getty.edu/aat/300014224> ,
+    <https://www.wikidata.org/wiki/Q389782> ;
+  :note "007 (Bilder)" ,
+    "04 (Bildens bärande material): c" .
+
+<material/Ceramic> a :Material ;
+  :prefLabel "Ceramic"@en ;
+  :prefLabel "Keramik"@sv ;
+  :definition "A material that consists of a nonmetallic mineral, such as clay, fired at a high temperature to form a hard, brittle, heat- and corrosion-resistant material."@en ;
+  :definition "Material bestående av ickemetalliskt mineral, t.ex. lera, bränd vid hög temperatur för att skapa ett hårt, sprött material som tål värme och slitage"@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAMaterial/1007> ;
+  :closeMatch <http://vocab.getty.edu/aat/300235507> ,
+    <https://www.wikidata.org/wiki/Q45621> .
+
+<material/Chalk> a :Material ;
+  :prefLabel "Chalk"@en ;
+  :prefLabel "Krita"@sv ;
+  :definition "A material that consists of fine-grained limestone, or a soft, earthy form of calcium carbonate."@en ;
+  :definition "Material bestående av finkornig kalksten eller en mjuk, jordig form av kalciumkarbonat"@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAMaterial/1008> ;
+  :closeMatch <http://vocab.getty.edu/aat/300011727> ,
+    <https://www.wikidata.org/wiki/Q183670> .
+
+<material/Charcoal> a :Material ;
+  :prefLabel "Charcoal"@en ;
+  :prefLabel "Kol"@sv ;
+  :definition "A material that consists of the dark grey residue made of carbon, and any remaining ash, obtained by removing water and other volatile constituents from animal and plant substances."@en ;
+  :definition "Material bestående av de mörkgrå kolrester, samt eventuell återstående aska, som är kvar när vatten och andra flyktiga beståndsdelar avlägsnats från djur- och växtsubstanser"@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAMaterial/1009> ;
+  :closeMatch <http://vocab.getty.edu/aat/300012862> ,
+    <https://www.wikidata.org/wiki/Q1424515> .
+
+<material/Diacetate> a :Material ;
+  :prefLabel "Diacetate"@en ;
+  :prefLabel "Diacetat"@sv ;
+  :altLabel "Cellulose diacetate"@en ;
+  :definition "A material that is made by treating cellulose with acetic acid."@en ;
+  :definition "Material framställt genom att cellulosa behandlas med ättiksyra"@sv ;
+  :related <SafetyBase> ;
+  :exactMatch <http://rdaregistry.info/termList/RDAMaterial/1010> ;
+  :closeMatch <http://vocab.getty.edu/aat/300138328> .
+
+<material/Dye> a :Material ;
+  :prefLabel "Dye"@en ;
+  :prefLabel "Färgämne"@sv ;
+  :definition "A material that consists of a coloured substance dissolved or suspended in a liquid that can be absorbed by the base material."@en ;
+  :definition "Material bestående av en färgad substans upplöst i en vätska som kan absorberas av basmaterialet"@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAMaterial/1011> ;
+  :closeMatch <http://vocab.getty.edu/aat/300013029> ,
+    <https://www.wikidata.org/wiki/Q189720> .
+
+<material/Glass> a :Material ;
+  :prefLabel "Glass"@en ;
+  :prefLabel "Glas"@sv ;
+  :definition "A material that consists of silicon dioxide, also known as silica, fused with one or more basic oxides; generally transparent but often translucent or opaque."@en ;
+  :definition "Material bestående av kiseldioxid, även känt som silikat, samt en eller flera basiska oxider, vanligtvis genomskinligt men ofta halvgenomskinligt eller ogenomskinligt"@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAMaterial/1012> ;
+  :closeMatch <http://vocab.getty.edu/aat/300010797> ,
+    <https://www.wikidata.org/wiki/Q11469> ,
+    <https://libris.kb.se/katalogisering/78snclsb941s36pl> ,
+    <https://libris.kb.se/katalogisering/96rkhnvdc19d4gz5> ,
+    <https://libris.kb.se/katalogisering/96rkhnvdc19d4gz5> .
+
+<material/Gouache> a :Material ;
+  :prefLabel "Gouache"@en ;
+  :prefLabel "Gouach"@sv ;
+  :definition "A material that consists of pigment and a binding substance, and sometimes added inert materials, to form an opaque, coloured, water-soluble paint."@en ;
+  :definition "Material bestående av pigment och bindmedel och ibland ytterligare inerta material, som tillsammans bildar en täckande, vattenlöslig färg."@sv ;
+  :scopeNote "Poster paints are included. The term originally referred to the technique of oil paint applied on top of tempera."@en ;
+  :exactMatch <http://rdaregistry.info/termList/RDAMaterial/1013> ;
+  :closeMatch <http://vocab.getty.edu/aat/300070114> ,
+    <https://www.wikidata.org/wiki/Q204330> .
+
+<material/Graphite> a :Material ;
+  :prefLabel "Graphite"@en ;
+  :prefLabel "Grafit"@sv ;
+  :definition "A material that consists of a naturally occurring allotrope of carbon that is opaque, soft, greasy to the touch, and iron black to steel gray in colour."@en ;
+  :definition "Material bestående av naturligt förekommande allotroper av kol, som är ogenomskinligt, mjukt och känns oljigt vid beröring, med järnsvart till stålgrå färg"@sv ;
+  :scopeNote "The material is used in the form of powder, sticks, or in pencils."@en ;
+  :exactMatch <http://rdaregistry.info/termList/RDAMaterial/1014> ;
+  :closeMatch <http://vocab.getty.edu/aat/300011098> ,
+    <https://www.wikidata.org/wiki/Q5309> .
+
+<material/Hardboard> a :Material ;
+  :prefLabel "Hardboard"@en ;
+  :prefLabel "Hårdpapp"@sv ;
+  :altLabel "Fibreboard"@en ;
+  :definition "A material that consists of any firm, dense, rigid board, often manufactured from fiber consolidated in a hot press."@en ;
+  :definition "Material bestående av en fast, tät, styv platta, ofta framställd av fiber som har pressats i en värmepress"@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAMaterial/1015> ;
+  :closeMatch <http://vocab.getty.edu/aat/300014203> ,
+    <https://www.wikidata.org/wiki/Q1251688> ;
+  :note """007 (Bilder)
+04 (Bildens bärande material): q (Hardboard)""" ,
+    "007 (Bilder)" ,
+    "05 (Montering): q" ,
+    "Förekomster i Libris: 0" .
+
+<material/IllustrationBoard> a :Material ;
+  :prefLabel "Illustration board"@en ;
+  :prefLabel "Illustration board"@sv ;
+  :definition "A material that consists of laminated paper board that has paper layers glued to its surface."@en ;
+  :definition "Material tillverkat av en laminerad pappersplatta med lager av papper limmade på ytan"@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAMaterial/1016> ;
+  :closeMatch <http://vocab.getty.edu/aat/300014229> ,
+    <https://www.wikidata.org/wiki/Q99900954> .
+
+<material/Ink> a :Material ;
+  :prefLabel "Ink"@en ;
+  :prefLabel "Bläck"@sv ;
+  :definition "A material that consists of pigment or dye contained in a liquid or paste."@en ;
+  :definition "Material bestående av pigment eller färgämnen i en vätska eller massa."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAMaterial/1017> ;
+  :closeMatch <http://vocab.getty.edu/aat/300015012> ,
+    <https://www.wikidata.org/wiki/Q127418> .
+
+<material/Ivory> a :Material ;
+  :prefLabel "Ivory"@en ;
+  :prefLabel "Elfenben"@sv ;
+  :definition "A material that consists of the dentine forming the bulk of the teeth and tusks of animals such as elephants, walruses, and narwhals."@en ;
+  :definition "Material bestående av tandben eller betar från djur som elefanter, valrossar och narvalar."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAMaterial/1018> ;
+  :closeMatch <http://vocab.getty.edu/aat/300011857> ,
+    <https://www.wikidata.org/wiki/Q82001> .
+
+<material/Lacquer> a :Material ;
+  :prefLabel "Lacquer"@en ;
+  :prefLabel "Lack"@sv ;
+  :definition "A material that consists of polymers or acrylic compounds dissolved in volatile organic compounds or other solvents, that when dry is hard and durable."@en ;
+  :definition "Material bestående av plaster eller akrylföreningar upplösta i flyktiga organiska föreningar eller andra lösningsmedel, som blir hårt och hållbart när det torkat."@sv ;
+  :scopeNote "The material is generally used as a finish that may be clear or coloured."@en ;
+  :exactMatch <http://rdaregistry.info/termList/RDAMaterial/1019> ;
+  :closeMatch <http://vocab.getty.edu/aat/300014916> ,
+    <https://www.wikidata.org/wiki/Q11236878> .
+
+<material/Leather> a :Material ;
+  :prefLabel "Leather"@en ;
+  :prefLabel "Läder"@sv ;
+  :definition "A material that consists of the skin or hide of an animal that has been tanned to render it resistant to putrefaction and relatively soft and flexible when dry."@en ;
+  :definition "Material tillverkat av hud eller skinn från djur som garvats för att motstå förruttnelse och som är relativt mjukt och böjligt när det är torrt."@sv ;
+  :related <Skin> ;
+  :exactMatch <http://rdaregistry.info/termList/RDAMaterial/1020> ;
+  :closeMatch <http://vocab.getty.edu/aat/300011845> ,
+    <https://www.wikidata.org/wiki/Q286> ;
+  :note "007 (Kartor)" ,
+    "04 (Material): v" ,
+    "007 (Glob)" ,
+    "04 (Material): v" ,
+    "Förekomster i Libris: 0" .
+
+<material/MagneticParticles> a :Material ;
+  :prefLabel "Magnetic particles"@en ;
+  :prefLabel "Magnetiska partiklar"@sv ;
+  :definition "A material that is a natural or synthetic inorganic compound that consists of particles that are highly magnetic and are commonly used to store binary or analog information."@en ;
+  :definition "Material bestående av en naturlig eller syntetisk oorganisk förening som utgörs av kraftigt magnetiska partiklar och som vanligtvis används för att lagra digital eller analog information."@sv ;
+  :closeMatch <https://www.wikidata.org/wiki/Q105954869> ;
+  :note "----" .
+
+<material/Metal> a :Material ;
+  :prefLabel "Metal"@en ;
+  :prefLabel "Metall"@sv ;
+  :definition "A material that consists of a substance typified by being a good conductor of electricity and heat, opaque with a characteristic lustre, fusible, and usually malleable or ductile."@en ;
+  :definition "Material bestående av ett ämne med metalliska egenskaper, till exempel hög ledningsförmåga för elektricitet och värme, ogenomskinligt med karakteristisk glans, smältbart och vanligtvis formbart."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAMaterial/1022> ;
+  :closeMatch <http://vocab.getty.edu/aat/300010900> ,
+    <https://www.wikidata.org/wiki/Q11426> ,
+    <https://libris.kb.se/katalogisering/mmcwt06qp13khqjs> ,
+    <https://libris.kb.se/katalogisering/rt36w4bvt2d9smnb> .
+
+<material/Nitrate> a :Material ;
+  :prefLabel "Nitrate"@en ;
+  :prefLabel "Nitrat"@sv ;
+  :altLabel "Celluloid"@en ;
+  :definition "A material that is made of cellulose nitrate plasticized with camphor."@en ;
+  :definition "Material tillverkat av cellulosanitrat som mjukgjorts med kamfer"@sv ;
+  :related <Plastic> ;
+  :exactMatch <http://rdaregistry.info/termList/RDAMaterial/1023> ;
+  :closeMatch <http://vocab.getty.edu/aat/300379863> .
+
+<material/OilPaint> a :Material ;
+  :prefLabel "Oil paint"@en ;
+  :prefLabel "Oljefärg"@sv ;
+  :definition "A material that consists of pigment suspended in a drying oil."@en ;
+  :definition "Material bestående av pigment flytande i torkande olja"@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAMaterial/1024> ;
+  :closeMatch <http://vocab.getty.edu/aat/300015050> ,
+    <https://www.wikidata.org/wiki/Q296955> .
+
+<material/Paper> a :Material ;
+  :prefLabel "Paper"@en ;
+  :prefLabel "Papper"@sv ;
+  :definition "A material that consists of thin material made from felted sheets or webs of animal, plant, mineral, or synthetic fibres formed and dried from a suspension in water."@en ;
+  :definition "Tunt material bestående av hopfiltade djur- växt-, mineral- eller syntetfiber som bearbetats i vatten och bretts ut på en väv och som när vattnet runnit av, pressats och torkats."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAMaterial/1025> ;
+  :closeMatch <http://vocab.getty.edu/aat/300014109> ,
+    <https://www.wikidata.org/wiki/Q11472> .
+
+<material/Parchment> a :Material ;
+  :prefLabel "Parchment"@en ;
+  :prefLabel "Pergament"@sv ;
+  :definition "A material that consists of calf, sheep, or goat skin which has been prepared to produce a thin, strong, translucent or opaque substance for writing, bookbinding, or other uses."@en ;
+  :definition "Material bestående av kalv-, får- eller getskinn som har behandlats för att få fram ett tunt, starkt, halv- eller ogenomskinligt material för att skriva på, binda in böcker med mera"@sv ;
+  :related <Vellum> ;
+  :exactMatch <http://rdaregistry.info/termList/RDAMaterial/1026> ;
+  :closeMatch <http://vocab.getty.edu/aat/300011851> ,
+    <https://www.wikidata.org/wiki/Q226697> ;
+  :note "007 (Bilder)" ,
+    "04 (Bildens bärande material): w" .
+
+<material/Pastel> a :Material ;
+  :prefLabel "Pastel"@en ;
+  :prefLabel "Pastell"@sv ;
+  :definition "A material that consists of pigment mixed with a binder, usually in the form of a stick."@en ;
+  :definition "Material bestående av pigment blandat med bindemedel, vanligtvis i form av en krita"@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAMaterial/1027> ;
+  :closeMatch <http://vocab.getty.edu/aat/300404632> ,
+    <https://www.wikidata.org/wiki/Q189085> .
+
+<material/Plaster> a :Material ;
+  :prefLabel "Plaster"@en ;
+  :prefLabel "Gips"@sv ;
+  :definition "A material that consists of a powder prepared from calcium sulphate dihydrate, also known as gypsum, or calcium carbonate and mixed with water and sometimes a filler to form a paste that liberates heat and then hardens."@en ;
+  :definition "Material bestående av ett pulver, framställt av kalciumsulfatdihydrat, även känt som naturgips, eller kalciumkarbonat, blandat med vatten och ibland ett fyllnadsmedel, som blir en massa som frigör värme och då stelnar."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAMaterial/1028> ;
+  :closeMatch <http://vocab.getty.edu/aat/300014922> ,
+    <https://libris.kb.se/katalogisering/h4q5mv2lk3p42q5q> .
+
+<material/Plastic> a :Material ;
+  :prefLabel "Plastic"@en ;
+  :prefLabel "Plast"@sv ;
+  :definition "A material that consists of synthetic or semi-synthetic organic polymers of high molecular weight that are moldable."@en ;
+  :definition "Material bestående av syntetiska eller halvsyntetiska organiska polymerer, med hög molekylmassa, som är formbar"@sv ;
+  :related <Acetate> ;
+  :exactMatch <http://rdaregistry.info/termList/RDAMaterial/1029> ;
+  :closeMatch <http://vocab.getty.edu/aat/300014570> ,
+    <https://www.wikidata.org/wiki/Q11474> ;
+  :note "007 (Bilder)" ,
+    "04 (Bildens bärande material): i" .
+
+<material/Polyester> a :Material ;
+  :prefLabel "Polyester"@en ;
+  :prefLabel "Polyester"@sv ;
+  :definition "A material that is a category of polymers that contain the ester functional group in their main chain."@en ;
+  :definition "Material tillhörande en grupp av plaster som har estermonomerer i sin kedja"@sv ;
+  :related <SafetyBase> ;
+  :exactMatch <http://rdaregistry.info/termList/RDAMaterial/1030> ;
+  :closeMatch <http://vocab.getty.edu/aat/300379829> ,
+    <https://www.wikidata.org/wiki/Q188245> .
+
+<material/Porcelain> a :Material ;
+  :prefLabel "Porcelain"@en ;
+  :prefLabel "Porslin"@sv ;
+  :definition "A material that consists of a refractory white clay, known as kaolin, and a feldspathic rock that is heated to form a ceramic material."@en ;
+  :definition "Material bestående av eldfast vit lera, känd som kaolin, och fältspat som upphettas och då bildar ett keramiskt material"@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAMaterial/1031> ;
+  :closeMatch <http://vocab.getty.edu/aat/300010662> ,
+    <https://www.wikidata.org/wiki/Q130693> .
+
+<material/Rubber> a :Material ;
+  :prefLabel "Rubber"@en ;
+  :prefLabel "Gummi"@sv ;
+  :definition "A material that consists of natural or synthetic polymers that have a high degree of resilience and elasticity."@en ;
+  :definition "Material bestående av naturliga eller syntetiska plaster och som har en hög grad av flexibilitet och elasticitet"@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAMaterial/1032> ;
+  :closeMatch <http://vocab.getty.edu/aat/300012941> ,
+    <https://www.wikidata.org/wiki/Q18113858> .
+
+<material/SafetyBase> a :Material ;
+  :prefLabel "Safety base"@en ;
+  :prefLabel "Säkerhetsfilm"@sv ;
+  :definition "A material that consists of nonflammable cellulose acetate or polyester."@en ;
+  :definition "Material tillverkat av svårantändliga cellulosaacetat eller polyester"@sv ;
+  :related <Polyester> ;
+  :exactMatch <http://rdaregistry.info/termList/RDAMaterial/1033> ;
+  :closeMatch <http://vocab.getty.edu/aat/300127384> .
+
+<material/Shellac> a :Material ;
+  :prefLabel "Shellac"@en ;
+  :prefLabel "Shellack"@sv ;
+  :definition "A material that consists of lac, a resinous substance excreted by the female lac insect, that can be dissolved in ethyl alcohol to form a liquid that can be applied with a brush."@en ;
+  :definition "Material bestående av en hartsartad utsöndring från sköldlushonan som genom att lösas upp i etanol bildar en vätska som kan appliceras med pensel"@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAMaterial/1034> ;
+  :closeMatch <http://vocab.getty.edu/aat/300014918> ,
+    <https://www.wikidata.org/wiki/Q429659> .
+
+<material/Skin> a :Material ;
+  :prefLabel "Skin"@en ;
+  :prefLabel "Skinn (hud)"@sv ;
+  :definition "A material that consists of the integument of animals, such as sheep, goats, or calves, separated from the body and variously processed to remove hair, dry, tan, or otherwise dress."@en ;
+  :definition "Material bestående av hud från djur, till exempel från får, get eller kalv, som avskilts från kroppen och bearbetats på olika sätt för att avlägsna hår, torka, garva och så vidare"@sv ;
+  :related <Leather> ;
+  :exactMatch <http://rdaregistry.info/termList/RDAMaterial/1035> ;
+  :closeMatch <http://vocab.getty.edu/aat/300011840> .
+
+<material/Stone> a :Material ;
+  :prefLabel "Stone"@en ;
+  :prefLabel "Sten"@sv ;
+  :definition "A material that consists of rock in its naturally occurring shape or that has been cut, shaped, crushed, or otherwise formed."@en ;
+  :definition "Material bestående av bergarter och mineraler antingen i sin naturliga form eller hugget, krossat eller på annat sätt format"@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAMaterial/1036> ;
+  :closeMatch <http://vocab.getty.edu/aat/300011176> ,
+    <https://www.wikidata.org/wiki/Q22731> ;
+  :note "007 (Bilder)" ,
+    "04 (Bildens bärande material): s" .
+
+<material/Synthetic> a :Material ;
+  :prefLabel "Synthetic"@en ;
+  :prefLabel "Syntet"@sv ;
+  :definition "A material that is created by processing man-made materials, usually as a substitute for a natural material."@en ;
+  :definition "Material som producerats på konstgjord väg, används vanligtvis som substitut för naturmaterial"@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAMaterial/1037> ;
+  :closeMatch <http://vocab.getty.edu/aat/300218678> ,
+    <https://www.wikidata.org/wiki/Q3300022> .
+
+<material/Tempera> a :Material ;
+  :prefLabel "Tempera"@en ;
+  :prefLabel "Tempera"@sv ;
+  :definition "A material that consists of pigment mixed with a water-soluble binder medium, usually a glutinous material such as egg yolk or some other size, to form a permanent fast-drying painting medium."@en ;
+  :definition "Material bestående av pigment blandat med ett vattenlösligt bindemedel, vanligtvis av limliknande konsistens, till exempel äggula eller något annat klistrigt, för att få fram en beständig, snabbtorkande målarfärg"@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAMaterial/1038> ;
+  :closeMatch <http://vocab.getty.edu/aat/300015062> ,
+    <https://www.wikidata.org/wiki/Q175166> .
+
+<material/Textile> a :Material ;
+  :prefLabel "Textile"@en ;
+  :prefLabel "Textil"@sv ;
+  :definition "A material that is produced by weaving, felting, knotting, twining, or otherwise processing natural or synthetic fibers so that they cohere."@en ;
+  :definition "Material framställt genom vävning, tovning, knytning, tvinning eller annan bearbetning av naturliga eller syntetiska fibrer så att de hänger samman"@sv ;
+  :scopeNote "Excludes fibreboard, paper, papier-mâché, and papyrus."@en ;
+  :exactMatch <http://rdaregistry.info/termList/RDAMaterial/1039> ;
+  :closeMatch <http://vocab.getty.edu/aat/300231565> ,
+    <https://www.wikidata.org/wiki/Q28823> ;
+  :note "007 (Bilder)" ,
+    "04 (Bildens bärande material): g" .
+
+<material/Triacetate> a :Material ;
+  :prefLabel "Triacetate"@en ;
+  :prefLabel "Triacetat"@sv ;
+  :altLabel "Cellulose triacetate"@en ;
+  :definition "A material that is manufactured from cellulose and a source of acetate esters, typically acetic anhydride."@en ;
+  :definition "Material framställt av cellulosaacetat, vanligtvis ättiksyraanhydrider"@sv ;
+  :related <Acetate> ;
+  :exactMatch <http://rdaregistry.info/termList/RDAMaterial/1040> ;
+  :closeMatch <http://vocab.getty.edu/aat/300130950> .
+
+<material/Vellum> a :Material ;
+  :prefLabel "Vellum"@en ;
+  :prefLabel "Veläng"@sv ;
+  :definition "A material that consists of fine-quality calf or lamb parchment."@en ;
+  :definition "Material bestående av högkvalitativt pergament från kalvar eller lamm"@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAMaterial/1041> ;
+  :closeMatch <http://vocab.getty.edu/aat/300011852> ,
+    <https://www.wikidata.org/wiki/Q378274> ;
+  :note "007 (Bilder)" ,
+    "04 (Bildens bärande material): n" ,
+    "Velin" .
+
+<material/Vinyl> a :Material ;
+  :prefLabel "Vinyl"@en ;
+  :prefLabel "Vinyl"@sv ;
+  :definition "A material that consists of a polymer or copolymer derived from a vinyl group, typically vinyl chloride."@en ;
+  :definition "Material bestående av en polymer eller sampolymer från en vinylgrupp, vanligtvis vinylklorid."@sv ;
+  :related <Parchment> ;
+  :exactMatch <http://rdaregistry.info/termList/RDAMaterial/1042> ;
+  :closeMatch <http://vocab.getty.edu/aat/300014502> ;
+  :note "007 (Bilder)" ,
+    "04 (Bildens bärande material): l" .
+
+<material/Watercolour> a :Material ;
+  :prefLabel "Watercolour"@en ;
+  :prefLabel "Akvarell"@sv ;
+  :altLabel "Watercolor"@en ;
+  :definition "A material that consists of pigment suspended in water to form a transparent painting medium."@en ;
+  :definition "Material bestående av pigment i vattensuspension som skapar ett transparent färgmedium."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAMaterial/1043> ;
+  :closeMatch <http://vocab.getty.edu/aat/300015045> ,
+    <https://www.wikidata.org/wiki/Q22915256> .
+
+<material/Wax> a :Material ;
+  :prefLabel "Wax"@en ;
+  :prefLabel "Vax"@sv ;
+  :definition "A material that consists of a chemical compound from an animal, plant, mineral, or synthetic source that is malleable near ambient temperatures, slightly greasy to the touch, with a low melting point, and usually translucent, water-repellant, and soluble in organic solvents."@en ;
+  :definition "Material bestående av en kemisk förening med animaliskt, växtbaserat, mineraliskt eller syntetiskt ursprung som är formbart vid rumstemperatur, känns lätt oljigt vid beröring, har en låg smältpunkt och är vanligtvis genomskinligt, vattenavvisande och lösligt i organiska lösningsmedel."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAMaterial/1044> ;
+  :closeMatch <http://vocab.getty.edu/aat/300014585> ,
+    <https://www.wikidata.org/wiki/Q124695> .
+
+<material/Wood> a :Material ;
+  :prefLabel "Wood"@en ;
+  :prefLabel "Trä"@sv ;
+  :definition "A material that consists of the principal tissue of trees and similar plants."@en ;
+  :definition "Material bestående av träd och liknande växters ved"@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAMaterial/1045> ;
+  :closeMatch <http://vocab.getty.edu/aat/300011914> ,
+    <https://www.wikidata.org/wiki/Q287> ;
+  :note "007 (Bilder)" ,
+    "04 (Bildens bärande material): t" .
+
+<material/DiazoEmulsion> a :Material ;
+  :prefLabel "Diazo emulsion"@en ;
+  :prefLabel "Diazo"@sv ;
+  :definition "A material that consists of an emulsion of one or more light-sensitive layers of diazonium salts in a polyester or acetate base that react with dye couplers when processed to produce azo dye images."@en ;
+  :definition "Material bestående av en emulsion av ett eller flera ljuskänsliga lager diazoniumsalter i en polyester- eller acetatbas som reagerar med färgämneskopplare i processen för att skapa diazofärgbilder."@sv ;
+  :scopeNote "The material is usually applied to the base material of a microfilm or microfiche."@en ;
+  :exactMatch <http://rdaregistry.info/termList/RDAMaterial/1046> .
+
+<material/SilverHalideEmulsion> a :Material ;
+  :prefLabel "Silver halide emulsion"@en ;
+  :prefLabel "Silverhalogen"@sv ;
+  :definition "A material that consists of an emulsion of a light-sensitive compound of silver and chlorine, bromine, iodine or fluorine suspended in a colloidal medium, usually gelatin."@en ;
+  :definition "Material bestående av en blandning av ljuskänsliga föreningar av silver och klorid, bromid, jod eller fluor flytande i en kolloidal lösning"@sv ;
+  :scopeNote "The material is usually applied to the base material of a microfilm or microfiche."@en ;
+  :exactMatch <http://rdaregistry.info/termList/RDAMaterial/1047> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q105755385> .
+
+<material/VesicularEmulsion> a :Material ;
+  :prefLabel "Vesicular emulsion"@en ;
+  :prefLabel "Vesikulär emulsion"@sv ;
+  :definition "A material that consists of an emulsion of one or more light-sensitive layers of diazonium salts in a polyester thermoplastic base that decompose on exposure to produce nitrogen bubbles, known as vesicles, that form a latent image, commonly blue or beige, which becomes visible and fixed when heated and allowed to cool."@en ;
+  :definition "Material bestående av en emulsion av ett eller flera ljuskänsliga lager diazoniumsalter i en termoplastbas av polyester som sönderdelas vid exponering och producerar kvävebubblor, så kallade vesiklar, som skapar en latent bild, vanligtvis blå eller beige, som blir synlig och fixeras när den värms upp och får svalna."@sv ;
+  :scopeNote "The material is usually applied to the base material of a microfilm or microfiche."@en ;
+  :exactMatch <http://rdaregistry.info/termList/RDAMaterial/1048> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q106298646> .
+
+<material/SvenskaTermerSomEjFinnsIRdaToolkit> a :Material ;
+  :prefLabel "Svenska termer som ej finns i RDA Toolkit"@sv .
+
+<material/Papp%28Cardboard%29> a :Material ;
+  :prefLabel "Papp (cardboard)"@sv ;
+  :definition "KoBs förslag:  Ta bort. Använd papp, kartong. (cardboard)."@sv ;
+  :note "Se ovan: cardboard" .
+
+<material/Siden> a :Material ;
+  :prefLabel "Siden"@sv ;
+  :definition "Väv av natursilke, textilfibrer från kokonger av främst silkesfjärilen. (NE)"@sv ;
+  :closeMatch <http://vocab.getty.edu/aat/300243428> ,
+    <https://www.wikidata.org/wiki/Q12019351> .
+
+<material/Bister> a :Material ;
+  :prefLabel "Bister"@sv ;
+  :definition "Vattensuspension av fint sot från förbränd bokved. Den har en brunaktig färg och används främst vid lavering. (NE)"@sv ;
+  :closeMatch <http://vocab.getty.edu/aat/300013351> ,
+    <https://www.wikidata.org/wiki/Q774061> .
+
+<material/Penna> a :Material ;
+  :prefLabel "Penna"@sv ;
+  :definition "KoB:s förslag: Penna används som en övergripande term för teckningar i bläck, tusch, sepia och bister, eftersom det ofta inte går att avgöra om det ena eller det andra använts, se definitioner av bläck, tusch, sepia och bister. De specifika termerna används om man med säkerhet vet vilken som konstnären använt sig av."@sv ;
+  :closeMatch <http://vocab.getty.edu/aat/300022452> .
+
+<material/F%C3%A4rgpenna> a :Material ;
+  :prefLabel "Färgpenna"@sv ;
+  :definition "KoB:s förslag: Består av en vax-, olje- eller vattenbaserad kärna, s.k. bindemedel, blandat med olika proportioner av pigment och tillsatser, se Colored pencil society of America:"@sv ;
+  :closeMatch <http://vocab.getty.edu/page/aat/300022441> .
+
+<material/Sepia> a :Material ;
+  :prefLabel "Sepia"@sv ;
+  :definition "Typ av mörkbrunt vattenlösligt färgämne, som utvinns ur bläckfiskens bläckkörtel. (Wikipedia)"@sv ;
+  :closeMatch <http://vocab.getty.edu/aat/300015025> ,
+    <https://www.wikidata.org/wiki/Q767608> .
+
+<material/Papyrus> a :Material ;
+  :prefLabel "Papyrus"@sv ;
+  :definition "Naturmaterial, tillverkat av papyrusväxten. (NE)"@sv ;
+  :closeMatch <http://vocab.getty.edu/aat/300014127> ,
+    <https://www.wikidata.org/wiki/Q125576> .
+
+<mediatype/Audio> a :MediaType ;
+  :prefLabel "Audio"@en ;
+  :prefLabel "Audio"@sv ;
+  :definition "A media type used to store recorded sound, designed for use with a playback device such as a turntable, audiocassette player, CD player, or MP3 player."@en ;
+  :definition "Medietyp som används för att lagra inspelat ljud, designad för användning med en uppspelningsapparat som en skivspelare, ljudkassettspelare, CD-spelare eller MP3-spelare."@sv ;
+  :scopeNote "Media used to store digitally encoded as well as analog sound are included."@en ;
+  :scopeNote "Media som används för att lagra digitalt kodat såväl som analogt ljud ingår."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAMediaType/1001> ;
+  :note "007 (Koder för fysiska bäraregenskaper)" ,
+    "00 (Bärartyp): s" ,
+    "Ljudupptagningar" .
+
+<mediatype/Microform> a :MediaType ;
+  :prefLabel "Microform"@en ;
+  :prefLabel "Mikroform"@sv ;
+  :definition "A media type used to store reduced-size images not readable to the human eye, designed for use with a device such as a microfilm or microfiche reader."@en ;
+  :definition "Medietyp som används för att lagra bilder i förminskad storlek som inte är läsbara för det mänskliga ögat, designad för användning med en apparat som en mikrofilm eller mikroficheläsare."@sv ;
+  :scopeNote "Both transparent and opaque micrographic media are included."@en ;
+  :scopeNote "Både transparenta och ogenomskinliga mikrografiska medier ingår."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAMediaType/1002> ;
+  :note "007 (Koder för fysiska bäraregenskaper)" ,
+    "00 (Bärartyp): h" ,
+    "Mikroformer" .
+
+<mediatype/Computer> a :MediaType ;
+  :prefLabel "Computer"@en ;
+  :prefLabel "Dator"@sv ;
+  :definition "A media type used to store electronic files, designed for use with a computer."@en ;
+  :definition "Medietyp som används för att lagra elektroniska filer, designad för användning med en dator."@sv ;
+  :scopeNote "Media that are accessed remotely through file servers as well as direct-access media such as computer tapes and discs are included."@en ;
+  :scopeNote "Media som nås på distans via filservrar samt direktåtkomstmedia som datorband och skivor ingår."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAMediaType/1003> ;
+  :note "007 (Koder för fysiska bäraregenskaper)" ,
+    "00 (Bärartyp): c" .
+
+<mediatype/Microscopic> a :MediaType ;
+  :prefLabel "Microscopic"@en ;
+  :prefLabel "Mikroskopisk"@sv ;
+  :definition "A media type used to store minute objects, designed for use with a device such as a microscope to reveal details invisible to the naked eye."@en ;
+  :definition "Mediteyp som används för att lagra små föremål, designad för användning med en apparat som ett mikroskop för att avslöja detaljer som är osynliga för blotta ögat."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAMediaType/1004> .
+
+<mediatype/Projected> a :MediaType ;
+  :prefLabel "Projected"@en ;
+  :prefLabel "Projicerad"@sv ;
+  :definition "A media type used to store moving or still images, designed for use with a projection device such as a motion picture film projector, slide projector, or overhead projector."@en ;
+  :definition "Medietyp som används för att lagra rörliga bilder eller stillbilder, designad för användning med en projektionsapparat som en filmprojektor, diaprojektor eller overheadprojektor."@sv ;
+  :scopeNote "Media designed to project both two-dimensional and three-dimensional images are included."@en ;
+  :scopeNote "Media utformade för att projicera både tvådimensionella och tredimensionella bilder ingår."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAMediaType/1005> .
+
+<mediatype/Stereographic> a :MediaType ;
+  :prefLabel "Stereographic"@en ;
+  :prefLabel "Stere"@sv ;
+  :definition "A media type used to store pairs of still images, designed for use with a device such as a stereoscope or stereograph viewer to give the effect of three dimensions."@en ;
+  :definition "Medietyp som används för att lagra par av stillbilder, designad för användning med en apparat som ett stereoskop eller stereografvisare för att ge effekten av tre dimensioner."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAMediaType/1006> .
+
+<mediatype/Unmediated> a :MediaType ;
+  :prefLabel "Unmediated"@en ;
+  :prefLabel "Omedierad"@sv ;
+  :definition "A media type used to store content designed to be perceived directly through one or more of the human senses without the aid of an intermediating device."@en ;
+  :definition "Medietyp som används för att lagra innehåll som är utformat för att uppfattas direkt genom ett eller flera av de mänskliga sinnena utan hjälp av en förmedlande apparat."@sv ;
+  :scopeNote "Media containing visual or tactile content produced using processes such as printing, engraving, lithography, etc., embossing, texturing, etc., or by means of handwriting, drawing, painting, etc., are included. Media used to convey three-dimensional forms such as sculptures, models, etc., are also included."@en ;
+  :scopeNote "Media som innehåller visuellt eller taktilt innehåll framställt med hjälp av processer som tryckteknik, gravering, litografi etc., prägling, texturering etc. eller med hjälp av handskrift, teckning, målning etc. ingår. Media som används för att förmedla tredimensionella former som skulpturer, modeller etc. ingår också."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAMediaType/1007> .
+
+<mediatype/Video> a :MediaType ;
+  :prefLabel "Video"@en ;
+  :prefLabel "Video"@sv ;
+  :definition "A media type used to store moving or still images, designed for use with a playback device such as a videocassette player or DVD player."@en ;
+  :definition "Medietyp som används för att lagra rörliga bilder eller stillbilder, designad för användning med en uppspelningsapparat som en videokassettspelare eller DVD-spelare."@sv ;
+  :scopeNote "Media used to store digitally encoded as well as analog images are included."@en ;
+  :scopeNote "Media som används för att lagra digitalt kodade såväl som analoga bilder ingår."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAMediaType/1008> .
+
+<musicalnotationform/GraphicNotation> a :MusicalNotationForm ;
+  :prefLabel "Graphic notation"@en ;
+  :prefLabel "Grafisk notation"@sv ;
+  :definition "A form of musical notation that uses various suggestive lines, symbols, colour, etc., to prompt or guide the performers."@en ;
+  :definition "Musikalisk notationsform som använder olika suggestiva linjer, symboler, färg osv. för att hjälpa eller vägleda exekutörerna."@sv ;
+  :scopeNote "This notation is used for music that is indeterminate in pitch, duration, temperament, etc., and also to depict electronic music in which no performer is involved."@en ;
+  :scopeNote "Omfattar musik som är obestämd vad gäller tonhöjd, varaktighet, temperament etc., och även elektronisk musik där ingen framförande agent är inblandad."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/MusNotation/1001> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q1329869> ;
+  :note "348 #c (term)" .
+
+<musicalnotationform/LetterNotation> a :MusicalNotationForm ;
+  :prefLabel "Letter notation"@en ;
+  :prefLabel "Bokstavsnotation"@sv ;
+  :definition "A form of musical notation that uses the letters of the alphabet to designate pitches."@en ;
+  :definition "Musikalisk notationsform som använder alfabetets bokstäver för att beteckna tonhöjder."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/MusNotation/1002> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q6533561> ;
+  :note "348 #c (term)" .
+
+<musicalnotationform/MensuralNotation> a :MusicalNotationForm ;
+  :prefLabel "Mensural notation"@en ;
+  :prefLabel "Mensuralnotation"@sv ;
+  :definition "A form of musical notation, beginning around 1260 and continuing through about 1600, employing four principal note-values and associated rests: long, breve, semibreve, and minim to notate duration."@en ;
+  :definition "Musikalisk notationsform, från år 1260 ca till omkring 1600, som begagnar sig av fyra huvudsakliga notvärden och därmed förknippade pauser: long, breve, semibreve, and minim för att notera varaktighet."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/MusNotation/1003> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q1920919> ;
+  :note "348 #c (term)" .
+
+<musicalnotationform/NumberNotation> a :MusicalNotationForm ;
+  :prefLabel "Number notation"@en ;
+  :prefLabel "Siffernotation"@sv ;
+  :definition "A form of musical notation conveying pitch by use of numbers, assigned to the notes of a scale, the keys of a keyboard, the finger positions or frets of a string instrument, or to the holes or valves of a wind instrument."@en ;
+  :definition "Musikalisk notationsform som förmedlar tonhöjd genom användning av siffror som hänför sig till noter på en skala, tangenter på ett tangentbord, fingerställningar eller band på ett stränginstrument eller till hål och klaffar på ett blåsinstrument."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/MusNotation/1004> ;
+  :note "348 #c (term)" .
+
+<musicalnotationform/PlainsongNotation> a :MusicalNotationForm ;
+  :prefLabel "Plainsong notation"@en ;
+  :definition "Deprecated"@en ;
+  :note "348 #c (term)" .
+
+<musicalnotationform/Solmization> a :MusicalNotationForm ;
+  :prefLabel "Solmization"@en ;
+  :prefLabel "Solmisation"@sv ;
+  :definition "Deprecated"@en ;
+  :closeMatch <https://www.wikidata.org/wiki/Q223064> ;
+  :note "348 #c (term)" .
+
+<musicalnotationform/StaffNotation> a :MusicalNotationForm ;
+  :prefLabel "Staff notation"@en ;
+  :prefLabel "Traditionell västerländsk notskrift"@sv ;
+  :definition "A form of musical notation in wide use for Western art music, conveying pitch and duration using a staff of parallel lines, often in combination with other staves."@en ;
+  :definition "Musikalisk notationsform, ofta använd för västerländsk konstmusik, som förmedlar tonhöjd och varaktighet genom användning av notsystem med parallella linjer, ofta i kombination med andra notsystem."@sv ;
+  :scopeNote "This notation is usually a staff of five lines in music dating from the 15th century to the present."@en ;
+  :scopeNote "Vanligen ett notsystem med fem linjer i 1400-talsmusik."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/MusNotation/1007> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q107017556> ;
+  :note "348 #c (term)" .
+
+<musicalnotationform/Tablature> a :MusicalNotationForm ;
+  :prefLabel "Tablature"@en ;
+  :prefLabel "Tabulatur"@sv ;
+  :definition "A form of musical notation that uses letters of the alphabet or other symbols not found in staff notation, and which generally specifies the physical action required to produce the music from a specific instrument, rather than an abstract representation of the music itself."@en ;
+  :definition "Musikalisk notationsform som använder alfabetets bokstäver eller andra symboler som man inte finner i traditionell västerländsk notskrift, och som i allmänhet specificerar den fysiska handling som krävs för att frambringa musik från ett specifikt musikinstrument, snarare än en abstrakt representation av själva musiken."@sv ;
+  :scopeNote "Includes the German organ tablatures of the late Middle Ages and later."@en ;
+  :scopeNote "Omfattar de tyska orgeltabulaturerna från sen medeltid och senare."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/MusNotation/1008> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q143217> ;
+  :note "348 #c (term)" .
+
+<musicalnotationform/TonicSolFa> a :MusicalNotationForm ;
+  :prefLabel "Tonic sol-fa"@en ;
+  :prefLabel "Tonic sol-fa"@sv ;
+  :definition "A form of musical notation that replaces staff notation with sol-fa syllables or their initials."@en ;
+  :definition "Musikalisk notationsform som ersätter traditionell västerländsk notskrift med sol-fa-stavelser eller deras initialer."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/MusNotation/1009> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q1078884> ;
+  :note "348 #c (term)" .
+
+<musicalnotationform/NeumaticNotation> a :MusicalNotationForm ;
+  :prefLabel "Neumatic notation"@en ;
+  :prefLabel "Neumer"@sv ;
+  :definition "A form of musical notation using neumes, i.e., graphic signs that represent essentially the movement in pitch of a melody."@en ;
+  :definition "Musikalisk notationsform som använder neumer, dvs. grafiska tecken som i huvudsak representerar förflyttningen i tonhöjd för en melodi."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/MusNotation/1010> ;
+  :note "348 #c (term)" .
+
+<musicalnotationform/SyllabicNotation> a :MusicalNotationForm ;
+  :prefLabel "Syllabic notation"@en ;
+  :prefLabel "Syllabic notation"@sv ;
+  :definition "A form of musical notation that designates pitches by means of conventional syllables."@en ;
+  :definition "Musikalisk notationsform som betecknar tonhöjder med hjälp av konventionella stavelser."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/MusNotation/1011> ;
+  :note "348 #c (term)" .
+
+<notatedmovementform/StepanovDanceNotation> a :NotatedMovementForm ;
+  :prefLabel "Stepanov dance notation"@en ;
+  :prefLabel "Stepanovnotation"@sv ;
+  :definition "A form of notated movement for dance using musical notation to represent movements by single parts of the body."@en ;
+  :definition "Form av rörelsenotation för dans som använder musiknotation för att representera rörelser av kroppens enskilda delar."@sv ;
+  :scopeNote "It is recorded on a horizontal nine-line staff that represents the body."@en ;
+  :scopeNote "Återges på ett horisontellt notsystem med niodelade rader som representerar kroppen."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/noteMove/1001> ;
+  :note "546 #b" .
+
+<notatedmovementform/Labanotation> a :NotatedMovementForm ;
+  :prefLabel "Labanotation"@en ;
+  :prefLabel "Labanotation"@sv ;
+  :definition "A form of notated movement using abstract symbols on a vertical three-line staff to represent movement of the body and limbs as seen from the back, developed in the United States and the United Kingdom in the middle of the 20th century."@en ;
+  :definition "Form av rörelsenotation för dans som använder abstrakta symboler på ett vertikalt notsystem med tredelade kolumner för att representera kroppens och lemmarnas rörelse sedda bakifrån, utvecklad i Förenta staterna och Storbritannien i mitten av 1900-talet."@sv ;
+  :scopeNote "Labanotation is now harmonized with, while remaining distinct from, Kinetography Laban."@en ;
+  :scopeNote "Labanotation är nu harmoniserad med, men fortfarande skild från, Kinetography Laban."@sv ;
+  :related <KinetographyLaban> ;
+  :exactMatch <http://rdaregistry.info/termList/noteMove/1002> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q1751702> ;
+  :note "546 #b" .
+
+<notatedmovementform/GamePlayNotation> a :NotatedMovementForm ;
+  :prefLabel "Game play notation"@en ;
+  :prefLabel "Spelnotation"@sv ;
+  :definition "A form of notated movement for recording the position of players or pieces during the course of a game."@en ;
+  :definition "Form av rörelsenotation för återgivning av spelarnas eller pjäsernas position under spelets gång."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/noteMove/1004> ;
+  :note "546 #b" .
+
+<notatedmovementform/EshkolWachmanMovementNotation> a :NotatedMovementForm ;
+  :prefLabel "Eshkol-Wachman movement notation"@en ;
+  :prefLabel "Eshkol-Wachmannotation"@sv ;
+  :definition "A form of notated movement using a spherical coordinate system to denote body and limb positions."@en ;
+  :definition "Form av rörelsenotation som använder ett sfäriskt koordinatsystem för att återge positioner för kropp och lemmar."@sv ;
+  :scopeNote "It is recorded on a grid that represents the body."@en ;
+  :scopeNote "Återges på ett rutsystem som representerar kroppen."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/noteMove/1005> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q1367618> ;
+  :note "546 #b" .
+
+<notatedmovementform/Dancewriting> a :NotatedMovementForm ;
+  :prefLabel "DanceWriting"@en ;
+  :prefLabel "DanceWriting"@sv ;
+  :definition "A form of notated movement using figurative and abstract symbols to represent body and limb positions and movements."@en ;
+  :definition "Form av rörelsenotation som använder figurativa och abstrakta symboler  för att representera kroppens och lemmarnas positioner och rörelser."@sv ;
+  :scopeNote "It is recorded on a five-line horizontal staff that represents the body."@en ;
+  :scopeNote "Den återges på ett horisontellt notsystem med femdelade rader som representerar kroppen. Svensk term saknas."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/noteMove/1006> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q3013309> ;
+  :note "546 #b" .
+
+<notatedmovementform/BeneshMovementNotation> a :NotatedMovementForm ;
+  :prefLabel "Benesh movement notation"@en ;
+  :prefLabel "Beneshnotation"@sv ;
+  :definition "A form of notated movement using abstract symbols to represent body and limb positions as seen from the back."@en ;
+  :definition "Form av rörelsenotation som använder abstrakta symboler för att representera kroppens och lemmarnas rörelse sedda bakifrån."@sv ;
+  :scopeNote "It is recorded on a five-line horizontal staff that represents the body."@en ;
+  :scopeNote "Återges på ett horisontellt notsystem med femdelade rader som representerar kroppen."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/noteMove/1007> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q259948> ;
+  :note "546 #b" .
+
+<notatedmovementform/BeauchampFeuilletNotation> a :NotatedMovementForm ;
+  :prefLabel "Beauchamp-Feuillet notation"@en ;
+  :prefLabel "Feuilletnotation"@sv ;
+  :definition "A form of notated movement using abstract symbols to represent movements of the feet during an associated passage of music."@en ;
+  :definition "Form av rörelsenotation som använder abstrakta symboler för att representera fötternas rörelse under en musikalisk passage förknippad med dansen."@sv ;
+  :scopeNote "It is recorded on a track drawing that traces the path of the dancer across the floor."@en ;
+  :scopeNote "Återges på en teckning med fotspår som följer dansarens väg över golvet."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/noteMove/1008> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q4877409> ;
+  :note "546 #b" .
+
+<notatedmovementform/ActionStrokeDanceNotation> a :NotatedMovementForm ;
+  :prefLabel "Action stroke dance notation"@en ;
+  :prefLabel "Action stroke dance notation"@sv ;
+  :definition "A form of notated movement using abstract symbols to represent body and limb positions and movements."@en ;
+  :definition "Form av rörelsenotation som använder abstrakta symboler för att representera kroppens och lemmarnas positioner och rörelser."@sv ;
+  :scopeNote "It is recorded on separate vertical staffs representing the arms, legs, and trunk."@en ;
+  :scopeNote "Återges på separata vertikala notsystem som representerar armarna, benen och bålen."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/noteMove/1009> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q4677425> ;
+  :note "546 #b" .
+
+<notatedmovementform/KinetographyLaban> a :NotatedMovementForm ;
+  :prefLabel "Kinetography Laban"@en ;
+  :prefLabel "Kinetography Laban"@sv ;
+  :definition "A form of notated movement using abstract symbols on a vertical three-line staff to represent movement of the body and limbs as seen from the back, developed in Europe in the middle of the 20th century."@en ;
+  :definition "Form av rörelsenotation för dans som använder abstrakta symboler på ett vertikalt notsystem med tredelade kolumner för att representera kroppens och lemmarnas rörelse sedda bakifrån, utvecklad i Förenta staterna och Storbritannien i mitten av 1900-talet."@sv ;
+  :scopeNote "Kinetography Laban is now harmonized with, while remaining distinct from, Labanotation."@en ;
+  :scopeNote "Kinetography Laban är nu harmoniserad med, men fortfarande skild från, Labanotation."@sv ;
+  :related <Labanotation> ;
+  :exactMatch <http://rdaregistry.info/termList/noteMove/1010> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q1751702> ;
+  :note "546 #b" .
+
+<notatedmusicformat/ChoirBook> a :NotatedMusicFormat ;
+  :prefLabel "Choir book"@en ;
+  :prefLabel "Korbok"@sv ;
+  :definition "A format of notated music that consists of a large music book made to be placed on a stand in front of a choir."@en ;
+  :definition "Format för noterad musik som består av en stor musikbok gjord för att placera på ett ställ framför en kör."@sv ;
+  :scopeNote "Each part is notated separately, usually in the configuration that presents, when the book is open, the soprano and tenor parts on the verso of a leaf, and the alto and bass parts on the recto of the next leaf."@en ;
+  :scopeNote "Varje stämma är noterad separat, vanligen i en konfiguration som när boken är uppslagen visar sopran- och tenorstämmorna på bladets verso och alt- och basstämmorna på nästa blads recto."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/formatNoteMus/1001> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q2457903> ;
+  :note "006 (music)" ,
+    "/03:" ,
+    "/04:" ,
+    "348 #a (term)" .
+
+<notatedmusicformat/ChorusScore> a :NotatedMusicFormat ;
+  :prefLabel "Chorus score"@en ;
+  :prefLabel "Körpartitur"@sv ;
+  :definition "A format of notated music that consists of a score of a work for solo voices and chorus showing only the parts for chorus, at least in those portions of the work in which the chorus sings, with the instrumental accompaniment either omitted or arranged for a keyboard or other chordal instrument or instruments."@en ;
+  :definition "Format för noterad musik som består av ett partitur av ett verk för soloröster och kör som enbart visar stämmorna för kören, åtminstone i de avsnitt av verket där kören sjunger, med det instrumentala ackompanjemanget antingen uteslutet eller arrangerat för klaviatur eller annat ackordinstrument."@sv ;
+  :related <VocalScore> ;
+  :exactMatch <http://rdaregistry.info/termList/formatNoteMus/1002> ;
+  :note "006 (music)" ,
+    "/03: h" ,
+    "/04:" ,
+    "348 #a (term)" .
+
+<notatedmusicformat/CondensedScore> a :NotatedMusicFormat ;
+  :prefLabel "Condensed score"@en ;
+  :prefLabel "Dirigentstämma"@sv ;
+  :altLabel "Reduced score"@en ;
+  :definition "A format of notated music that consists of a score in which the number of staves is reduced to two or a few, generally organized by instrumental sections or vocal parts, and often with cues for individual parts."@en ;
+  :definition "Format för noterad musik som består av ett partitur i vilket antalet notsystem är reducerat till två eller ett par, i allmänhet organiserade efter instrument- eller röststämmor, och ofta med inprickningar för individuella stämmor."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/formatNoteMus/1003> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q17991520> ;
+  :note "006 (music)" ,
+    "/03: i" ,
+    "/04:" ,
+    "348 #a (term)" .
+
+<notatedmusicformat/Part> a :NotatedMusicFormat ;
+  :prefLabel "Part"@en ;
+  :prefLabel "Stämma"@sv ;
+  :definition "A format of notated music that consists of the music for the use of one or more, but not all, performers."@en ;
+  :definition "Format för noterad musik som består av musik för användning av en eller flera, men inte alla, exekutörer."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/formatNoteMus/1004> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q7401> ;
+  :note "006 (music)" ,
+    "/03:" ,
+    "/04:" ,
+    "348 #a (term)" .
+
+<notatedmusicformat/PianoConductorPart> a :NotatedMusicFormat ;
+  :prefLabel "Piano conductor part"@en ;
+  :prefLabel "Pianodirektion"@sv ;
+  :definition "A format of notated music that consists of a performance part for a piano performer in an ensemble, with cues for the other instruments that enable the performer of that part also to conduct."@en ;
+  :definition "Format för noterad musik som består av en framförandestämma för en pianoexekutör i en ensemble, med inprickningar av de andra instrumenten som möjliggör för exekutören av den stämman att också dirigera."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/formatNoteMus/1005> ;
+  :note "006 (music)" ,
+    "/03: e" ,
+    "/04:" ,
+    "348 #a (term)" .
+
+<notatedmusicformat/PianoScore> a :NotatedMusicFormat ;
+  :prefLabel "Piano score"@en ;
+  :prefLabel "Klaverutdrag"@sv ;
+  :definition "A format of notated music that consists of a reduction of an instrumental work or a vocal work with instruments to a version for piano."@en ;
+  :definition "Format för noterad musik som består av en reduktion av ett instrumentalverk eller vokalverk med instrument till en version för piano."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/formatNoteMus/1006> ;
+  :note "006 (music)" ,
+    "/03: p" ,
+    "/04:" ,
+    "348 #a (term)" .
+
+<notatedmusicformat/Score> a :NotatedMusicFormat ;
+  :prefLabel "Score"@en ;
+  :prefLabel "Partitur"@sv ;
+  :altLabel "Full score"@en ;
+  :definition "A format of notated music that consists of graphical, symbolic, or word-based musical notation representing the sounds of all the parts of an ensemble or a work for solo performer or electronic media."@en ;
+  :definition "Format för noterad musik som består av grafisk, symbolisk eller ordbaserad musikalisk notation som representerar ljudet från alla stämmor i en ensemble eller ett verk för solist eller elektroniskt medium."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/formatNoteMus/1007> ;
+  :note "006 (music)" ,
+    "/03: a" ,
+    "/04:" ,
+    "348 #a (term)" .
+
+<notatedmusicformat/StudyScore> a :NotatedMusicFormat ;
+  :prefLabel "Study score"@en ;
+  :prefLabel "Studiepartitur"@sv ;
+  :altLabel "Miniature score"@en ;
+  :definition "A format of notated music that consists of a score issued in a musical image of reduced size, not primarily intended for use in performance."@en ;
+  :definition "Format för noterad musik som består av ett partitur i en musikalisk bild av förminskad storlek, inte huvudsakligen avsett för användning vid framförande."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/formatNoteMus/1008> ;
+  :note "006 (music)" ,
+    "/03: b" ,
+    "/04:" ,
+    "348 #a (term)" .
+
+<notatedmusicformat/TableBook> a :NotatedMusicFormat ;
+  :prefLabel "Table book"@en ;
+  :prefLabel "Table book"@sv ;
+  :definition "A format of notated music that consists of a music book made to be placed on a table and displayed in such a way that the performers can read their parts while seated or standing across or around the table."@en ;
+  :definition "Format för noterad musik som består av en musikbok gjord för att placeras på ett bord och visas på ett sådant sätt att exekutörerna kan läsa sina stämmor sittande eller stående på andra sidan eller runt bordet."@sv ;
+  :scopeNote "Each part is notated separately, usually in a configuration that presents, when the book is open, different parts in inverted and/or perpendicular positions."@en ;
+  :scopeNote "Varje stämma är noterad separat, vanligen i en konfiguration som när boken är uppslagen visar olika stämmor i inverterade och/eller i lodräta positioner. Svensk term saknas - table book verkar inte förekomma i Sverige."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/formatNoteMus/1009> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q7673115> ;
+  :note "006 (music)" ,
+    "/03:" ,
+    "/04:" ,
+    "348 #a (term)" .
+
+<notatedmusicformat/ViolinConductorPart> a :NotatedMusicFormat ;
+  :prefLabel "Violin conductor part"@en ;
+  :prefLabel "Violindirektion"@sv ;
+  :definition "A format of notated music that consists of a performance part for a violin performer in an ensemble, with cues for the other instruments that enable the performer of that part also to conduct."@en ;
+  :definition "Format för noterad musik som består av en framförandestämma för en violinexekutör i en ensemble, med inprickningar av de andra instrumenten som möjliggör för exekutören av den stämman att också dirigera."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/formatNoteMus/1010> ;
+  :note "006 (music)" ,
+    "/03: e" ,
+    "/04:" ,
+    "348 #a (term)" .
+
+<notatedmusicformat/VocalScore> a :NotatedMusicFormat ;
+  :prefLabel "Vocal score"@en ;
+  :prefLabel "Vokalpartitur"@sv ;
+  :definition "A format of notated music that consists of a score showing all vocal parts, with the instrumental accompaniment either omitted or arranged for a keyboard or other chordal instrument or instruments."@en ;
+  :definition "Format för noterad musik som består av ett partitur som visar alla sångstämmor, med ackompanjemanget antingen uteslutet eller arrangerat för klaviatur eller andra ackordinstrument."@sv ;
+  :related <ChorusScore> ;
+  :exactMatch <http://rdaregistry.info/termList/formatNoteMus/1011> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q106129133> ;
+  :note "006 (music)" ,
+    "/03: k" ,
+    "/04:" ,
+    "348 #a (term)" .
+
+<playbackchannelconfiguration/Mono> a :PlaybackChannelConfiguration ;
+  :prefLabel "Mono"@en ;
+  :prefLabel "Mono"@sv ;
+  :definition "A configuration of playback channels that consists of a single channel for monophonic sound."@en ;
+  :definition "En ljudkanal för monofoniskt ljud."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/configPlayback/1001> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q1323979> ;
+  :note "007  (Ljudupptagningar) 04 (ljudkonfiguration): m" ,
+    "007 (Spelfilmer, Videoupptagningar) 08 (ljudkonfiguration): m" ,
+    "344 #g (term)" .
+
+<playbackchannelconfiguration/Quadraphonic> a :PlaybackChannelConfiguration ;
+  :prefLabel "Quadraphonic"@en ;
+  :prefLabel "4-kanalstereo"@sv ;
+  :definition "A configuration of playback channels that consists of four channels for quadraphonic sound."@en ;
+  :definition "Fyra kanaler för quadrofoniskt ljud."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/configPlayback/1003> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q782526> ;
+  :note "007 (Ljudupptagningar) 04 (ljudkonfiguration): q" ,
+    "007 (Spelfilmer, Videoupptagningar) 08 (ljudkonfiguration): q" ,
+    "344 #g (term)" .
+
+<playbackchannelconfiguration/Stereo> a :PlaybackChannelConfiguration ;
+  :prefLabel "Stereo"@en ;
+  :prefLabel "Stereo"@sv ;
+  :definition "A configuration of playback channels that consists of two channels for stereophonic sound."@en ;
+  :definition "Två kanaler för stereofoniskt ljud."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/configPlayback/1002> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q34678> ;
+  :note "007 (Ljudupptagningar) 04 (ljudkonfiguration): s" ,
+    "007 (Spelfilmer, Videoupptagningar) 08 (ljudkonfiguration): s" ,
+    "344 #g (term)" .
+
+<playbackchannelconfiguration/Surround> a :PlaybackChannelConfiguration ;
+  :prefLabel "Surround"@en ;
+  :prefLabel "Surround"@sv ;
+  :definition "A configuration of playback channels that consists of more than four channels for surround sound."@en ;
+  :definition "Fler än fyra kanaler för surroundljud."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/configPlayback/1004> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q569874> ;
+  :note "007 (Ljudupptagningar) 04 (ljudkonfiguration): q" ,
+    "007 (Spelfilmer, Videoupptagningar) 08 (ljudkonfiguration): q" ,
+    "344 #g (term)" .
+
+<polarity/Positive> a :Polarity ;
+  :prefLabel "Positive"@en ;
+  :prefLabel "Positiv"@sv ;
+  :definition "A polarity in which colours and tones used for images are the same as those seen with the human eye."@en ;
+  :definition "Polaritet där färger och toner som används för bilder är desamma som de som ses med det mänskliga ögat."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAPolarity/1001> ;
+  :note "007 (Kartor)" ,
+    "07 (Positiv eller negativ polaritet): a" ,
+    "007 (Microform)" ,
+    "03 (Polaritet): a" ,
+    "007 (Spelfilmer)" ,
+    "10 (Polaritet): a" ,
+    "340 #o (term)" .
+
+<polarity/Negative> a :Polarity ;
+  :prefLabel "Negative"@en ;
+  :prefLabel "Negativ"@sv ;
+  :definition "A polarity in which colours and tones used for images are opposite those seen with the human eye."@en ;
+  :definition "Polaritet där färger och toner som används för bilder är motsatta de som ses med det mänskliga ögat."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAPolarity/1002> ;
+  :note "007 (Kartor)" ,
+    "07 (Positiv eller negativ polaritet): b" ,
+    "007 (Microform)" ,
+    "03 (Polaritet): b" ,
+    "007 (Spelfilmer)" ,
+    "10 (Polaritet): b" ,
+    "340 #o (term)" .
+
+<polarity/MixedPolarity> a :Polarity ;
+  :prefLabel "Mixed polarity"@en ;
+  :prefLabel "Blandad polaritet"@sv ;
+  :definition "A polarity in which colours and tones used for images are a mixture of those seen with the human eye and those opposite what the human eye would see."@en ;
+  :definition "Polaritet där färger och toner som används för bilder är en blandning av de som ses med det mänskliga ögat och de som är motsatta vad det mänskliga ögat skulle se."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAPolarity/1003> ;
+  :note "007 (Kartor)" ,
+    "07 (Positiv eller negativ polaritet): m" ,
+    "007 (Microform)" ,
+    "03 (Polaritet): m" ,
+    "340 #o (term)" .
+
+<productionmethod/BluelineProcess> a :ProductionMethod ;
+  :prefLabel "Blueline process"@en ;
+  :prefLabel "Bluelineprocess"@sv ;
+  :definition "A production method that consists of a contact printing process based on diazonium salt and azo dye chemical reactions that renders all opaque tones or colours as blue on a neutral background."@en ;
+  :definition "Produktionsmetod som består av en kontaktkopieringsprocess baserad på kemiska reaktioner mellan diazoniumsalt och azofärgämnen som återger alla ogenomskinliga toner eller färger som blå på en neutral bakgrund."@sv ;
+  :related <BlueprintProcess%28Bl%C3%A5kopia%29> ;
+  :exactMatch <http://rdaregistry.info/termList/RDAproductionMethod/1001> ;
+  :note "340 #d (term)" .
+
+<productionmethod/BlueprintProcess> a :ProductionMethod ;
+  :prefLabel "Blueprint process"@en ;
+  :prefLabel "Blueprintprocess"@sv ;
+  :definition "A production method that consists of a contact printing process based on iron salt chemical reactions that renders all opaque tones or colours as white on a blue background."@en ;
+  :definition "Produktionsmetod som består av en kontaktkopieringsprocess baserad på kemiska reaktioner med järnsalt som återger alla ogenomskinliga toner eller färger som vita på en blå bakgrund."@sv ;
+  :related <BluelineProcess> ;
+  :exactMatch <http://rdaregistry.info/termList/RDAproductionMethod/1002> ;
+  :closeMatch <http://vocab.getty.edu/page/aat/300053260> ;
+  :note "340 #d (term)" .
+
+<productionmethod/Collotype> a :ProductionMethod ;
+  :prefLabel "Collotype"@en ;
+  :prefLabel "Ljustryck"@sv ;
+  :definition "A production method that consists of a contact printing process using a dichromate chemical reaction that hardens gelatin on exposure to ultraviolet light to produce a positive master that is subsequently used in a lithographic process."@en ;
+  :definition "Produktionsmetod som består av en kontaktkopieringsprocess som använder en kemisk dikromatreaktion som härdar gelatin vid exponering för ultraviolett ljus för att producera en positiv master som sedan används i en litografisk process."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAproductionMethod/1003> ;
+  :closeMatch <http://vocab.getty.edu/page/aat/300053204> ,
+    <https://www.wikidata.org/wiki/Q1572315> ;
+  :note "340 #d (term)" .
+
+<productionmethod/DaguerreotypeProcess> a :ProductionMethod ;
+  :prefLabel "Daguerreotype process"@en ;
+  :prefLabel "Daguerrotyp"@sv ;
+  :definition "A production method that consists of a photographic process using a silver-coated copper plate that is exposed in a camera and subsequently developed, usually using mercury vapour, and fixed with salt to create a positive image."@en ;
+  :definition "Produktionsmetod som består av en fotografisk process med en silverbelagd kopparplatta som exponeras i en kamera och därefter framkallas, vanligtvis med hjälp av kvicksilverånga, och fixeras med salt för att skapa en positiv bild."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAproductionMethod/1004> ;
+  :closeMatch <http://vocab.getty.edu/page/aat/300053530> ,
+    <https://www.wikidata.org/wiki/Q179744> ;
+  :note "340 #d (term)" .
+
+<productionmethod/Engraving> a :ProductionMethod ;
+  :prefLabel "Engraving"@en ;
+  :prefLabel "Gravyr"@sv ;
+  :definition "A production method that consists of the incision of marks on the surface of a hard material using a sharp tool."@en ;
+  :definition "Produktionsmetod som består av inskärning av märken på ytan av ett hårt material med hjälp av ett vasst verktyg."@sv ;
+  :scopeNote "Engraving includes the preparation of a printing plate for an intaglio process."@en ;
+  :scopeNote "Gravering inkluderar förberedelsen av en tryckplåt för en djuptrycksprocess."@sv ;
+  :related <Etching> ;
+  :exactMatch <http://rdaregistry.info/termList/RDAproductionMethod/1005> ;
+  :closeMatch <http://vocab.getty.edu/page/aat/300053225> ,
+    <https://www.wikidata.org/wiki/Q139106> ;
+  :note "340 #d (term)" .
+
+<productionmethod/Etching> a :ProductionMethod ;
+  :prefLabel "Etching"@en ;
+  :prefLabel "Etsning"@sv ;
+  :definition "A production method that consists of an intaglio process in which a design is worked into an acid-resistant substance coating a metal printing plate; the plate is then exposed to acid, which etches the plate where the metal is exposed, to create lines and dark areas."@en ;
+  :definition "Produktionsmetod som består av en djuptrycksprocess där en design inarbetas i ett syrabeständigt ämne som täcker en metalltryckplåt; plåten exponeras sedan för syra, som etsar plåten där metallen exponeras, för att skapa linjer och mörka områden."@sv ;
+  :related <Engraving> ;
+  :exactMatch <http://rdaregistry.info/termList/RDAproductionMethod/1006> ;
+  :closeMatch <http://vocab.getty.edu/page/aat/300053241> ,
+    <https://www.wikidata.org/wiki/Q186986> ;
+  :note "340 #d (term)" .
+
+<productionmethod/Lithography> a :ProductionMethod ;
+  :prefLabel "Lithography"@en ;
+  :prefLabel "Litografi"@sv ;
+  :definition "A production method that consists of a planographic printing process in which a stone or plate is prepared using a water-repelling substance making parts of the plate receptive to ink."@en ;
+  :definition "Produktionsmetod som består av en plantryckprocess där en sten eller plåt prepareras med ett vattenavvisande ämne som gör delar av plåten mottagliga för bläck."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAproductionMethod/1007> ;
+  :closeMatch <http://vocab.getty.edu/page/aat/300053271> ,
+    <https://www.wikidata.org/wiki/Q133036> ;
+  :note "340 #d (term)" .
+
+<productionmethod/Photocopying> a :ProductionMethod ;
+  :prefLabel "Photocopying"@en ;
+  :prefLabel "Fotokopiering"@sv ;
+  :definition "A production method that consists of a macroform photoreproduction process using radiant energy in contact with or projected on opaque material."@en ;
+  :definition "Produktionsmetod som består av en makroform fotoreproduktionsprocess som använder strålningsenergi i kontakt med eller projicerad på ogenomskinligt material."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAproductionMethod/1008> ;
+  :closeMatch <http://vocab.getty.edu/page/aat/300053264> ,
+    <https://www.wikidata.org/wiki/Q56821429> ;
+  :note "340 #d (term)" .
+
+<productionmethod/Photoengraving> a :ProductionMethod ;
+  :prefLabel "Photoengraving"@en ;
+  :prefLabel "Fotogravyr"@sv ;
+  :definition "A production method that consists of a photomechanical process for the preparation of chemically etched printing plates."@en ;
+  :definition "Produktionsmetod som består av en fotomekanisk process för framställning av kemiskt etsade tryckplåtar."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAproductionMethod/1009> ;
+  :closeMatch <http://vocab.getty.edu/page/aat/300053297> ,
+    <https://www.wikidata.org/wiki/Q1439639> ;
+  :note "340 #d (term)" .
+
+<productionmethod/Printing> a :ProductionMethod ;
+  :prefLabel "Printing"@en ;
+  :prefLabel "Tryck"@sv ;
+  :definition "A production method that consists of a process that transfers a pictorial or textual image from a master carrier to the surface of another carrier, often using a plate, block, stone, or screen coated with a transferable material."@en ;
+  :definition "Produktionsmetod som består av en process som överför en bild- eller textbild från en huvudbärare till ytan på en annan bärare, ofta med hjälp av en platta, block, sten eller skärm belagd med ett överförbart material."@sv ;
+  :scopeNote "Includes the production of photographic prints and paper copies of stored computer data."@en ;
+  :scopeNote "Inkluderar framställning av fotografiska utskrifter och papperskopior av lagrad datordata."@sv ;
+  :related <WoodcutMaking> ;
+  :exactMatch <http://rdaregistry.info/termList/RDAproductionMethod/1010> ;
+  :closeMatch <http://vocab.getty.edu/page/aat/300053319> ,
+    <https://www.wikidata.org/wiki/Q11034> ;
+  :note "340 #d (term)" .
+
+<productionmethod/WhitePrintProcess> a :ProductionMethod ;
+  :prefLabel "White print process"@en ;
+  :prefLabel "[svensk term saknas]"@sv ;
+  :definition "A production method that consists of a contact printing process based on a light sensitive process that renders all opaque tones or colours as black or a colour on a white background."@en ;
+  :definition "Produktionsmetod som består av en kontaktkopieringsprocess"@sv ;
+  :related <BluelineProcess> ;
+  :exactMatch <http://rdaregistry.info/termList/RDAproductionMethod/1011> ;
+  :note "340 #d (term)" .
+
+<productionmethod/WoodcutMaking> a :ProductionMethod ;
+  :prefLabel "Woodcut making"@en ;
+  :prefLabel "Träsnitt"@sv ;
+  :definition "A production method that consists of a relief process in which a design is cut into and printed from the surface of a wood block."@en ;
+  :definition "Produktionsmetod som består av en reliefprocess där en design skärs in i och trycks från ytan av ett träblock."@sv ;
+  :related <Printing> ;
+  :exactMatch <http://rdaregistry.info/termList/RDAproductionMethod/1012> ;
+  :closeMatch <http://vocab.getty.edu/page/aat/300053296> ,
+    <https://www.wikidata.org/wiki/Q173242> ;
+  :note "340 #d (term)" .
+
+<productionmethod/PhotogravureProcess> a :ProductionMethod ;
+  :prefLabel "Photogravure process"@en ;
+  :prefLabel "Fotogravyr"@sv ;
+  :definition "A production method that consists of an intaglio process in which the metal printing plate is prepared using a dichromate process to leave a gelatin resist coating of varying thickness that is etched to form cells of varying depth able to hold different amounts of ink."@en ;
+  :definition "Produktionsmetod som består av en djuptrycksprocess där metalltryckplåten framställs med hjälp av en dikromatprocess för att lämna en gelatinresistbeläggning av varierande tjocklek som etsas för att bilda celler med varierande djup som kan hålla olika mängder bläck."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAproductionMethod/1014> ;
+  :closeMatch <http://vocab.getty.edu/page/aat/300053207> ,
+    <https://www.wikidata.org/wiki/Q1602553> ;
+  :note "340 #d (term)" .
+
+<productionmethod/Burning> a :ProductionMethod ;
+  :prefLabel "Burning"@en ;
+  :prefLabel "Bränning"@sv ;
+  :definition "A production method that consists of the application of heat to mark the surface of a material."@en ;
+  :definition "Produktionsmetod som består av applicering av värme för att markera ytan på ett material."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAproductionMethod/1015> ;
+  :closeMatch <http://vocab.getty.edu/page/aat/300228062> ;
+  :note "340 #d (term)" .
+
+<productionmethod/Inscribing> a :ProductionMethod ;
+  :prefLabel "Inscribing"@en ;
+  :definition "A production method that consists of a process that fixes signs and symbols onto a base material by cutting into the surface."@en ;
+  :definition "Produktionsmetod som består av en process som fäster tecken och symboler på ett basmaterial genom att skära i ytan."@sv ;
+  :related <Engraving> ;
+  :exactMatch <http://rdaregistry.info/termList/RDAproductionMethod/1016> ;
+  :closeMatch <http://vocab.getty.edu/page/aat/300404794> ;
+  :note "340 #d (term)" .
+
+<productionmethod/Stamping> a :ProductionMethod ;
+  :prefLabel "Stamping"@en ;
+  :prefLabel "Stämpling"@sv ;
+  :definition "A production method that consists of the application of pressure to make an impression on the surface of a material."@en ;
+  :definition "Produktionsmetod som består av att man applicerar tryck för att göra avtryck på ytan av ett material."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAproductionMethod/1017> ;
+  :closeMatch <http://vocab.getty.edu/page/aat/300239001> ;
+  :note "340 #d (term)" .
+
+<productionmethod/Embossing> a :ProductionMethod ;
+  :prefLabel "Embossing"@en ;
+  :prefLabel "Prägling"@sv ;
+  :definition "A production method that consists of the use of either a metal or plastic sheet as a master with specialized equipment to produce copies for a manifestation of a tactile expression."@en ;
+  :definition "Produktionsmetod som består av att använda antingen en metall- eller plastplåt som en master med specialutrustning för att producera kopior för en manifestation av ett taktilt uttryck."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAproductionMethod/1018> ;
+  :closeMatch <http://vocab.getty.edu/page/aat/300053826> ;
+  :note "340 #d (term)" .
+
+<productionmethod/SolidDot> a :ProductionMethod ;
+  :prefLabel "Solid dot"@en ;
+  :prefLabel "[svensk term saknas]"@sv ;
+  :definition "A production method for a manifestation of a tactile expression in which solid plastic dots are heat sealed onto the surface of thin but strong paper."@en ;
+  :definition "Produktionsmetod för en manifestation av ett taktilt uttryck där solida plastprickar värmeförseglas på ytan av tunt men starkt papper."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAproductionMethod/1019> ;
+  :note "340 #d (term)" .
+
+<productionmethod/SwellPaper> a :ProductionMethod ;
+  :prefLabel "Swell paper"@en ;
+  :prefLabel "Svällpapper"@sv ;
+  :altLabel "Minolta paper"@en ;
+  :definition "A production method for a manifestation of a tactile expression in which an image is printed on a special type of paper with embedded microcapsules of alcohol which burst when exposed to heat to make the surface of the paper swell up."@en ;
+  :definition "Produktionsmetod för en manifestation av ett taktilt uttryck där en bild trycks på en speciell typ av papper med inbäddade mikrokapslar av alkohol som spricker när de utsätts för värme för att få papprets yta att svälla upp."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAproductionMethod/1020> ;
+  :note "340 #d (term)" .
+
+<productionmethod/Thermoform> a :ProductionMethod ;
+  :prefLabel "Thermoform"@en ;
+  :prefLabel "Termoform"@sv ;
+  :altLabel "Vacuum form"@en ;
+  :definition "A production method for a manifestation of a tactile expression in which a collage master is covered with a sheet of plastic, which is heated and vacuumed to generate a copy of a model or diagram."@en ;
+  :definition "Produktionsmetod för en manifestation av ett taktilt uttryck där en collage-master är täckt med ett plastark, som värms upp och dammsugs för att generera en kopia av en modell eller ett diagram."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAproductionMethod/1021> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q1759746> ;
+  :note "340 #d (term)" .
+
+<recordingmedium/Magnetic> a :RecordingMedium ;
+  :prefLabel "Magnetic"@en ;
+  :prefLabel "Magnetisk"@sv ;
+  :definition "A recording medium that relies on pole reversal in a ferromagnetic medium, typically ferromagnetic oxide particles bound to a tape or a disc."@en ;
+  :definition "Inspelningsmedium som använder polomkastning i ett ferromagnetiskt medium, vanligtvis ferromagnetiska oxidpartiklar bundna till ett band eller en skiva."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/recMedium/1001> ;
+  :note "007/01" ,
+    "344 #b (term)" .
+
+<recordingmedium/MagnetoOptical> a :RecordingMedium ;
+  :prefLabel "Magneto-optical"@en ;
+  :prefLabel "Magnet-optisk"@sv ;
+  :definition "A recording medium that uses a combination of laser heating with a varying magnetic field to write data to a disc."@en ;
+  :definition "Inspelningsmedium som använder en kombination av laseruppvärmning med ett varierande magnetfält för att skriva data till en skiva."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/recMedium/1002> ;
+  :note "007/01" ,
+    "344 #b (term)" .
+
+<recordingmedium/Optical> a :RecordingMedium ;
+  :prefLabel "Optical"@en ;
+  :prefLabel "Optisk"@sv ;
+  :definition "A recording medium for recording binary encoded data in a transparent medium with a reflective backing. A laser is used to read the changes in reflectivity as a binary data stream."@en ;
+  :definition "Inspelningsmedium för inspelning av binärkodad data i ett transparent medium med en reflekterande baksida. En laser används för att läsa förändringarna i reflektivitet som en binär dataström."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/recMedium/1003> ;
+  :note "007/01" ,
+    "344 #b (term)" .
+
+<recordingsource/Container> a :RecordingSource ;
+  :prefLabel "Container"@en ;
+  :prefLabel "Förpackning"@sv ;
+  :definition "A source of information in a manifestation that is a housing that is physically separable from the manifestation."@en ;
+  :definition "Informationskälla i en manifestation som är en behållare som är fysiskt avskiljbar från manifestationen."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDARecordingSources/1001> ;
+  :note "588 #a  (anmärkning)" .
+
+<recordingsource/TitleFrame> a :RecordingSource ;
+  :prefLabel "Title frame"@en ;
+  :prefLabel "Titelruta"@sv ;
+  :definition "A source of information in a manifestation that is a frame of a film that contains information about title proper, statement of responsibility, publication, or other aspect of the manifestation."@en ;
+  :definition "Informationskälla i en manifestation som är en ruta av en film som innehåller information om huvudtitel, upphovsuppgift, utgivning eller annan aspekt av manifestationen."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDARecordingSources/1002> ;
+  :note "588 #a  (anmärkning)" .
+
+<recordingsource/TitlePage> a :RecordingSource ;
+  :prefLabel "Title page"@en ;
+  :prefLabel "Titelsida"@sv ;
+  :definition "A source of information in a manifestation that is a page of a volume that contains information about title proper, statement of responsibility, publication, or other aspect of the manifestation."@en ;
+  :definition "Informationskälla i en manifestation som är en sida av en volym som innehåller information om huvudtitel, upphovsuppgift, utgivning eller annan aspekt av manifestationen."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDARecordingSources/1003> ;
+  :note "588 #a  (anmärkning)" .
+
+<recordingsource/TitleScreen> a :RecordingSource ;
+  :prefLabel "Title screen"@en ;
+  :prefLabel "Titelskärmbild"@sv ;
+  :definition "A source of information in a manifestation that is a screen of a digital manifestation that contains information about title proper, statement of responsibility, publication, or other aspect of the manifestation."@en ;
+  :definition "Informationskälla i en manifestation som är en skärmbild av en digital manifestation som innehåller information om huvudtitel, upphovsuppgift, utgivning eller annan aspekt av manifestationen."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDARecordingSources/1004> ;
+  :note "588 #a  (anmärkning)" .
+
+<recordingsource/TitleSheet> a :RecordingSource ;
+  :prefLabel "Title sheet"@en ;
+  :prefLabel "Titelark"@sv ;
+  :definition "A source of information in a manifestation that is a sheet in a set of sheets that contains information about title proper, statement of responsibility, publication, or other aspect of the manifestation."@en ;
+  :definition "Informationskälla i en manifestation som är ett ark av en uppsättning ark som innehåller information om huvudtitel, upphovsuppgift, utgivning eller annan aspekt av manifestationen."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDARecordingSources/1005> ;
+  :note "588 #a  (anmärkning)" .
+
+<recordingsource/TitleCard> a :RecordingSource ;
+  :prefLabel "Title card"@en ;
+  :prefLabel "Titelkort"@sv ;
+  :definition "A source of information in a manifestation that is a card in a set of cards that contains information about title proper, statement of responsibility, publication, or other aspect of the manifestation."@en ;
+  :definition "Informationskälla i en manifestation som är ett kort av en uppsättning kort som innehåller information om huvudtitel, upphovsuppgift, utgivning eller annan aspekt av manifestationen."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDARecordingSources/1006> ;
+  :note "588 #a  (anmärkning)" .
+
+<recordingsource/CarrierLabel> a :RecordingSource ;
+  :prefLabel "Carrier label"@en ;
+  :prefLabel "Bäraretikett"@sv ;
+  :altLabel "Label, carrier"@en ;
+  :definition "A source of information in a manifestation that is a human-readable label that is permanently affixed to the manifestation."@en ;
+  :definition "Informationskälla i en manifestation som är en läsbar etikett som är permanent fäst på manifestationen."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDARecordingSources/1007> ;
+  :note "588 #a  (anmärkning)" .
+
+<recordingsource/Cover> a :RecordingSource ;
+  :prefLabel "Cover"@en ;
+  :prefLabel "Omslag"@sv ;
+  :definition "A source of information in a manifestation that is a protective binding of a volume."@en ;
+  :definition "Informationskälla i en manifestation som är en skyddande bindning av en volym."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDARecordingSources/1008> ;
+  :note "588 #a  (anmärkning)" .
+
+<recordingsource/Jacket> a :RecordingSource ;
+  :prefLabel "Jacket"@en ;
+  :prefLabel "Löst skyddsomslag"@sv ;
+  :altLabel "Book jacket"@en ;
+  :definition "A source of information in a manifestation that is a detachable, protective wrapping of a volume."@en ;
+  :definition "Informationskälla i en manifestation som är en löstagbar, skyddande inslagning av en volym."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDARecordingSources/1009> ;
+  :note "588 #a  (anmärkning)" .
+
+<recordingsource/Masthead> a :RecordingSource ;
+  :prefLabel "Masthead"@en ;
+  :prefLabel "Titelhuvud (?)"@sv ;
+  :definition "A source of information in a manifestation that appears on a first page, editorial page, or list of contents page in the manifestation of each issue of a serial work."@en ;
+  :definition "Informationskälla i en manifestation som förekommer på första sidan, den redaktionella sidan eller innehållsförteckningssidan i manifestationen av varje nummer av ett seriellt verk."@sv ;
+  :scopeNote "A masthead usually contains statements about a title proper, statement of responsibility, publication information, or other common aspects of the embodiment of each issue."@en ;
+  :scopeNote "Ett titelhuvud innehåller vanligtvis uttalanden om huvudtitel, upphovsuppgift, utgivning eller andra vanliga aspekter av förkroppsligandet av varje nummer."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDARecordingSources/1010> ;
+  :note "588 #a  (anmärkning)" .
+
+<recordingsource/Caption> a :RecordingSource ;
+  :prefLabel "Caption"@en ;
+  :prefLabel "Rubrik"@sv ;
+  :definition "A source of information in a manifestation that is a textual augmentation of a still image that contains information about title, brief description, or other aspect of the manifestation."@en ;
+  :definition "Informationskälla i en manifestation som är en komplettering i text av en stillbild som innehåller information om titel, kort beskrivning eller annan aspekt av manifestationen."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDARecordingSources/1011> ;
+  :note "588 #a  (anmärkning)" .
+
+<recordingsource/EmbeddedMetadata> a :RecordingSource ;
+  :prefLabel "Embedded metadata"@en ;
+  :prefLabel "Inbäddad metadata"@sv ;
+  :definition "A source of information in a manifestation that is metadata embedded in an online manifestation."@en ;
+  :definition "Informationskälla i en manifestation som är metadata inbäddad i en online-manifestation."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDARecordingSources/1012> ;
+  :note "588 #a  (anmärkning)" .
+
+<recordingsource/SeriesTitlePage> a :RecordingSource ;
+  :prefLabel "Series title page"@en ;
+  :prefLabel "Serietitelsida"@sv ;
+  :definition "A source of information in a manifestation that is an additional title page bearing a title proper of series and other information about a successive work, and information relating to an issue of the work that is embodied by the manifestation."@en ;
+  :definition "Informationskälla i en manifestation som är en extra titelsida med en seriehuvudtitel och annan information om ett efterföljande verk, och information som rör ett nummer av verket som manifestationen förkroppsligar."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDARecordingSources/1013> ;
+  :note "588 #a  (anmärkning)" .
+
+<recordingtype/Analog> a :RecordingType ;
+  :prefLabel "Analog"@en ;
+  :prefLabel "Analog"@sv ;
+  :definition "A type of recording in which the content is stored as continuous variable quantities in or on the media."@en ;
+  :definition "Typ av inspelning i vilken innehållet är sparat som kontinuerligt variabla mängder i eller på mediet."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/typeRec/1001> ;
+  :note "344 #a (term)" .
+
+<recordingtype/Digital> a :RecordingType ;
+  :prefLabel "Digital"@en ;
+  :prefLabel "Digital"@sv ;
+  :definition "A type of recording in which the content is continuously sampled and a sequence of discrete binary values is stored to represent the amplitude of each sample in the waveform."@en ;
+  :definition "Typ av inspelning i vilken innehållet löpande samplas/analyseras och en sekvens av skilda binära värden lagras för att representera varje sampels/provs amplitud i vågformen."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/typeRec/1002> ;
+  :note "344 #a (term)" .
+
+<reductionratiodesignation/LowReduction> a :ReductionRatioDesignation ;
+  :prefLabel "Low reduction"@en ;
+  :prefLabel "Låg förminskning"@sv ;
+  :definition "A reduction ratio designation for less than 16× for a microform resource."@en ;
+  :definition "Beteckning för förminskningsförhållande för mindre än 16× för en mikroformresurs."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAReductionRatio/1001> ;
+  :note "340 #q (term)" ,
+    "007/05 Förminskningsgrad, kodad (mikroform): a" .
+
+<reductionratiodesignation/NormalReduction> a :ReductionRatioDesignation ;
+  :prefLabel "Normal reduction"@en ;
+  :prefLabel "Normal förminskning"@sv ;
+  :definition "A reduction ratio designation for between 16× and 30× for a microform resource."@en ;
+  :definition "Beteckning för förminskningsförhållande för mellan 16× och 30x för en mikroformresurs."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAReductionRatio/1002> ;
+  :note "340 #q (term)" ,
+    "007/05 Förminskningsgrad, kodad (mikroform): b" .
+
+<reductionratiodesignation/HighReduction> a :ReductionRatioDesignation ;
+  :prefLabel "High reduction"@en ;
+  :prefLabel "Stark förminskning"@sv ;
+  :definition "A reduction ratio designation for between 31× and 60× for a microform resource."@en ;
+  :definition "Beteckning för förminskningsförhållande för mellan 31x och 60x för en mikroformresurs."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAReductionRatio/1003> ;
+  :note "340 #q (term)" ,
+    "007/05 Förminskningsgrad, kodad (mikroform): c" .
+
+<reductionratiodesignation/VeryHighReduction> a :ReductionRatioDesignation ;
+  :prefLabel "Very high reduction"@en ;
+  :prefLabel "Mycket stark förminskning"@sv ;
+  :definition "A reduction ratio designation for between 61× and 90× for a microform resource."@en ;
+  :definition "Beteckning för förminskningsförhållande för mellan 61x och 90x för en mikroformresurs."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAReductionRatio/1004> ;
+  :note "340 #q (term)" ,
+    "007/05 Förminskningsgrad, kodad (mikroform): d" .
+
+<reductionratiodesignation/UltraHighReduction> a :ReductionRatioDesignation ;
+  :prefLabel "Ultra high reduction"@en ;
+  :prefLabel "Ultrastark förminskning"@sv ;
+  :definition "A reduction ratio designation for over 90× for a microform resource."@en ;
+  :definition "Beteckning för förminskningsförhållande för mer än 90× för en mikroformresurs."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAReductionRatio/1005> ;
+  :note "340 #q (term)" ,
+    "007/05 Förminskningsgrad, kodad (mikroform): e" .
+
+<regionalencoding/AllRegions> a :RegionalEncoding ;
+  :prefLabel "All regions"@en ;
+  :prefLabel "Alla regioner"@sv ;
+  :altLabel "Region 0"@en ;
+  :definition "A regional encoding for a videodisc or video game carrier that indicates that playback is permitted on devices worldwide."@en ;
+  :definition "Regionkod för en videoskiva eller videospelbärare som betyder att uppspelning är tillåten på enheter över hela världen."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDARegionalEncoding/1001> ;
+  :note "347 #e (term)" ,
+    "538 #a (anmärkning)" .
+
+<regionalencoding/Region1> a :RegionalEncoding ;
+  :prefLabel "Region 1"@en ;
+  :prefLabel "Region 1"@sv ;
+  :definition "A regional encoding for a DVD videodisc encoded for playback by devices configured to decode it in the United States, Canada, Bermuda, and U.S. territories."@en ;
+  :definition "Regionkod för en DVD-videoskiva kodad för uppspelning på enheter som är konfigurerade att avkoda den i USA, Kanada, Bermuda och USA:s territorier."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDARegionalEncoding/1002> ;
+  :note "347 #e (term)" ,
+    "538 #a (anmärkning)" .
+
+<regionalencoding/RegionA> a :RegionalEncoding ;
+  :prefLabel "Region A"@en ;
+  :prefLabel "Region A"@sv ;
+  :definition "A regional encoding for a Blu-ray videodisc encoded for playback by devices configured to decode it in North America, Central America, South America, Japan, North Korea, South Korea, Taiwan, Hong Kong, and Southeast Asia."@en ;
+  :definition "Regionkod för en Blu-ray-videoskiva kodad för uppspelning på enheter som är konfigurerade att avkoda den i Nordamerika, Centralamerika, Sydamerika, Japan, Nordkorea, Sydkorea, Taiwan, Hong Kong och Sydostasien."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDARegionalEncoding/1003> ;
+  :note "347 #e (term)" ,
+    "538 #a (anmärkning)" .
+
+<regionalencoding/Region2> a :RegionalEncoding ;
+  :prefLabel "Region 2"@en ;
+  :prefLabel "Region 2"@sv ;
+  :definition "A regional encoding for a DVD videodisc encoded for playback by devices configured to decode it in Japan, Europe, South Africa, and the Middle East, including Egypt."@en ;
+  :definition "Regionkod för en DVD-videoskiva kodad för uppspelning på enheter som är konfigurerade att avkoda den i Japan, Europa, Sydafrika och Mellanöstern inklusive Egypten."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDARegionalEncoding/1004> ;
+  :note "347 #e (term)" ,
+    "538 #a (anmärkning)" .
+
+<regionalencoding/RegionB> a :RegionalEncoding ;
+  :prefLabel "Region B"@en ;
+  :prefLabel "Region B"@sv ;
+  :definition "A regional encoding for a Blu-ray videodisc encoded for playback by devices configured to decode it in Europe, Greenland, French territories, Middle East, Africa, Australia, and New Zealand."@en ;
+  :definition "Regionkod för en Blu-ray-videoskiva kodad för uppspelning på enheter som är konfigurerade att avkoda den i Europa, Grönland, Frankrikes utomeuropeiska områden, Mellanöstern, Afrika, Australien och Nya Zeland."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDARegionalEncoding/1005> ;
+  :note "347 #e (term)" ,
+    "538 #a (anmärkning)" .
+
+<regionalencoding/Region8> a :RegionalEncoding ;
+  :prefLabel "Region 8"@en ;
+  :prefLabel "Region 8"@sv ;
+  :definition "A regional encoding for a DVD videodisc encoded for playback by devices configured to decode it in international venues such as aircraft, cruise ships, spacecraft, etc."@en ;
+  :definition "Regionkod för en DVD-videoskiva kodad för uppspelning på enheter som är konfigurerade att avkoda den på internationella arenor som flygplan, kryssningsfartyg, rymdfarkoster etc."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDARegionalEncoding/1006> ;
+  :note "347 #e (term)" ,
+    "538 #a (anmärkning)" .
+
+<regionalencoding/Region7> a :RegionalEncoding ;
+  :prefLabel "Region 7"@en ;
+  :prefLabel "Region 7"@sv ;
+  :definition "A regional encoding for a DVD videodisc encoded for playback by devices configured to decode it for special uses, such as playing protected copies sent to film industry professionals or to the media."@en ;
+  :definition "Regionkod för en DVD-videoskiva kodad för uppspelning på enheter som är konfigurerade att avkoda den för speciella ändamål, som att spela upp skyddade kopior som skickas till filmbranschen eller media."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDARegionalEncoding/1007> ;
+  :note "347 #e (term)" ,
+    "538 #a (anmärkning)" .
+
+<regionalencoding/Region3> a :RegionalEncoding ;
+  :prefLabel "Region 3"@en ;
+  :prefLabel "Region 3"@sv ;
+  :definition "A regional encoding for a DVD videodisc encoded for playback by devices configured to decode it in Southeast Asia and East Asia, including Hong Kong."@en ;
+  :definition "Regionkod för en DVD-videoskiva kodad för uppspelning på enheter som är konfigurerade att avkoda den i Sydostasien och Östra Asien inklusive Hong Kong."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDARegionalEncoding/1008> ;
+  :note "347 #e (term)" ,
+    "538 #a (anmärkning)" .
+
+<regionalencoding/RegionC%28VideoGame%29> a :RegionalEncoding ;
+  :prefLabel "Region C (video game)"@en ;
+  :prefLabel "Region C (datorspel)"@sv ;
+  :definition "A regional encoding for a video game carrier encoded for playback by devices configured to decode it in China."@en ;
+  :definition "Regionkod för en videospelbärare kodad för uppspelning på enheter som är konfigurerade att avkoda den i Kina."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDARegionalEncoding/1009> ;
+  :note "347 #e (term)" ,
+    "538 #a (anmärkning)" .
+
+<regionalencoding/Region4> a :RegionalEncoding ;
+  :prefLabel "Region 4"@en ;
+  :prefLabel "Region 4"@sv ;
+  :definition "A regional encoding for a DVD videodisc encoded for playback by devices configured to decode it in Australia, New Zealand, Pacific Islands, Central America, South America, and the Caribbean."@en ;
+  :definition "Regionkod för en DVD-videoskiva kodad för uppspelning på enheter som är konfigurerade att avkoda den i Australien, Nya Zeland, Stillahavsöarna, Centralamerika, Sydameika och Karibien."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDARegionalEncoding/1010> ;
+  :note "347 #e (term)" ,
+    "538 #a (anmärkning)" .
+
+<regionalencoding/Region5> a :RegionalEncoding ;
+  :prefLabel "Region 5"@en ;
+  :prefLabel "Region 5"@sv ;
+  :definition "A regional encoding for a DVD videodisc encoded for playback by devices configured to decode it in Eastern Europe, Baltic States, Russia, Central and South Asia, Indian subcontinent, Africa, North Korea, and Mongolia."@en ;
+  :definition "Regionkod för en DVD-videoskiva kodad för uppspelning på enheter som är konfigurerade att avkoda den i Östeuropa, de Baltiska staterna, Ryssland, Central- och Sydasien, den indiska subkontinenten, Afrika, Nordkorea och Mongoliet."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDARegionalEncoding/1011> ;
+  :note "347 #e (term)" ,
+    "538 #a (anmärkning)" .
+
+<regionalencoding/RegionC%28BluRay%29> a :RegionalEncoding ;
+  :prefLabel "Region C (Blu-ray)"@en ;
+  :prefLabel "Region C ( Blu-ray)"@sv ;
+  :definition "A regional encoding for a Blu-ray videodisc encoded for playback by devices configured to decode it in India, Nepal, mainland China, Russia, Central Asia, and South Asia."@en ;
+  :definition "Regionkod för en Blu-ray-videoskiva kodad för uppspelning på enheter som är konfigurerade att avkoda den i Indien, Nepal, kinesiska fastlandet, Ryssland, Central- och Sydasien."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDARegionalEncoding/1012> ;
+  :note "347 #e (term)" ,
+    "538 #a (anmärkning)" .
+
+<regionalencoding/RegionJ> a :RegionalEncoding ;
+  :prefLabel "Region J"@en ;
+  :prefLabel "Region J"@sv ;
+  :definition "A regional encoding for a video game carrier encoded for playback by devices configured to decode it in Japan, South Korea, Taiwan, Hong Kong, Macau, and Southeast Asia."@en ;
+  :definition "Regionkod för en videospelbärare kodad för uppspelning på enheter som är konfigurerade att avkoda den i Japan, Sydkorea, Taiwan, Hong Kong, Macau och Sydostasien."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDARegionalEncoding/1013> ;
+  :note "347 #e (term)" ,
+    "538 #a (anmärkning)" .
+
+<regionalencoding/RegionU/C> a :RegionalEncoding ;
+  :prefLabel "Region U/C"@en ;
+  :prefLabel "Region U/C"@sv ;
+  :definition "A regional encoding for a video game carrier encoded for playback by devices configured to decode it in the United States, Canada, Mexico, and South America."@en ;
+  :definition "Regionkod för en videospelbärare kodad för uppspelning på enheter som är konfigurerade att avkoda den i USA, Canada, Mexiko och Sydamerika."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDARegionalEncoding/1014> ;
+  :note "347 #e (term)" ,
+    "538 #a (anmärkning)" .
+
+<regionalencoding/Region6> a :RegionalEncoding ;
+  :prefLabel "Region 6"@en ;
+  :prefLabel "Region 6"@sv ;
+  :definition "A regional encoding for a DVD videodisc encoded for playback by devices configured to decode it in China."@en ;
+  :definition "Regionkod för en DVD-videoskiva kodad för uppspelning på enheter som är konfigurerade att avkoda den i Kina."@sv ;
+  :note "347 #e (term)" ,
+    "538 #a (anmärkning)" .
+
+<scaledesignation/ScalesDiffer> a :ScaleDesignation ;
+  :prefLabel "Scales differ"@en ;
+  :prefLabel "Varierande skala"@sv ;
+  :definition "A scale designation for a resource consisting of more than one image, map, etc., with different scales."@en ;
+  :definition "Skalbeteckning för en resurs som består av mer än en bild, karta etc. med olika skalor."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/scale/1001> ;
+  :note "034 #a, c ??" ,
+    "255 #a" .
+
+<scaledesignation/ScaleNotGiven> a :ScaleDesignation ;
+  :prefLabel "Scale not given"@en ;
+  :prefLabel "Skala ej angiven"@sv ;
+  :definition "A scale designation for a resource when no scale can be determined."@en ;
+  :definition "Skalbeteckning för en resurs när ingen skala kan fastställas."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/scale/1002> ;
+  :note "034 #a, c ??" ,
+    "255 #a" .
+
+<scaledesignation/ScaleVaries> a :ScaleDesignation ;
+  :prefLabel "Scale varies"@en ;
+  :prefLabel "Varierande skala"@sv ;
+  :definition "A scale designation for a resource whose scale is variable across the resource, when the range of values cannot be determined."@en ;
+  :definition "Skalbeteckning för en resurs vars skala varierar inom resursen, när värdeintervallet inte kan bestämmas."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/scale/1003> ;
+  :note "034 #a, c ??" ,
+    "255 #a" .
+
+<scaledesignation/NotDrawnToScale> a :ScaleDesignation ;
+  :prefLabel "Not drawn to scale"@en ;
+  :prefLabel "Ej skalriktigt"@sv ;
+  :definition "A scale designation for a still image or three-dimensional form that is not to scale."@en ;
+  :definition "Skalbeteckning för en stillbild eller tredimensionell form som inte är skalenlig."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/scale/1004> ;
+  :note "034 #a, c ??" ,
+    "255 #a" .
+
+<soundcontent/Sound> a :SoundContent ;
+  :prefLabel "Sound"@en ;
+  :prefLabel "Ljud"@sv ;
+  :definition "A sound content indicator for a resource that contains sound."@en ;
+  :definition "Ljudinnehållsindikator för en resurs som innehåller ljud."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/soundCont/1001> ;
+  :note "344 #i (term)" .
+
+<soundcontent/Silent> a :SoundContent ;
+  :prefLabel "Silent"@en ;
+  :prefLabel "Stum"@sv ;
+  :definition "A sound content indicator for a resource that does not contain sound."@en ;
+  :definition "Ljudinnehållsindikator för en resurs som inte innehåller ljud."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/soundCont/1002> ;
+  :note "344 #i (term)" .
+
+<specialplaybackcharacteristic/CcirEncoded> a :SpecialPlaybackCharacteristic ;
+  :prefLabel "CCIR encoded"@en ;
+  :prefLabel "CCIR-kodad"@sv ;
+  :definition "A special playback characteristic of sound that is a standard originally issued in 1982 by the CCIR for encoding interlaced analog video signals in digital video form."@en ;
+  :definition "Speciell uppspelningsegenskap för ljud som är en standard som ursprungligen utfärdades 1982 av CCIR för kodning av sammanflätade analoga videosignaler i digital videoform."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/specPlayback/1001> ;
+  :note "007(ljudupptagningar)" ,
+    "/12 (inspelningsprotokoll): b" ,
+    "344 #h (term)" ,
+    "538 #a (anmärkning)" .
+
+<specialplaybackcharacteristic/CxEncoded> a :SpecialPlaybackCharacteristic ;
+  :prefLabel "CX encoded"@en ;
+  :prefLabel "CX-kodad"@sv ;
+  :definition "A special playback characteristic of sound that is a noise reduction system for recorded analog audio developed by CBS Laboratories in the late 1970s."@en ;
+  :definition "Speciell uppspelningsegenskap för ljud som är ett brusreduceringssystem för inspelat analogt ljud utvecklat av CBS Laboratories i slutet av 1970-talet."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/specPlayback/1002> ;
+  :note "007 (ljudupptagningar)" ,
+    "/12 (inspelningsprotokoll): h" ,
+    "344 #h (term)" ,
+    "538 #a (anmärkning)" .
+
+<specialplaybackcharacteristic/DbxEncoded> a :SpecialPlaybackCharacteristic ;
+  :prefLabel "Dbx encoded"@en ;
+  :prefLabel "Dbx-kodad"@sv ;
+  :definition "A special playback characteristic of sound that is a family of noise reduction systems developed by dbx."@en ;
+  :definition "Speciell uppspelningsegenskap för ljud som är en familj av brusreduceringssystem utvecklad av dbx."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/specPlayback/1003> ;
+  :note "007 (ljudupptagningar)" ,
+    "/12 (inspelningsprotokoll): d" ,
+    "344 #h (term)" ,
+    "538 #a (anmärkning)" .
+
+<specialplaybackcharacteristic/Dolby> a :SpecialPlaybackCharacteristic ;
+  :prefLabel "Dolby"@en ;
+  :prefLabel "Dolby"@sv ;
+  :definition "A special playback characteristic of sound that is a series of noise reduction systems developed by Dolby Laboratories for use in analog magnetic tape recording."@en ;
+  :definition "Speciell uppspelningsegenskap för ljud som är en serie av brusreduceringssystem utvecklade av Dolby Laboratories för användning inom analog inspelning av magnetiska band."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/specPlayback/1004> ;
+  :note "007 (ljudupptagningar)" ,
+    "/12 (inspelningsprotokoll): ?" ,
+    "344 #h (term)" ,
+    "538 #a (anmärkning)" .
+
+<specialplaybackcharacteristic/DolbyAEncoded> a :SpecialPlaybackCharacteristic ;
+  :prefLabel "Dolby-A encoded"@en ;
+  :prefLabel "Dolby-A-kodad"@sv ;
+  :definition "A special playback characteristic of sound that is a noise reduction system developed by Dolby Laboratories for professional use in analog magnetic tape recording."@en ;
+  :definition "Speciell uppspelningsegenskap för ljud som är ett brusreduceringssystem utvecklat av Dolby Laboratories för professionell användning inom analog inspelning av magnetiska band."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/specPlayback/1005> ;
+  :note "007 (ljudupptagningar)" ,
+    "/12 (inspelningsprotokoll): f" ,
+    "344 #h (term)" ,
+    "538 #a (anmärkning)" .
+
+<specialplaybackcharacteristic/DolbyBEncoded> a :SpecialPlaybackCharacteristic ;
+  :prefLabel "Dolby-B encoded"@en ;
+  :prefLabel "Dolby-B-kodad"@sv ;
+  :definition "A special playback characteristic of sound that is a noise reduction system developed by Dolby Laboratories as a simplified version of Dolby-A for consumer use in analog magnetic tape recording."@en ;
+  :definition "Speciell uppspelningsegenskap för ljud som är ett brusreduceringssystem utvecklat av Dolby Laboratories som en enklare version av Dolby-A för kommersiell användning inom analog inspelning av magnetiska band."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/specPlayback/1006> ;
+  :note "007 (ljudupptagningar)" ,
+    "/12 (inspelningsprotokoll): c" ,
+    "344 #h (term)" ,
+    "538 #a (anmärkning)" .
+
+<specialplaybackcharacteristic/DolbyCEncoded> a :SpecialPlaybackCharacteristic ;
+  :prefLabel "Dolby-C encoded"@en ;
+  :prefLabel "Dolby-C-kodad"@sv ;
+  :definition "A special playback characteristic of sound that is a noise reduction system developed by Dolby Laboratories in 1980 as a combined version of Dolby-A and Dolby-B for use in analog magnetic tape recording."@en ;
+  :definition "Speciell uppspelningsegenskap för ljud som är ett brusreduceringssystem utvecklat av Dolby Laboratories 1980 som en kombinerad version av Dolby-A och Dolby-B för användning inom analog inspelning av magnetiska band."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/specPlayback/1007> ;
+  :note "007 (ljudupptagningar)" ,
+    "/12 (inspelningsprotokoll): g" ,
+    "344 #h (term)" ,
+    "538 #a (anmärkning)" .
+
+<specialplaybackcharacteristic/Lpcm> a :SpecialPlaybackCharacteristic ;
+  :prefLabel "LPCM"@en ;
+  :prefLabel "LPCM"@sv ;
+  :altLabel "Linear pulse-code modulation"@en ;
+  :definition "A special playback characteristic of sound that is a digital sampling of analog sound based on the pulse-code modulation method."@en ;
+  :definition "Speciell uppspelningsegenskap för ljud som är en digital sampling av analogt ljud baserad på pulskodmodulationsmetoden."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/specPlayback/1008> ;
+  :note "007 (ljudupptagningar)" ,
+    "/12 (inspelningsprotokoll): ?" ,
+    "344 #h (term)" ,
+    "538 #a (anmärkning)" .
+
+<specialplaybackcharacteristic/NabStandard> a :SpecialPlaybackCharacteristic ;
+  :prefLabel "NAB standard"@en ;
+  :prefLabel "NAB-standard"@sv ;
+  :definition "A special playback characteristic of sound that follows the standards of the National Association of Broadcasters."@en ;
+  :definition "Speciell uppspelningsegenskap för ljud som följer National Association of Broadcasters standard."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/specPlayback/1009> ;
+  :note "007 (ljudupptagningar)" ,
+    "/12 (inspelningsprotokoll): a" ,
+    "344 #h (term)" ,
+    "538 #a (anmärkning)" .
+
+<tactilenotationform/BrailleCode> a :TactileNotationForm ;
+  :prefLabel "Braille code"@en ;
+  :prefLabel "Punktskrift"@sv ;
+  :definition "A form of tactile notation for text using embossed characters formed by raised dots in six-dot cells."@en ;
+  :definition "Taktil notationsform för text med präglade tecken bestående av sex punkter ordnade i punktskriftsceller."@sv ;
+  :closeMatch <https://www.wikidata.org/wiki/Q79894> ;
+  :note "546 #b" .
+
+<tactilenotationform/ComputingBrailleCode> a :TactileNotationForm ;
+  :prefLabel "Computing braille code"@en ;
+  :prefLabel "Punktskriftssystem för databehandling"@sv ;
+  :altLabel "Computer braille code"@en ;
+  :definition "A form of tactile notation for computer related materials which enables the representation of symbols and ASCII code."@en ;
+  :definition "Taktil notationsform för datorrelaterade material som möjliggör representation av symboler och ASCII-kod."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/TacNotation/1002> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q5157421> ;
+  :note "546 #b" .
+
+<tactilenotationform/MathematicsBrailleCode> a :TactileNotationForm ;
+  :prefLabel "Mathematics braille code"@en ;
+  :prefLabel "Matematisk och naturvetenskaplig punktskrift"@sv ;
+  :definition "A form of tactile notation used to transcribe mathematical and scientific information."@en ;
+  :definition "Taktil notationsform för att återge matematisk och naturvetenskaplig information."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/TacNotation/1003> ;
+  :note "546 #b" .
+
+<tactilenotationform/MoonCode> a :TactileNotationForm ;
+  :prefLabel "Moon code"@en ;
+  :prefLabel "Moonskrift"@sv ;
+  :definition "A form of tactile notation based on simplified letter forms."@en ;
+  :definition "Taktil notationsform baserat på förenklade teckenformer."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/TacNotation/1004> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q918391> ;
+  :note "546 #b" .
+
+<tactilenotationform/MusicBrailleCode> a :TactileNotationForm ;
+  :prefLabel "Music braille code"@en ;
+  :prefLabel "Punktskrift för musik"@sv ;
+  :definition "A form of tactile notation for music using braille cells."@en ;
+  :definition "Taktil notationsform för musik som använder punktskriftsceller."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/TacNotation/1005> ;
+  :note "546 #b" .
+
+<tactilenotationform/TactileMusicalNotation> a :TactileNotationForm ;
+  :prefLabel "Tactile musical notation"@en ;
+  :prefLabel "Taktil musiknotation"@sv ;
+  :definition "A form of tactile notation for music."@en ;
+  :definition "Taktil notationsform för musik."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/TacNotation/1006> ;
+  :note "546 #b" .
+
+<tactilenotationform/TactileGraphic> a :TactileNotationForm ;
+  :prefLabel "Tactile graphic"@en ;
+  :prefLabel "Taktil grafik"@sv ;
+  :definition "A form of tactile notation using a raised version of a print graphic."@en ;
+  :definition "Taktil notationsform som använder upphöjda versioner av bilder."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/TacNotation/1007> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q7674130> ;
+  :note "546 #b" .
+
+<timeunit/Century> a :TimeUnit ;
+  :prefLabel "Century"@en ;
+  :prefLabel "Sekel"@sv ;
+  :definition "A unit of time that is 10 decades in duration."@en ;
+  :definition "Tidsenhet som är 10 decennier i varaktighet."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAUnitOfTime/1001> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q578> .
+
+<timeunit/Hour> a :TimeUnit ;
+  :prefLabel "Hour"@en ;
+  :prefLabel "Timme"@sv ;
+  :definition "A unit of time that is 60 minutes in duration."@en ;
+  :definition "Tidsenhet som är 60 minuter i varaktighet."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAUnitOfTime/1002> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q25235> .
+
+<timeunit/Month> a :TimeUnit ;
+  :prefLabel "Month"@en ;
+  :prefLabel "Månad"@sv ;
+  :definition "A unit of time that is approximately 4-5 weeks in duration."@en ;
+  :definition "Tidsenhet som är cirka 4-5 veckor i varaktighet."@sv ;
+  :scopeNote "The number of days in a month varies between different calendar systems."@en ;
+  :scopeNote "Antalet dagar i en månad varierar mellan olika kalendersystem."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAUnitOfTime/1003> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q5151> .
+
+<timeunit/Year> a :TimeUnit ;
+  :prefLabel "Year"@en ;
+  :prefLabel "År"@sv ;
+  :definition "A unit of time that is approximately 12-13 months in duration."@en ;
+  :definition "Tidsenhet som är cirka 12-13 månader i varaktighet."@sv ;
+  :scopeNote "A Julian year is 31,557,600 seconds. A year is also approximately 365-366 days in duration. The number of months in a year varies between different calendar systems."@en ;
+  :scopeNote "Ett julianskt år är 31.557.600 sekunder. Ett år är också cirka 365-366 dagar i varaktighet. Antalet månader i ett år varierar mellan olika kalendersystem."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAUnitOfTime/1004> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q577> .
+
+<timeunit/Day> a :TimeUnit ;
+  :prefLabel "Day"@en ;
+  :prefLabel "Dygn"@sv ;
+  :definition "A unit of time that is 24 hours in duration."@en ;
+  :definition "Tidsenhet som är 24 timmar i varaktighet."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAUnitOfTime/1005> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q573> .
+
+<timeunit/Millisecond> a :TimeUnit ;
+  :prefLabel "Millisecond"@en ;
+  :prefLabel "Millisekund"@sv ;
+  :definition "A unit of time that is one thousandth of a second."@en ;
+  :definition "Tidsenhet som är en tusendel av en sekund."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAUnitOfTime/1006> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q723733> .
+
+<timeunit/Nanosecond> a :TimeUnit ;
+  :prefLabel "Nanosecond"@en ;
+  :prefLabel "Nanosekund"@sv ;
+  :definition "A unit of time that is one billionth of a second."@en ;
+  :definition "Tidsenhet som är en miljarddel av en sekund."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAUnitOfTime/1007> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q838801> .
+
+<timeunit/Second> a :TimeUnit ;
+  :prefLabel "Second"@en ;
+  :prefLabel "Sekund"@sv ;
+  :definition "A unit of time that is 9,192,631,770 periods of the radiation corresponding to the transition between the two hyperfine levels of the ground state of the caesium-133 atom."@en ;
+  :definition "Tidsenhet som är 9.192.631.770 perioder av strålningen som motsvarar övergången mellan de två hyperfinnivåerna i grundtillståndet hos atomen cesium-133."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAUnitOfTime/1008> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q11574> .
+
+<timeunit/Microsecond> a :TimeUnit ;
+  :prefLabel "Microsecond"@en ;
+  :prefLabel "Mikrosekund"@sv ;
+  :definition "A unit of time that is one millionth of a second."@en ;
+  :definition "Tidsenhet som är en miljondel av en sekund."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAUnitOfTime/1009> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q842015> .
+
+<timeunit/Decade> a :TimeUnit ;
+  :prefLabel "Decade"@en ;
+  :prefLabel "Decennium"@sv ;
+  :definition "A unit of time that is 10 years in duration."@en ;
+  :definition "Tidsenhet som är 10 år i varaktighet."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAUnitOfTime/1010> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q39911> .
+
+<timeunit/Millennium> a :TimeUnit ;
+  :prefLabel "Millennium"@en ;
+  :prefLabel "Millennium"@sv ;
+  :definition "A unit of time that is 10 centuries in duration."@en ;
+  :definition "Tidsenhet som är 10 sekel i varaktighet."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAUnitOfTime/1011> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q36507> .
+
+<timeunit/Week> a :TimeUnit ;
+  :prefLabel "Week"@en ;
+  :prefLabel "Vecka"@sv ;
+  :definition "A unit of time that is 7 days in duration."@en ;
+  :definition "Tidsenhet som är 7 dagar i varaktighet."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAUnitOfTime/1012> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q23387> .
+
+<timeunit/Minute> a :TimeUnit ;
+  :prefLabel "Minute"@en ;
+  :prefLabel "Minut"@sv ;
+  :definition "A unit of time that is 60 seconds in duration."@en ;
+  :definition "Tidsenhet som är 60 sekunder  i varaktighet."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/RDAUnitOfTime/1013> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q7727> .
+
+<trackconfiguration/CentreTrack> a :TrackConfiguration ;
+  :prefLabel "Centre track"@en ;
+  :prefLabel "Centralspår"@sv ;
+  :definition "A track configuration in which the audio track is located in the centre of a separate film roll."@en ;
+  :definition "Spårkonfiguration där ljudspåret är placerat i mitten av en separat filmrulle."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/trackConfig/1001> ;
+  :note "344 #e (term)" .
+
+<trackconfiguration/EdgeTrack> a :TrackConfiguration ;
+  :prefLabel "Edge track"@en ;
+  :prefLabel "Kantspår"@sv ;
+  :definition "A track configuration in which the audio track is located near the edge of a film roll."@en ;
+  :definition "Spårkonfiguration där ljudspåret är placerat nära kanten av en filmrulle."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/trackConfig/1002> ;
+  :note "344 #e (term)" .
+
+<videoformat/Betamax> a :VideoFormat ;
+  :prefLabel "Betamax"@en ;
+  :prefLabel "Betamax"@sv ;
+  :altLabel "Beta"@en ;
+  :definition "A video format for analog tape developed for consumer use by Sony in 1975."@en ;
+  :definition "Videoformat för analogt band utvecklat för privat bruk av Sony 1975."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/videoFormat/1001> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q690148> ;
+  :note "007 (videoupptagnngar)" ,
+    "/04 (format): a" ,
+    "346 #a" ,
+    "538 #a" .
+
+<videoformat/Betacam> a :VideoFormat ;
+  :prefLabel "Betacam"@en ;
+  :prefLabel "Betacam"@sv ;
+  :definition "A video format for analog tape developed for professional use by Sony in 1982."@en ;
+  :definition "Videoformat för analogt band utvecklat för professionellt bruk av Sony 1982."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/videoFormat/1002> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q830910> ;
+  :note "007 (videoupptagnngar)" ,
+    "/04 (format): i" ,
+    "346 #a" ,
+    "538 #a" .
+
+<videoformat/Ced> a :VideoFormat ;
+  :prefLabel "CED"@en ;
+  :prefLabel "CED"@sv ;
+  :altLabel "Capacitance Electronic Disc"@en ;
+  :definition "A video format for analog disc."@en ;
+  :definition "Videoformat för analog skiva."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/videoFormat/1004> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q3246349> ;
+  :note "007 (videoupptagnngar)" ,
+    "/04 (format): h" ,
+    "346 #a" ,
+    "538 #a" .
+
+<videoformat/D2> a :VideoFormat ;
+  :prefLabel "D-2"@en ;
+  :prefLabel "D-2"@sv ;
+  :definition "A video format for analog tape developed for professional use by Ampex in 1988."@en ;
+  :definition "Videoformat för analogt band utvecklat för professionellt bruk av Ampex 1988."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/videoFormat/1005> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q1158883> ;
+  :note "007 (videoupptagnngar)" ,
+    "/04 (format): o" ,
+    "346 #a" ,
+    "538 #a" .
+
+<videoformat/Eiaj> a :VideoFormat ;
+  :prefLabel "EIAJ"@en ;
+  :prefLabel "EIAJ"@sv ;
+  :definition "A video format for analog tape developed for professional use by the Electronic Industries Association of Japan in 1969."@en ;
+  :definition "Videoformat för analogt band utvecklat för professionellt bruk av Electronic Industries Association of Japan 1969."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/videoFormat/1006> ;
+  :note "007 (videoupptagnngar)" ,
+    "/04 (format): d" ,
+    "346 #a" ,
+    "538 #a" .
+
+<videoformat/8Mm> a :VideoFormat ;
+  :prefLabel "8 mm"@en ;
+  :prefLabel "8 mm"@sv ;
+  :definition "A video format for analog and digital tape that includes Video8, Hi-8, and Digital8 formats."@en ;
+  :definition "Videoformat för analogt och digitalt band som inkluderar Video8-, Hi-8- och Digital8-format."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/videoFormat/1007> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q1155472> ;
+  :note "007 (videoupptagnngar)" ,
+    "/04 (format): p" ,
+    "346 #a" ,
+    "538 #a" .
+
+<videoformat/Hi8Mm> a :VideoFormat ;
+  :prefLabel "Hi-8 mm"@en ;
+  :prefLabel "Hi-8 mm"@sv ;
+  :definition "A video format for analog tape that is part of the 8 mm format."@en ;
+  :definition "Videoformat för analogt band som ingår i 8 mm-formatet."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/videoFormat/1008> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q2302273> ;
+  :note "007 (videoupptagnngar)" ,
+    "/04 (format): q" ,
+    "346 #a" ,
+    "538 #a" .
+
+<videoformat/LaserOptical> a :VideoFormat ;
+  :prefLabel "Laser optical"@en ;
+  :prefLabel "Laser optical"@sv ;
+  :definition "A video format for optical disc that is read by a laser."@en ;
+  :definition "Videoformat för optisk skiva som läses av en laser."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/videoFormat/1009> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q234870> ;
+  :note "007 (videoupptagnngar)" ,
+    "/04 (format): g?" ,
+    "346 #a" ,
+    "538 #a" .
+
+<videoformat/MIi> a :VideoFormat ;
+  :prefLabel "M-II"@en ;
+  :prefLabel "M-II"@sv ;
+  :definition "A video format for analog tape developed for professional use by Panasonic in 1986."@en ;
+  :definition "Videoformat för analogt band utvecklat för professionellt bruk av Panasonic 1986."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/videoFormat/1010> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q3841334> ;
+  :note "007 (videoupptagnngar)" ,
+    "/04 (format): m" ,
+    "346 #a" ,
+    "538 #a" .
+
+<videoformat/Quadruplex> a :VideoFormat ;
+  :prefLabel "Quadruplex"@en ;
+  :prefLabel "Quadruplex"@sv ;
+  :definition "A video format for analog tape developed for professional use by Ampex in 1956."@en ;
+  :definition "Videoformat för analogt band utvecklat för professionellt bruk av Ampex 1956."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/videoFormat/1011> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q2121997> ;
+  :note "007 (videoupptagnngar)" ,
+    "/04 (format): f" ,
+    "346 #a" ,
+    "538 #a" .
+
+<videoformat/SuperVhs> a :VideoFormat ;
+  :prefLabel "Super-VHS"@en ;
+  :prefLabel "Super-VHS"@sv ;
+  :definition "A video format for analog tape based on VHS that increases horizontal resolution to 420 lines."@en ;
+  :definition "Videoformat för analogt band baserat på VHS som ökar den horisontella upplösningen till 420 linjer."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/videoFormat/1012> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q1050875> ;
+  :note "007 (videoupptagnngar)" ,
+    "/04 (format): k" ,
+    "346 #a" ,
+    "538 #a" .
+
+<videoformat/TypeC> a :VideoFormat ;
+  :prefLabel "Type C"@en ;
+  :prefLabel "Type C"@sv ;
+  :definition "A video format for analog tape developed for professional use by Ampex and Sony in 1976."@en ;
+  :definition "Videoformat för analogt band utvecklat för professionellt bruk av Ampex och Sony 1976."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/videoFormat/1013> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q209020> ;
+  :note "007 (videoupptagnngar)" ,
+    "/04 (format): e" ,
+    "346 #a" ,
+    "538 #a" .
+
+<videoformat/UMatic> a :VideoFormat ;
+  :prefLabel "U-matic"@en ;
+  :prefLabel "U-matic"@sv ;
+  :definition "A video format for analog tape developed for professional use by Sony in 1969."@en ;
+  :definition "Videoformat för analogt band utvecklat för professionellt bruk av Sony 1969."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/videoFormat/1014> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q278080> ;
+  :note "007 (videoupptagnngar)" ,
+    "/04 (format): c" ,
+    "346 #a" ,
+    "538 #a" .
+
+<videoformat/Vhs> a :VideoFormat ;
+  :prefLabel "VHS"@en ;
+  :prefLabel "VHS"@sv ;
+  :altLabel "Video Home System"@en ;
+  :definition "A video format for analog tape developed for consumer use by JVC in the 1970s."@en ;
+  :definition "Videoformat för analogt band utvecklat för privat bruk av JVC under 1970-talet."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/videoFormat/1015> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q183976> ;
+  :note "007 (videoupptagnngar)" ,
+    "/04 (format): b" ,
+    "346 #a" ,
+    "538 #a" .
+
+<videoformat/BetacamSp> a :VideoFormat ;
+  :prefLabel "Betacam SP"@en ;
+  :prefLabel "Betacam SP"@sv ;
+  :definition "A video format for analog tape based on the Betacam format that increases horizontal resolution to 340 lines."@en ;
+  :definition "Videoformat för analogt band baserat på Betacam-formatet som ökar den horisontella upplösningen till 340 linjer."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/videoFormat/1016> ;
+  :closeMatch <https://www.wikidata.org/wiki/Q830904> ;
+  :note "007 (videoupptagnngar)" ,
+    "/04 (format): j" ,
+    "346 #a" ,
+    "538 #a" .

--- a/source/rda/terms.ttl
+++ b/source/rda/terms.ttl
@@ -4008,6 +4008,7 @@ Skall betraktas som språklig resurs (000/06 = a) med fält 007/00 = c.""" .
   :prefLabel "Punktskrift"@sv ;
   :definition "A form of tactile notation for text using embossed characters formed by raised dots in six-dot cells."@en ;
   :definition "Taktil notationsform för text med präglade tecken bestående av sex punkter ordnade i punktskriftsceller."@sv ;
+  :exactMatch <http://rdaregistry.info/termList/TacNotation/1001> ;
   :closeMatch <https://www.wikidata.org/wiki/Q79894> ;
   :note "546 #b" .
 


### PR DESCRIPTION
This adds RDA term descriptions, extracted from a ZIP download of the box notes.

See the amended script for how it was done. It can be further modified and re-run if needed; or we can use the results as the new source and directly work more on that.

Before merging, we need to consider the new types, and how to merge these with the various existing enumerations. Then we need to reference the results as new term lists to be used for cataloguing; both as datasets in this repository, and in documentation.