### PR TITLE
Define DocumentPart and uses thereof

### DIFF
--- a/source/vocab/details.ttl
+++ b/source/vocab/details.ttl
@@ -202,7 +202,9 @@
 :identifier a owl:DatatypeProperty ;
     :category :shorthand;
     rdfs:label "identifier"@en, "identifikator"@sv;
+    rdfs:comment "Används enbart för enkla identifikatorer på administrativa resurser."@sv;
     rdfs:subPropertyOf :label;
+    sdo:domainIncludes :DocumentPart ;
     rdfs:range :Identifier;
     owl:equivalentProperty dc:identifier, bibo:identifier;
     owl:propertyChainAxiom ( :identifiedBy :value ) .

--- a/source/vocab/platform.ttl
+++ b/source/vocab/platform.ttl
@@ -12,6 +12,7 @@
 @prefix dc: <http://purl.org/dc/terms/> .
 @prefix dctype: <http://purl.org/dc/dcmitype/> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix bibo: <http://purl.org/ontology/bibo/> .
 @prefix sdo: <http://schema.org/> .
 @prefix bf2: <http://id.loc.gov/ontologies/bibframe/> .
 @prefix bflc: <http://id.loc.gov/ontologies/bflc/> .
@@ -47,7 +48,13 @@
 :Document a owl:Class;
     #:category :platform ;
     rdfs:label "Document"@en, "Dokument"@sv;
-    owl:equivalentClass foaf:Document .
+    owl:equivalentClass foaf:Document, bibo:Document .
+
+:DocumentPart a owl:Class;
+    #:category :platform ;
+    rdfs:label "Document part"@en, "Dokumentdel"@sv;
+    rdfs:subClassOf :Document ;
+    owl:equivalentClass bibo:DocumentPart .
 
 ##
 # Records
@@ -201,7 +208,7 @@
     rdfs:label "Source metadata"@en, "Metadatakälla"@sv;
     rdfs:comment "Länk till metadata som var källan för resursen"@sv;
     rdfs:domain :AdminMetadata;
-    rdfs:range :AdminMetadata;
+    sdo:rangeIncludes :AdminMetadata, :DocumentPart ;
     owl:equivalentProperty bf2:derivedFrom .
 
 :GenerationProcess a owl:Class;


### PR DESCRIPTION
For use with `derivedFrom` to provide detailed metadata provenance.