### PR TITLE
Fix bibdb dataset build

### DIFF
--- a/bibdb_datasets.py
+++ b/bibdb_datasets.py
@@ -19,14 +19,14 @@ compiler = Compiler(base_dir=SCRIPT_DIR,
 @compiler.dataset
 def libraries():
     graph = _construct_bibdb_data('sigel=*&holdings=True&org_type=library')
-    return "/library", "2019-03-14T15:31:17.000Z", graph
+    return "/library", "2019-03-14T15:31:17.000Z", compiler.to_jsonld(graph)
 
 
 @compiler.dataset
 def bibliographies():
     graph = _construct_bibdb_data('sigel=*&org_type=bibliography')
     graph |= Graph().parse(str(compiler.path('source/bibdb/bibliographies.ttl')), format='turtle')
-    return "/library", "2019-03-14T19:32:20.000Z", graph
+    return "/library", "2019-03-14T19:32:20.000Z", compiler.to_jsonld(graph)
 
 
 def _construct_bibdb_data(query):


### PR DESCRIPTION
https://github.com/libris/definitions/pull/591/changes/bd8756a888a98a05bcb5d4687d5b97af28294cca broke `bibdb_datasets.py` when Graph->JSON-LD conversion was moved:
```
~/l/definitions (develop=) uv run bibdb_datasets.py
Writing: /home/andjen/lxl/definitions/build/dataset/bibdb.jsonld
Dataset: libraries
Writing dataset lines to file: /home/andjen/lxl/definitions/build/libraries.json.lines
Using cached URL: https://bibdb.libris.kb.se/api?sigel=*&holdings=True&org_type=library
Using cached URL: https://bibdb.libris.kb.se/api?sigel=*&holdings=True&org_type=library&start=200
Using cached URL: https://bibdb.libris.kb.se/api?sigel=*&holdings=True&org_type=library&start=400
Using cached URL: https://bibdb.libris.kb.se/api?sigel=*&holdings=True&org_type=library&start=600
Using cached URL: https://bibdb.libris.kb.se/api?sigel=*&holdings=True&org_type=library&start=800
Using cached URL: https://bibdb.libris.kb.se/api?sigel=*&holdings=True&org_type=library&start=1000
Using cached URL: https://bibdb.libris.kb.se/libdb/static/meta/context.jsonld
Writing: /home/andjen/lxl/definitions/build/dataset/libraries.jsonld
Traceback (most recent call last):
  File "/home/andjen/lxl/definitions/bibdb_datasets.py", line 75, in <module>
    compiler.main()
  File "/home/andjen/lxl/definitions/lxltools/datacompiler.py", line 82, in main
    self._run(args.datasets)
  File "/home/andjen/lxl/definitions/lxltools/datacompiler.py", line 102, in _run
    self._compile_datasets(names)
  File "/home/andjen/lxl/definitions/lxltools/datacompiler.py", line 144, in _compile_datasets
    self._compile_dataset(name, result)
  File "/home/andjen/lxl/definitions/lxltools/datacompiler.py", line 160, in _compile_dataset
    for node in data['@graph']:
                ~~~~^^^^^^^^^^
  File "/home/andjen/lxl/definitions/.venv/lib/pypy3.11/site-packages/rdflib/graph.py", line 537, in __getitem__
    raise TypeError(
TypeError: You can only index a graph by a single rdflib term or path, or a slice of rdflib terms.
``` 